### PR TITLE
feat: add table formatter with TTY-sensitive output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ claude mcp add fortnox -- noxctl serve
 |------|-------------|
 | `fortnox_company_info` | Company information and settings |
 
+## CLI output
+
+By default, `noxctl` uses **table output** on interactive terminals and **JSON** when piped or redirected. Override with `-o`:
+
+```bash
+noxctl invoices list              # table on terminal, JSON when piped
+noxctl -o json invoices list      # force JSON
+noxctl -o table invoices list     # force table
+noxctl invoices list | jq .       # auto-JSON (piped)
+```
+
 ## Examples
 
 Ask Claude naturally:

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -162,9 +162,7 @@ export async function refreshAccessToken(creds: FortnoxCredentials): Promise<For
 export async function getValidToken(): Promise<string> {
   const creds = await loadCredentials();
   if (!creds) {
-    throw new Error(
-      'Not authenticated. Run `noxctl setup` to connect your Fortnox account.',
-    );
+    throw new Error('Not authenticated. Run `noxctl setup` to connect your Fortnox account.');
   }
 
   // Token still valid — use it

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,9 +75,7 @@ program
   });
 
 // --- invoices ---
-const invoices = program
-  .command('invoices')
-  .description('Invoice operations');
+const invoices = program.command('invoices').description('Invoice operations');
 
 invoices
   .command('list')
@@ -98,7 +96,10 @@ invoices
       page: opts.page,
       limit: opts.limit,
     });
-    const envelope = data as unknown as { Invoices: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
+    const envelope = data as unknown as {
+      Invoices: Record<string, unknown>[];
+      MetaInformation?: Record<string, unknown>;
+    };
     outputList(envelope.Invoices ?? [], invoiceListColumns, json(), data, envelope.MetaInformation);
   });
 
@@ -118,9 +119,7 @@ invoices
   .requiredOption('--input <file>', 'Invoice data as JSON file (or - for stdin)')
   .action(async (opts) => {
     const { createInvoice } = await import('./operations/invoices.js');
-    const raw = opts.input === '-'
-      ? readFileSync(0, 'utf-8')
-      : readFileSync(opts.input, 'utf-8');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
     const input = JSON.parse(raw) as Record<string, unknown>;
     const params = { CustomerNumber: opts.customer, ...input };
     const data = await createInvoice(params);
@@ -160,9 +159,7 @@ invoices
   });
 
 // --- tax ---
-const tax = program
-  .command('tax')
-  .description('Tax operations');
+const tax = program.command('tax').description('Tax operations');
 
 tax
   .command('report')
@@ -185,9 +182,7 @@ tax
   });
 
 // --- accounts ---
-const accounts = program
-  .command('accounts')
-  .description('Chart of accounts operations');
+const accounts = program.command('accounts').description('Chart of accounts operations');
 
 accounts
   .command('list')
@@ -205,9 +200,7 @@ accounts
   });
 
 // --- customers ---
-const customers = program
-  .command('customers')
-  .description('Customer operations');
+const customers = program.command('customers').description('Customer operations');
 
 customers
   .command('list')
@@ -222,8 +215,17 @@ customers
       page: opts.page,
       limit: opts.limit,
     });
-    const envelope = data as unknown as { Customers: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
-    outputList(envelope.Customers ?? [], customerListColumns, json(), data, envelope.MetaInformation);
+    const envelope = data as unknown as {
+      Customers: Record<string, unknown>[];
+      MetaInformation?: Record<string, unknown>;
+    };
+    outputList(
+      envelope.Customers ?? [],
+      customerListColumns,
+      json(),
+      data,
+      envelope.MetaInformation,
+    );
   });
 
 customers
@@ -244,9 +246,7 @@ customers
     const { createCustomer } = await import('./operations/customers.js');
     let input: Record<string, unknown> = {};
     if (opts.input) {
-      const raw = opts.input === '-'
-        ? readFileSync(0, 'utf-8')
-        : readFileSync(opts.input, 'utf-8');
+      const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
       input = JSON.parse(raw) as Record<string, unknown>;
     }
     const params = { ...input, Name: opts.name };
@@ -260,18 +260,14 @@ customers
   .requiredOption('--input <file>', 'Customer data as JSON file (or - for stdin)')
   .action(async (customerNumber: string, opts: { input: string }) => {
     const { updateCustomer } = await import('./operations/customers.js');
-    const raw = opts.input === '-'
-      ? readFileSync(0, 'utf-8')
-      : readFileSync(opts.input, 'utf-8');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
     const fields = JSON.parse(raw) as Record<string, unknown>;
     const data = await updateCustomer(customerNumber, fields);
     outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
   });
 
 // --- company ---
-const company = program
-  .command('company')
-  .description('Company operations');
+const company = program.command('company').description('Company operations');
 
 company
   .command('info')
@@ -283,9 +279,7 @@ company
   });
 
 // --- vouchers ---
-const vouchers = program
-  .command('vouchers')
-  .description('Voucher operations');
+const vouchers = program.command('vouchers').description('Voucher operations');
 
 vouchers
   .command('list')
@@ -306,7 +300,10 @@ vouchers
       page: opts.page,
       limit: opts.limit,
     });
-    const envelope = data as unknown as { Vouchers: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
+    const envelope = data as unknown as {
+      Vouchers: Record<string, unknown>[];
+      MetaInformation?: Record<string, unknown>;
+    };
     outputList(envelope.Vouchers ?? [], voucherListColumns, json(), data, envelope.MetaInformation);
   });
 
@@ -316,9 +313,7 @@ vouchers
   .requiredOption('--input <file>', 'Voucher data as JSON file (or - for stdin)')
   .action(async (opts) => {
     const { createVoucher } = await import('./operations/vouchers.js');
-    const raw = opts.input === '-'
-      ? readFileSync(0, 'utf-8')
-      : readFileSync(opts.input, 'utf-8');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
     const params = JSON.parse(raw) as Record<string, unknown>;
     const data = await createVoucher(params);
     outputDetail(data as Record<string, unknown>, voucherDetailColumns, json());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import {
 import {
   invoiceListColumns,
   invoiceDetailColumns,
+  invoiceConfirmColumns,
   customerListColumns,
   customerDetailColumns,
   voucherListColumns,
@@ -137,7 +138,12 @@ invoices
   .action(async (documentNumber: string, opts: { method: string }) => {
     const { sendInvoice } = await import('./operations/invoices.js');
     const data = await sendInvoice(documentNumber, opts.method as 'email' | 'print' | 'einvoice');
-    outputConfirmation(`Invoice ${documentNumber} sent via ${opts.method}.`, json(), data);
+    outputConfirmation(
+      `Invoice ${documentNumber} sent via ${opts.method}.`,
+      json(),
+      data,
+      invoiceConfirmColumns,
+    );
   });
 
 invoices
@@ -146,7 +152,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { bookkeepInvoice } = await import('./operations/invoices.js');
     const data = await bookkeepInvoice(documentNumber);
-    outputConfirmation(`Invoice ${documentNumber} bookkeept.`, json(), data);
+    outputConfirmation(`Invoice ${documentNumber} bookkeept.`, json(), data, invoiceConfirmColumns);
   });
 
 invoices
@@ -155,7 +161,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { creditInvoice } = await import('./operations/invoices.js');
     const data = await creditInvoice(documentNumber);
-    outputConfirmation(`Invoice ${documentNumber} credited.`, json(), data);
+    outputConfirmation(`Invoice ${documentNumber} credited.`, json(), data, invoiceConfirmColumns);
   });
 
 // --- tax ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,13 +2,39 @@
 
 import { Command, Option } from 'commander';
 import { readFileSync } from 'node:fs';
+import {
+  isJsonMode,
+  outputList,
+  outputDetail,
+  outputConfirmation,
+  formatTaxReport,
+} from './formatter.js';
+import {
+  invoiceListColumns,
+  invoiceDetailColumns,
+  customerListColumns,
+  customerDetailColumns,
+  voucherListColumns,
+  voucherDetailColumns,
+  accountListColumns,
+  companyDetailColumns,
+} from './views.js';
 
 const program = new Command();
 
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.1.0');
+  .version('0.1.0')
+  .addOption(
+    new Option('-o, --output <format>', 'Output format')
+      .choices(['json', 'table'])
+      .default(undefined),
+  );
+
+function json(): boolean {
+  return isJsonMode(program.opts());
+}
 
 // --- setup ---
 program
@@ -72,7 +98,8 @@ invoices
       page: opts.page,
       limit: opts.limit,
     });
-    console.log(JSON.stringify(data, null, 2));
+    const envelope = data as unknown as { Invoices: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
+    outputList(envelope.Invoices ?? [], invoiceListColumns, json(), data, envelope.MetaInformation);
   });
 
 invoices
@@ -81,7 +108,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { getInvoice } = await import('./operations/invoices.js');
     const data = await getInvoice(documentNumber);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json());
   });
 
 invoices
@@ -97,7 +124,7 @@ invoices
     const input = JSON.parse(raw) as Record<string, unknown>;
     const params = { CustomerNumber: opts.customer, ...input };
     const data = await createInvoice(params);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json());
   });
 
 invoices
@@ -111,7 +138,7 @@ invoices
   .action(async (documentNumber: string, opts: { method: string }) => {
     const { sendInvoice } = await import('./operations/invoices.js');
     const data = await sendInvoice(documentNumber, opts.method as 'email' | 'print' | 'einvoice');
-    console.log(JSON.stringify(data, null, 2));
+    outputConfirmation(`Invoice ${documentNumber} sent via ${opts.method}.`, json(), data);
   });
 
 invoices
@@ -120,7 +147,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { bookkeepInvoice } = await import('./operations/invoices.js');
     const data = await bookkeepInvoice(documentNumber);
-    console.log(JSON.stringify(data, null, 2));
+    outputConfirmation(`Invoice ${documentNumber} bookkeept.`, json(), data);
   });
 
 invoices
@@ -129,7 +156,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { creditInvoice } = await import('./operations/invoices.js');
     const data = await creditInvoice(documentNumber);
-    console.log(JSON.stringify(data, null, 2));
+    outputConfirmation(`Invoice ${documentNumber} credited.`, json(), data);
   });
 
 // --- tax ---
@@ -150,7 +177,11 @@ tax
       toDate: opts.to,
       financialYear: opts.year,
     });
-    console.log(JSON.stringify(data, null, 2));
+    if (json()) {
+      console.log(JSON.stringify(data, null, 2));
+    } else {
+      console.log(formatTaxReport(data as unknown as Record<string, unknown>));
+    }
   });
 
 // --- accounts ---
@@ -169,7 +200,8 @@ accounts
       search: opts.search,
       financialYear: opts.year,
     });
-    console.log(JSON.stringify(data, null, 2));
+    const items = Array.isArray(data) ? data : [];
+    outputList(items as Record<string, unknown>[], accountListColumns, json(), data);
   });
 
 // --- customers ---
@@ -190,7 +222,8 @@ customers
       page: opts.page,
       limit: opts.limit,
     });
-    console.log(JSON.stringify(data, null, 2));
+    const envelope = data as unknown as { Customers: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
+    outputList(envelope.Customers ?? [], customerListColumns, json(), data, envelope.MetaInformation);
   });
 
 customers
@@ -199,7 +232,7 @@ customers
   .action(async (customerNumber: string) => {
     const { getCustomer } = await import('./operations/customers.js');
     const data = await getCustomer(customerNumber);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
   });
 
 customers
@@ -218,7 +251,7 @@ customers
     }
     const params = { ...input, Name: opts.name };
     const data = await createCustomer(params);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
   });
 
 customers
@@ -232,7 +265,7 @@ customers
       : readFileSync(opts.input, 'utf-8');
     const fields = JSON.parse(raw) as Record<string, unknown>;
     const data = await updateCustomer(customerNumber, fields);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
   });
 
 // --- company ---
@@ -246,7 +279,7 @@ company
   .action(async () => {
     const { getCompanyInfo } = await import('./operations/company.js');
     const data = await getCompanyInfo();
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, companyDetailColumns, json());
   });
 
 // --- vouchers ---
@@ -273,7 +306,8 @@ vouchers
       page: opts.page,
       limit: opts.limit,
     });
-    console.log(JSON.stringify(data, null, 2));
+    const envelope = data as unknown as { Vouchers: Record<string, unknown>[]; MetaInformation?: Record<string, unknown> };
+    outputList(envelope.Vouchers ?? [], voucherListColumns, json(), data, envelope.MetaInformation);
   });
 
 vouchers
@@ -287,7 +321,7 @@ vouchers
       : readFileSync(opts.input, 'utf-8');
     const params = JSON.parse(raw) as Record<string, unknown>;
     const data = await createVoucher(params);
-    console.log(JSON.stringify(data, null, 2));
+    outputDetail(data as Record<string, unknown>, voucherDetailColumns, json());
   });
 
 // Error handling

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,160 @@
+export interface Column {
+  key: string;
+  header: string;
+  width: number;
+  align?: 'left' | 'right';
+  format?: (value: unknown) => string;
+}
+
+function toString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value).replace(/[\n\r]+/g, ' ');
+}
+
+function truncate(str: string, width: number): string {
+  if (str.length <= width) return str;
+  return str.slice(0, width - 1) + '…';
+}
+
+function pad(str: string, width: number, align: 'left' | 'right'): string {
+  const truncated = truncate(str, width);
+  return align === 'right' ? truncated.padStart(width) : truncated.padEnd(width);
+}
+
+export function formatTable(rows: Record<string, unknown>[], columns: Column[]): string {
+  if (rows.length === 0) return 'No results.';
+
+  const header = columns.map((c) => pad(c.header, c.width, c.align ?? 'left')).join('  ');
+  const separator = columns.map((c) => '─'.repeat(c.width)).join('──');
+  const body = rows.map((row) =>
+    columns
+      .map((c) => {
+        const raw = row[c.key];
+        const str = c.format ? c.format(raw) : toString(raw);
+        return pad(str, c.width, c.align ?? 'left');
+      })
+      .join('  '),
+  );
+
+  return [header, separator, ...body].join('\n');
+}
+
+export function formatDetail(record: Record<string, unknown>, columns: Column[]): string {
+  const maxLabel = Math.max(...columns.map((c) => c.header.length));
+  return columns
+    .map((c) => {
+      const raw = record[c.key];
+      if (raw === null || raw === undefined || raw === '') return null;
+      const str = c.format ? c.format(raw) : toString(raw);
+      return `  ${c.header.padEnd(maxLabel)}  ${str}`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function formatMeta(meta?: Record<string, unknown>): string {
+  if (!meta) return '';
+  const total = meta['@TotalResources'];
+  const pages = meta['@TotalPages'];
+  const current = meta['@CurrentPage'];
+  if (total === undefined) return '';
+  return `\nPage ${current}/${pages} (${total} total)`;
+}
+
+export function formatTaxReport(report: Record<string, unknown>): string {
+  const period = report.period as { from: string; to: string } | undefined;
+  const vatAccounts = report.vatAccounts as Record<string, { debit: number; credit: number; description: string }> | undefined;
+  const accountBalances = report.accountBalances as Array<{ account: number; description: string; balance: number }> | undefined;
+  const summary = report.summary as { note: string } | undefined;
+
+  const lines: string[] = [];
+
+  if (period) {
+    lines.push(`Period: ${period.from} — ${period.to}`);
+    lines.push('');
+  }
+
+  if (vatAccounts && Object.keys(vatAccounts).length > 0) {
+    lines.push('VAT Accounts');
+    lines.push('─'.repeat(60));
+    lines.push(
+      `${'Account'.padEnd(8)}  ${'Description'.padEnd(25)}  ${'Debit'.padStart(10)}  ${'Credit'.padStart(10)}`,
+    );
+    lines.push('─'.repeat(60));
+    for (const [acct, data] of Object.entries(vatAccounts)) {
+      lines.push(
+        `${acct.padEnd(8)}  ${truncate(data.description, 25).padEnd(25)}  ${data.debit.toFixed(2).padStart(10)}  ${data.credit.toFixed(2).padStart(10)}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (accountBalances && accountBalances.length > 0) {
+    lines.push('Account Balances');
+    lines.push('─'.repeat(50));
+    lines.push(
+      `${'Account'.padEnd(8)}  ${'Description'.padEnd(25)}  ${'Balance'.padStart(10)}`,
+    );
+    lines.push('─'.repeat(50));
+    for (const row of accountBalances) {
+      lines.push(
+        `${String(row.account).padEnd(8)}  ${truncate(row.description, 25).padEnd(25)}  ${row.balance.toFixed(2).padStart(10)}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (summary?.note) {
+    lines.push(`Note: ${summary.note}`);
+  }
+
+  return lines.join('\n');
+}
+
+export interface OutputOptions {
+  json: boolean;
+}
+
+export function isJsonMode(programOpts: { output?: string }, stdout = process.stdout): boolean {
+  if (programOpts.output === 'json') return true;
+  if (programOpts.output === 'table') return false;
+  // Default: JSON when piped, table on TTY
+  return !stdout.isTTY;
+}
+
+export function outputList(
+  data: Record<string, unknown>[],
+  columns: Column[],
+  json: boolean,
+  rawData: unknown,
+  meta?: Record<string, unknown>,
+): void {
+  if (json) {
+    console.log(JSON.stringify(rawData, null, 2));
+    return;
+  }
+  console.log(formatTable(data, columns));
+  const metaLine = formatMeta(meta);
+  if (metaLine) console.log(metaLine);
+}
+
+export function outputDetail(
+  record: Record<string, unknown>,
+  columns: Column[],
+  json: boolean,
+): void {
+  if (json) {
+    console.log(JSON.stringify(record, null, 2));
+    return;
+  }
+  console.log(formatDetail(record, columns));
+}
+
+export function outputConfirmation(message: string, json: boolean, rawData: unknown): void {
+  if (json) {
+    console.log(JSON.stringify(rawData, null, 2));
+    return;
+  }
+  console.log(message);
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -64,8 +64,12 @@ export function formatMeta(meta?: Record<string, unknown>): string {
 
 export function formatTaxReport(report: Record<string, unknown>): string {
   const period = report.period as { from: string; to: string } | undefined;
-  const vatAccounts = report.vatAccounts as Record<string, { debit: number; credit: number; description: string }> | undefined;
-  const accountBalances = report.accountBalances as Array<{ account: number; description: string; balance: number }> | undefined;
+  const vatAccounts = report.vatAccounts as
+    | Record<string, { debit: number; credit: number; description: string }>
+    | undefined;
+  const accountBalances = report.accountBalances as
+    | Array<{ account: number; description: string; balance: number }>
+    | undefined;
   const summary = report.summary as { note: string } | undefined;
 
   const lines: string[] = [];
@@ -93,9 +97,7 @@ export function formatTaxReport(report: Record<string, unknown>): string {
   if (accountBalances && accountBalances.length > 0) {
     lines.push('Account Balances');
     lines.push('─'.repeat(50));
-    lines.push(
-      `${'Account'.padEnd(8)}  ${'Description'.padEnd(25)}  ${'Balance'.padStart(10)}`,
-    );
+    lines.push(`${'Account'.padEnd(8)}  ${'Description'.padEnd(25)}  ${'Balance'.padStart(10)}`);
     lines.push('─'.repeat(50));
     for (const row of accountBalances) {
       lines.push(

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -6,10 +6,26 @@ export interface Column {
   format?: (value: unknown) => string;
 }
 
+function stripControl(str: string): string {
+  return (
+    str
+      // Strip ANSI CSI sequences (e.g. \x1b[31m)
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+      // Strip OSC sequences (e.g. \x1b]52;c;...\x07)
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\][^\x07]*\x07/g, '')
+      // Strip remaining individual control characters
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x09\x0b-\x1f\x7f-\x9f]/g, '')
+      .replace(/[\n\r]+/g, ' ')
+  );
+}
+
 function toString(value: unknown): string {
   if (value === null || value === undefined) return '';
   if (typeof value === 'boolean') return value ? 'Yes' : 'No';
-  return String(value).replace(/[\n\r]+/g, ' ');
+  return stripControl(String(value));
 }
 
 function truncate(str: string, width: number): string {
@@ -88,7 +104,7 @@ export function formatTaxReport(report: Record<string, unknown>): string {
     lines.push('─'.repeat(60));
     for (const [acct, data] of Object.entries(vatAccounts)) {
       lines.push(
-        `${acct.padEnd(8)}  ${truncate(data.description, 25).padEnd(25)}  ${data.debit.toFixed(2).padStart(10)}  ${data.credit.toFixed(2).padStart(10)}`,
+        `${acct.padEnd(8)}  ${truncate(stripControl(data.description), 25).padEnd(25)}  ${data.debit.toFixed(2).padStart(10)}  ${data.credit.toFixed(2).padStart(10)}`,
       );
     }
     lines.push('');
@@ -101,14 +117,14 @@ export function formatTaxReport(report: Record<string, unknown>): string {
     lines.push('─'.repeat(50));
     for (const row of accountBalances) {
       lines.push(
-        `${String(row.account).padEnd(8)}  ${truncate(row.description, 25).padEnd(25)}  ${row.balance.toFixed(2).padStart(10)}`,
+        `${String(row.account).padEnd(8)}  ${truncate(stripControl(row.description), 25).padEnd(25)}  ${row.balance.toFixed(2).padStart(10)}`,
       );
     }
     lines.push('');
   }
 
   if (summary?.note) {
-    lines.push(`Note: ${summary.note}`);
+    lines.push(`Note: ${stripControl(summary.note)}`);
   }
 
   return lines.join('\n');
@@ -153,10 +169,18 @@ export function outputDetail(
   console.log(formatDetail(record, columns));
 }
 
-export function outputConfirmation(message: string, json: boolean, rawData: unknown): void {
+export function outputConfirmation(
+  message: string,
+  json: boolean,
+  rawData: unknown,
+  columns?: Column[],
+): void {
   if (json) {
     console.log(JSON.stringify(rawData, null, 2));
     return;
   }
   console.log(message);
+  if (columns && rawData && typeof rawData === 'object') {
+    console.log(formatDetail(rawData as Record<string, unknown>, columns));
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,7 @@ export async function startMcpServer(): Promise<void> {
 
 // Auto-start when run directly (backward compat: `node dist/index.js`)
 const isDirectRun =
-  import.meta.url === `file://${process.argv[1]}` ||
-  process.argv[1]?.endsWith('/index.js');
+  import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('/index.js');
 
 if (isDirectRun) {
   startMcpServer().catch((err) => {

--- a/src/operations/accounts.ts
+++ b/src/operations/accounts.ts
@@ -9,7 +9,9 @@ export interface ListAccountsParams {
   search?: string;
 }
 
-export async function listAccounts(params: ListAccountsParams = {}): Promise<Record<string, unknown>[]> {
+export async function listAccounts(
+  params: ListAccountsParams = {},
+): Promise<Record<string, unknown>[]> {
   const data = await fortnoxRequest<AccountsResponse>('accounts', {
     params: {
       financialyear: params.financialYear,

--- a/src/operations/customers.ts
+++ b/src/operations/customers.ts
@@ -30,7 +30,9 @@ export async function getCustomer(customerNumber: string): Promise<Record<string
   return data.Customer;
 }
 
-export async function createCustomer(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+export async function createCustomer(
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
   const data = await fortnoxRequest<CustomerResponse>('customers', {
     method: 'POST',
     body: { Customer: params },

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -36,7 +36,9 @@ export async function getInvoice(documentNumber: string): Promise<Record<string,
   return data.Invoice;
 }
 
-export async function createInvoice(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+export async function createInvoice(
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
   const data = await fortnoxRequest<InvoiceResponse>('invoices', {
     method: 'POST',
     body: { Invoice: params },
@@ -50,25 +52,27 @@ export async function sendInvoice(
   documentNumber: string,
   method: SendMethod = 'email',
 ): Promise<Record<string, unknown>> {
-  const endpointSuffix = method === 'email' ? 'email' : method === 'einvoice' ? 'einvoice' : 'print';
-  const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentNumber}/${endpointSuffix}`, {
+  const endpointSuffix =
+    method === 'email' ? 'email' : method === 'einvoice' ? 'einvoice' : 'print';
+  const data = await fortnoxRequest<InvoiceResponse>(
+    `invoices/${documentNumber}/${endpointSuffix}`,
+    {
+      method: 'PUT',
+    },
+  );
+  return data?.Invoice || {};
+}
+
+export async function bookkeepInvoice(documentNumber: string): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentNumber}/bookkeep`, {
     method: 'PUT',
   });
   return data?.Invoice || {};
 }
 
-export async function bookkeepInvoice(documentNumber: string): Promise<Record<string, unknown>> {
-  const data = await fortnoxRequest<InvoiceResponse>(
-    `invoices/${documentNumber}/bookkeep`,
-    { method: 'PUT' },
-  );
-  return data?.Invoice || {};
-}
-
 export async function creditInvoice(documentNumber: string): Promise<Record<string, unknown>> {
-  const data = await fortnoxRequest<InvoiceResponse>(
-    `invoices/${documentNumber}/credit`,
-    { method: 'PUT' },
-  );
+  const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentNumber}/credit`, {
+    method: 'PUT',
+  });
   return data?.Invoice || {};
 }

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -31,7 +31,9 @@ export async function listVouchers(params: ListVouchersParams = {}): Promise<Vou
   });
 }
 
-export async function createVoucher(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+export async function createVoucher(
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
   const data = await fortnoxRequest<VoucherResponse>('vouchers', {
     method: 'POST',
     body: {

--- a/src/tools/company.ts
+++ b/src/tools/company.ts
@@ -10,9 +10,7 @@ export function registerCompanyTools(server: McpServer): void {
       const data = await getCompanyInfo();
 
       return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(data, null, 2) },
-        ],
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
       };
     },
   );

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -1,6 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { listCustomers, getCustomer, createCustomer, updateCustomer } from '../operations/customers.js';
+import {
+  listCustomers,
+  getCustomer,
+  createCustomer,
+  updateCustomer,
+} from '../operations/customers.js';
 
 export function registerCustomerTools(server: McpServer): void {
   server.tool(

--- a/src/views.ts
+++ b/src/views.ts
@@ -1,0 +1,93 @@
+import type { Column } from './formatter.js';
+
+const currency = (v: unknown) => (typeof v === 'number' ? v.toFixed(2) : String(v ?? ''));
+
+// --- Invoice views (target ≤80 cols) ---
+
+// 7 + 2 + 20 + 2 + 10 + 2 + 10 + 2 + 10 + 2 + 10 = 77
+export const invoiceListColumns: Column[] = [
+  { key: 'DocumentNumber', header: 'Doc #', width: 7, align: 'right' },
+  { key: 'CustomerName', header: 'Customer', width: 20 },
+  { key: 'InvoiceDate', header: 'Date', width: 10 },
+  { key: 'DueDate', header: 'Due', width: 10 },
+  { key: 'Total', header: 'Total', width: 10, align: 'right', format: currency },
+  { key: 'Balance', header: 'Balance', width: 10, align: 'right', format: currency },
+];
+
+export const invoiceDetailColumns: Column[] = [
+  { key: 'DocumentNumber', header: 'Document #', width: 20 },
+  { key: 'CustomerNumber', header: 'Customer #', width: 20 },
+  { key: 'CustomerName', header: 'Customer', width: 40 },
+  { key: 'InvoiceDate', header: 'Invoice Date', width: 10 },
+  { key: 'DueDate', header: 'Due Date', width: 10 },
+  { key: 'Total', header: 'Total', width: 20, format: currency },
+  { key: 'Balance', header: 'Balance', width: 20, format: currency },
+  { key: 'Currency', header: 'Currency', width: 5 },
+  { key: 'Booked', header: 'Booked', width: 5 },
+  { key: 'Sent', header: 'Sent', width: 5 },
+  { key: 'OurReference', header: 'Our Reference', width: 30 },
+  { key: 'CreditInvoiceReference', header: 'Credit Ref', width: 20 },
+];
+
+// --- Customer views (target ≤80 cols) ---
+
+// 7 + 2 + 25 + 2 + 12 + 2 + 12 + 2 + 14 = 78
+export const customerListColumns: Column[] = [
+  { key: 'CustomerNumber', header: '#', width: 7, align: 'right' },
+  { key: 'Name', header: 'Name', width: 25 },
+  { key: 'OrganisationNumber', header: 'Org Nr', width: 12 },
+  { key: 'City', header: 'City', width: 12 },
+  { key: 'Email', header: 'Email', width: 14 },
+];
+
+export const customerDetailColumns: Column[] = [
+  { key: 'CustomerNumber', header: 'Customer #', width: 20 },
+  { key: 'Name', header: 'Name', width: 40 },
+  { key: 'OrganisationNumber', header: 'Org Nr', width: 20 },
+  { key: 'Email', header: 'Email', width: 40 },
+  { key: 'Phone', header: 'Phone', width: 20 },
+  { key: 'Address1', header: 'Address', width: 40 },
+  { key: 'ZipCode', header: 'Zip Code', width: 10 },
+  { key: 'City', header: 'City', width: 20 },
+  { key: 'Country', header: 'Country', width: 5 },
+  { key: 'VATNumber', header: 'VAT Number', width: 20 },
+];
+
+// --- Voucher views (target ≤80 cols) ---
+
+// 6 + 2 + 7 + 2 + 10 + 2 + 45 = 74
+export const voucherListColumns: Column[] = [
+  { key: 'VoucherSeries', header: 'Series', width: 6 },
+  { key: 'VoucherNumber', header: 'Number', width: 7, align: 'right' },
+  { key: 'TransactionDate', header: 'Date', width: 10 },
+  { key: 'Description', header: 'Description', width: 45 },
+];
+
+export const voucherDetailColumns: Column[] = [
+  { key: 'VoucherSeries', header: 'Series', width: 10 },
+  { key: 'VoucherNumber', header: 'Number', width: 10 },
+  { key: 'TransactionDate', header: 'Date', width: 10 },
+  { key: 'Description', header: 'Description', width: 50 },
+];
+
+// --- Account views (target ≤80 cols) ---
+
+// 8 + 2 + 50 + 2 + 6 = 68
+export const accountListColumns: Column[] = [
+  { key: 'Number', header: 'Account', width: 8, align: 'right' },
+  { key: 'Description', header: 'Description', width: 50 },
+  { key: 'SRU', header: 'SRU', width: 6, align: 'right' },
+];
+
+// --- Company views ---
+
+export const companyDetailColumns: Column[] = [
+  { key: 'CompanyName', header: 'Company', width: 40 },
+  { key: 'OrganisationNumber', header: 'Org Nr', width: 20 },
+  { key: 'Address', header: 'Address', width: 40 },
+  { key: 'ZipCode', header: 'Zip Code', width: 10 },
+  { key: 'City', header: 'City', width: 20 },
+  { key: 'Country', header: 'Country', width: 5 },
+  { key: 'Email', header: 'Email', width: 40 },
+  { key: 'DatabaseNumber', header: 'Database #', width: 10 },
+];

--- a/src/views.ts
+++ b/src/views.ts
@@ -29,6 +29,15 @@ export const invoiceDetailColumns: Column[] = [
   { key: 'CreditInvoiceReference', header: 'Credit Ref', width: 20 },
 ];
 
+export const invoiceConfirmColumns: Column[] = [
+  { key: 'DocumentNumber', header: 'Document #', width: 20 },
+  { key: 'CustomerNumber', header: 'Customer #', width: 20 },
+  { key: 'Total', header: 'Total', width: 20, format: currency },
+  { key: 'Booked', header: 'Booked', width: 5 },
+  { key: 'Sent', header: 'Sent', width: 5 },
+  { key: 'CreditInvoiceReference', header: 'Credit Ref', width: 20 },
+];
+
 // --- Customer views (target ≤80 cols) ---
 
 // 7 + 2 + 25 + 2 + 12 + 2 + 12 + 2 + 14 = 78

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatTable,
+  formatDetail,
+  formatMeta,
+  formatTaxReport,
+  isJsonMode,
+  type Column,
+} from '../src/formatter.js';
+
+const cols: Column[] = [
+  { key: 'id', header: 'ID', width: 5, align: 'right' },
+  { key: 'name', header: 'Name', width: 15 },
+  { key: 'amount', header: 'Amount', width: 10, align: 'right', format: (v) => (typeof v === 'number' ? v.toFixed(2) : String(v ?? '')) },
+];
+
+describe('formatTable', () => {
+  it('renders rows with headers and alignment', () => {
+    const rows = [
+      { id: 1, name: 'Alice', amount: 100 },
+      { id: 42, name: 'Bob', amount: 2500.5 },
+    ];
+    const output = formatTable(rows, cols);
+    const lines = output.split('\n');
+
+    expect(lines[0]).toContain('ID');
+    expect(lines[0]).toContain('Name');
+    expect(lines[0]).toContain('Amount');
+    // separator
+    expect(lines[1]).toMatch(/^─+/);
+    // right-aligned ID
+    expect(lines[2]).toMatch(/^\s+1/);
+    // formatted amount
+    expect(lines[3]).toContain('2500.50');
+  });
+
+  it('returns "No results." for empty array', () => {
+    expect(formatTable([], cols)).toBe('No results.');
+  });
+
+  it('truncates long values with ellipsis', () => {
+    const rows = [{ id: 1, name: 'A very long name that exceeds width', amount: 0 }];
+    const output = formatTable(rows, cols);
+    expect(output).toContain('…');
+    // truncated to 15 chars (14 + ellipsis)
+    const dataLine = output.split('\n')[2];
+    const nameSection = dataLine.slice(7, 22); // after "   1  "
+    expect(nameSection.length).toBe(15);
+  });
+
+  it('handles null and undefined values', () => {
+    const rows = [{ id: null, name: undefined, amount: null }];
+    const output = formatTable(rows, cols);
+    const lines = output.split('\n');
+    expect(lines.length).toBe(3); // header + separator + 1 row
+  });
+
+  it('handles boolean values', () => {
+    const boolCols: Column[] = [{ key: 'active', header: 'Active', width: 6 }];
+    const rows = [{ active: true }, { active: false }];
+    const output = formatTable(rows, boolCols);
+    expect(output).toContain('Yes');
+    expect(output).toContain('No');
+  });
+
+  it('sanitizes newlines in values', () => {
+    const rows = [{ id: 1, name: 'Line1\nLine2', amount: 0 }];
+    const output = formatTable(rows, cols);
+    expect(output).not.toContain('\nLine2');
+    expect(output).toContain('Line1 Line2');
+  });
+});
+
+describe('formatDetail', () => {
+  it('renders key-value pairs vertically', () => {
+    const record = { id: 42, name: 'Test Corp', amount: 1234.56 };
+    const output = formatDetail(record, cols);
+    expect(output).toContain('ID');
+    expect(output).toContain('42');
+    expect(output).toContain('Name');
+    expect(output).toContain('Test Corp');
+    expect(output).toContain('1234.56');
+  });
+
+  it('skips null/undefined/empty fields', () => {
+    const record = { id: 1, name: null, amount: undefined };
+    const output = formatDetail(record, cols);
+    expect(output).toContain('ID');
+    expect(output).not.toContain('Name');
+    expect(output).not.toContain('Amount');
+  });
+
+  it('aligns labels to same width', () => {
+    const record = { id: 1, name: 'Test', amount: 100 };
+    const output = formatDetail(record, cols);
+    const lines = output.split('\n');
+    // All labels should be padded to length of longest header ("Amount" = 6)
+    for (const line of lines) {
+      // format: "  Label   value"
+      expect(line).toMatch(/^\s{2}\w/);
+    }
+  });
+});
+
+describe('formatMeta', () => {
+  it('renders pagination info', () => {
+    const meta = { '@TotalResources': 150, '@TotalPages': 3, '@CurrentPage': 1 };
+    const output = formatMeta(meta);
+    expect(output).toContain('Page 1/3');
+    expect(output).toContain('150 total');
+  });
+
+  it('returns empty string for undefined meta', () => {
+    expect(formatMeta(undefined)).toBe('');
+  });
+
+  it('returns empty string when no @TotalResources', () => {
+    expect(formatMeta({})).toBe('');
+  });
+});
+
+describe('formatTaxReport', () => {
+  const report = {
+    period: { from: '2025-01-01', to: '2025-03-31' },
+    vatAccounts: {
+      '2610': { debit: 0, credit: 5000.0, description: 'Utgående moms 25%' },
+      '2640': { debit: 1200.5, credit: 0, description: 'Ingående moms' },
+    },
+    accountBalances: [
+      { account: 2610, description: 'Utgående moms 25%', balance: -5000.0 },
+      { account: 2640, description: 'Ingående moms', balance: 1200.5 },
+    ],
+    summary: { note: 'Kontrollera beloppen mot Fortnox momsrapport.' },
+  };
+
+  it('renders period header', () => {
+    const output = formatTaxReport(report);
+    expect(output).toContain('2025-01-01');
+    expect(output).toContain('2025-03-31');
+  });
+
+  it('renders VAT accounts table', () => {
+    const output = formatTaxReport(report);
+    expect(output).toContain('VAT Accounts');
+    expect(output).toContain('2610');
+    expect(output).toContain('5000.00');
+    expect(output).toContain('Utgående moms 25%');
+  });
+
+  it('renders account balances table', () => {
+    const output = formatTaxReport(report);
+    expect(output).toContain('Account Balances');
+    expect(output).toContain('1200.50');
+  });
+
+  it('renders summary note', () => {
+    const output = formatTaxReport(report);
+    expect(output).toContain('Kontrollera beloppen');
+  });
+
+  it('handles empty report gracefully', () => {
+    const output = formatTaxReport({});
+    expect(output).toBe('');
+  });
+});
+
+describe('isJsonMode', () => {
+  it('returns true when output is "json"', () => {
+    expect(isJsonMode({ output: 'json' })).toBe(true);
+  });
+
+  it('returns false when output is "table"', () => {
+    expect(isJsonMode({ output: 'table' })).toBe(false);
+  });
+
+  it('returns true when no TTY (piped)', () => {
+    const fakeStdout = { isTTY: false } as NodeJS.WriteStream;
+    expect(isJsonMode({}, fakeStdout)).toBe(true);
+  });
+
+  it('returns false when TTY (interactive)', () => {
+    const fakeStdout = { isTTY: true } as NodeJS.WriteStream;
+    expect(isJsonMode({}, fakeStdout)).toBe(false);
+  });
+
+  it('explicit flag overrides TTY detection', () => {
+    const fakeStdout = { isTTY: true } as NodeJS.WriteStream;
+    expect(isJsonMode({ output: 'json' }, fakeStdout)).toBe(true);
+  });
+});

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -11,7 +11,13 @@ import {
 const cols: Column[] = [
   { key: 'id', header: 'ID', width: 5, align: 'right' },
   { key: 'name', header: 'Name', width: 15 },
-  { key: 'amount', header: 'Amount', width: 10, align: 'right', format: (v) => (typeof v === 'number' ? v.toFixed(2) : String(v ?? '')) },
+  {
+    key: 'amount',
+    header: 'Amount',
+    width: 10,
+    align: 'right',
+    format: (v) => (typeof v === 'number' ? v.toFixed(2) : String(v ?? '')),
+  },
 ];
 
 describe('formatTable', () => {

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -69,6 +69,15 @@ describe('formatTable', () => {
     expect(output).toContain('No');
   });
 
+  it('strips ANSI/OSC escape sequences from values', () => {
+    const malicious = '\x1b]52;c;SGVsbG8=\x07Innocent Name';
+    const rows = [{ id: 1, name: malicious, amount: 0 }];
+    const output = formatTable(rows, cols);
+    expect(output).not.toContain('\x1b');
+    expect(output).not.toContain('\x07');
+    expect(output).toContain('Innocent Name');
+  });
+
   it('sanitizes newlines in values', () => {
     const rows = [{ id: 1, name: 'Line1\nLine2', amount: 0 }];
     const output = formatTable(rows, cols);
@@ -162,6 +171,22 @@ describe('formatTaxReport', () => {
   it('renders summary note', () => {
     const output = formatTaxReport(report);
     expect(output).toContain('Kontrollera beloppen');
+  });
+
+  it('strips escape sequences from descriptions', () => {
+    const evil = {
+      period: { from: '2025-01-01', to: '2025-03-31' },
+      vatAccounts: {
+        '2610': { debit: 0, credit: 100, description: '\x1b[31mEvil\x1b[0m' },
+      },
+      accountBalances: [{ account: 2610, description: '\x1b]52;c;test\x07', balance: 100 }],
+      summary: { note: '\x1b[1mBold note\x1b[0m' },
+    };
+    const output = formatTaxReport(evil);
+    expect(output).not.toContain('\x1b');
+    expect(output).not.toContain('\x07');
+    expect(output).toContain('Evil');
+    expect(output).toContain('Bold note');
   });
 
   it('handles empty report gracefully', () => {

--- a/tests/operations/accounts.test.ts
+++ b/tests/operations/accounts.test.ts
@@ -62,9 +62,7 @@ describe('accounts operations', () => {
 
     it('search is case-insensitive', async () => {
       mockFetch({
-        Accounts: [
-          { Number: 1930, Description: 'Företagskonto' },
-        ],
+        Accounts: [{ Number: 1930, Description: 'Företagskonto' }],
       });
       const { listAccounts } = await import('../../src/operations/accounts.js');
 

--- a/tests/operations/company.test.ts
+++ b/tests/operations/company.test.ts
@@ -20,7 +20,9 @@ describe('company operations', () => {
 
   describe('getCompanyInfo', () => {
     it('unwraps CompanyInformation envelope', async () => {
-      mockFetch({ CompanyInformation: { CompanyName: 'Test AB', OrganizationNumber: '556677-8899' } });
+      mockFetch({
+        CompanyInformation: { CompanyName: 'Test AB', OrganizationNumber: '556677-8899' },
+      });
       const { getCompanyInfo } = await import('../../src/operations/company.js');
 
       const result = await getCompanyInfo();

--- a/tests/operations/tax.test.ts
+++ b/tests/operations/tax.test.ts
@@ -14,24 +14,37 @@ describe('tax operations', () => {
       let callCount = 0;
       global.fetch = vi.fn().mockImplementation(() => {
         callCount++;
-        const response = callCount === 1
-          ? {
-              Accounts: [
-                { Number: 2610, Description: 'Utgående moms 25%', SRU: 0, BalanceBroughtForward: 0, BalanceCarriedForward: -12500 },
-                { Number: 2640, Description: 'Ingående moms', SRU: 0, BalanceBroughtForward: 0, BalanceCarriedForward: 3200 },
-              ],
-            }
-          : {
-              Vouchers: [
-                {
-                  VoucherRows: [
-                    { Account: 2610, Debit: 0, Credit: 12500 },
-                    { Account: 2640, Debit: 3200, Credit: 0 },
-                    { Account: 3001, Debit: 0, Credit: 50000 },
-                  ],
-                },
-              ],
-            };
+        const response =
+          callCount === 1
+            ? {
+                Accounts: [
+                  {
+                    Number: 2610,
+                    Description: 'Utgående moms 25%',
+                    SRU: 0,
+                    BalanceBroughtForward: 0,
+                    BalanceCarriedForward: -12500,
+                  },
+                  {
+                    Number: 2640,
+                    Description: 'Ingående moms',
+                    SRU: 0,
+                    BalanceBroughtForward: 0,
+                    BalanceCarriedForward: 3200,
+                  },
+                ],
+              }
+            : {
+                Vouchers: [
+                  {
+                    VoucherRows: [
+                      { Account: 2610, Debit: 0, Credit: 12500 },
+                      { Account: 2640, Debit: 3200, Credit: 0 },
+                      { Account: 3001, Debit: 0, Credit: 50000 },
+                    ],
+                  },
+                ],
+              };
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -54,14 +67,27 @@ describe('tax operations', () => {
       let callCount = 0;
       global.fetch = vi.fn().mockImplementation(() => {
         callCount++;
-        const response = callCount === 1
-          ? {
-              Accounts: [
-                { Number: 1930, Description: 'Bank', SRU: 0, BalanceBroughtForward: 0, BalanceCarriedForward: 100000 },
-                { Number: 2610, Description: 'Utgående moms 25%', SRU: 0, BalanceBroughtForward: 0, BalanceCarriedForward: -5000 },
-              ],
-            }
-          : { Vouchers: [] };
+        const response =
+          callCount === 1
+            ? {
+                Accounts: [
+                  {
+                    Number: 1930,
+                    Description: 'Bank',
+                    SRU: 0,
+                    BalanceBroughtForward: 0,
+                    BalanceCarriedForward: 100000,
+                  },
+                  {
+                    Number: 2610,
+                    Description: 'Utgående moms 25%',
+                    SRU: 0,
+                    BalanceBroughtForward: 0,
+                    BalanceCarriedForward: -5000,
+                  },
+                ],
+              }
+            : { Vouchers: [] };
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -78,7 +104,8 @@ describe('tax operations', () => {
     });
 
     it('handles empty period with no transactions', async () => {
-      global.fetch = vi.fn()
+      global.fetch = vi
+        .fn()
         .mockResolvedValueOnce({
           ok: true,
           status: 200,

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -69,7 +69,10 @@ describe('voucher operations', () => {
       await createVoucher({
         Description: 'Test',
         TransactionDate: '2025-01-15',
-        VoucherRows: [{ Account: 1930, Debit: 100 }, { Account: 2640, Credit: 100 }],
+        VoucherRows: [
+          { Account: 1930, Debit: 100 },
+          { Account: 2640, Credit: 100 },
+        ],
       });
 
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];


### PR DESCRIPTION
## Summary
- Replace raw JSON output with human-readable tables for all CLI commands
- TTY-sensitive defaults: table on interactive terminals, JSON when piped
- Explicit control via `-o json|table` flag
- View configs per command, all list views fit ≤80 columns
- Terse confirmations for mutation commands (send/bookkeep/credit)
- Bespoke multi-section renderer for tax reports

## Design
Plan was stress-tested via [adversarial debate with Codex](debate/table-formatter-summary.md) (2 rounds, 12 critique points). Key changes from debate:
- TTY-sensitive defaults instead of just `--json` flag
- `-o json|table` instead of `--json` for future extensibility
- View configs per command instead of per entity
- Default column sets target ≤80 columns
- Mutation confirmations instead of full detail dumps

## Test plan
- [x] 22 new formatter unit tests (table, detail, meta, tax report, TTY detection)
- [x] All 119 tests passing (97 existing + 22 new)
- [x] Build passes
- [ ] Manual: `noxctl invoices list` shows table on terminal
- [ ] Manual: `noxctl invoices list | cat` outputs JSON
- [ ] Manual: `noxctl -o json invoices list` forces JSON on terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)