### PR TITLE
feat: add interactive init wizard and improve onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,66 @@
 # noxctl
 
-MCP server for Fortnox — manage invoices, customers, bookkeeping, and VAT directly from Claude Code.
+CLI and MCP server for Fortnox — manage invoices, customers, bookkeeping, and VAT from the terminal or from AI agents like Claude Code.
 
-## Quick start
-
-### From npm
-
-```bash
-FORTNOX_CLIENT_ID=<your-id> FORTNOX_CLIENT_SECRET=<your-secret> npx noxctl setup
-
-claude mcp add fortnox -- npx noxctl serve
 ```
-
-### From source
-
-```bash
-git clone https://github.com/Magnus-Gille/noxctl.git
-cd noxctl
-npm install
-npm run build
-
-FORTNOX_CLIENT_ID=<your-id> FORTNOX_CLIENT_SECRET=<your-secret> node dist/cli.js setup
-
-claude mcp add fortnox -- node /absolute/path/to/noxctl/dist/cli.js serve
+noxctl init                          # interactive setup wizard
+noxctl company info                  # verify connection
+noxctl customers list                # list customers
+noxctl invoices list --filter unpaid # unpaid invoices
+noxctl -o json invoices list | jq .  # JSON output for scripting/AI
 ```
-
-Done. No manual tokens, no environment variables after setup.
 
 ## Prerequisites
 
 - **Node.js** 20+
 - **Fortnox account** with API access (Mellan plan or higher)
-- **Fortnox app** registered at [developer.fortnox.se](https://developer.fortnox.se/) with redirect URI `http://localhost:9876/callback`
 - **Linux only:** `secret-tool` available for secure credential storage
 
 ## Setup
 
 ### 1. Create a Fortnox app
 
-1. Go to [developer.fortnox.se](https://developer.fortnox.se/)
-2. Create a new app
-3. Set redirect URI to `http://localhost:9876/callback`
-4. Note your Client ID and Client Secret
-5. Request scopes: `customer`, `invoice`, `bookkeeping`, `companyinformation`, `settings`
-6. Enable "Service account" if you want to use the client credentials flow (recommended)
+> **Tip:** Run `npx noxctl init` for an interactive setup wizard that guides you through all of these steps.
+
+1. Go to [developer.fortnox.se](https://developer.fortnox.se/) and click **Integrationer** / **Integrations**
+2. Create a new app (integration)
+3. On the **OAuth** tab:
+   - Set **Redirect URI** to `http://localhost:9876/callback`
+   - Check **"Möjliggör auktorisering som servicekonto"** / **"Enable service account authorization"** (recommended)
+   - Copy your **Client ID** and **Client Secret**
+4. On the **Integration** tab, enable these scopes under **Behörigheter** / **Permissions**:
+
+   | Swedish (SV)         | English (EN)        |
+   |----------------------|---------------------|
+   | Bokföring            | Bookkeeping         |
+   | Faktura              | Invoice             |
+   | Företagsinformation  | Company Information |
+   | Inställningar        | Settings            |
+   | Kund                 | Customer            |
+
+5. Save the integration
 
 ### 2. Authenticate
 
+Set your credentials as environment variables, then run setup:
+
 ```bash
-FORTNOX_CLIENT_ID=<your-id> FORTNOX_CLIENT_SECRET=<your-secret> npx noxctl setup
+export FORTNOX_CLIENT_ID=<your-id>
+export FORTNOX_CLIENT_SECRET=<your-secret>
+export FORTNOX_SERVICE_ACCOUNT=1
+npx noxctl setup
 ```
 
-To enable the client credentials flow (recommended if you have service accounts enabled in the Developer Portal):
+> Drop the `FORTNOX_SERVICE_ACCOUNT` line if you did not enable service account authorization in step 1.
+
+If running from a local clone instead of npm:
 
 ```bash
-FORTNOX_CLIENT_ID=<your-id> FORTNOX_CLIENT_SECRET=<your-secret> FORTNOX_SERVICE_ACCOUNT=1 npx noxctl setup
+export FORTNOX_CLIENT_ID=<your-id>
+export FORTNOX_CLIENT_SECRET=<your-secret>
+export FORTNOX_SERVICE_ACCOUNT=1
+npm run build
+node dist/cli.js setup
 ```
 
 This opens your browser to log in to Fortnox. After authorization, credentials are stored in the OS secure store:
@@ -63,10 +69,9 @@ This opens your browser to log in to Fortnox. After authorization, credentials a
 - **Linux:** Secret Service via `secret-tool`
 - **Windows:** DPAPI-protected user store
 
-Legacy plaintext `~/.fortnox-mcp/credentials.json` files are read for migration only and removed on the next successful save.
+Token management is automatic after setup — no environment variables needed going forward.
 
-Token management is automatic:
-- **With service account (`FORTNOX_SERVICE_ACCOUNT=1`):** Uses client credentials flow with `TenantId` — no refresh tokens to manage. The tenant ID is fetched automatically during setup.
+- **With service account:** Uses client credentials flow with `TenantId` — no refresh tokens to manage. The tenant ID is fetched automatically during setup.
 - **Without service account (default):** Uses standard OAuth2 refresh token flow.
 
 ### 3. Register with Claude Code
@@ -81,47 +86,63 @@ If you are running from a local clone instead of npm:
 claude mcp add fortnox -- node /absolute/path/to/noxctl/dist/cli.js serve
 ```
 
+### 4. Verify the connection
+
+```bash
+noxctl company info
+```
+
+If running from source:
+
+```bash
+node dist/cli.js company info
+```
+
+You should see your company name, organisation number, and address. If this works, you're all set.
+
 ## Tools
+
+Every operation is available both as a CLI command and as an MCP tool. The CLI is the primary interface; the MCP server exposes the same operations to AI agents.
 
 ### Customers
 
-| Tool | Description |
-|------|-------------|
-| `fortnox_list_customers` | List/search customers |
-| `fortnox_get_customer` | Get a single customer |
-| `fortnox_create_customer` | Create a new customer |
-| `fortnox_update_customer` | Update an existing customer |
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl customers list [--search <term>]` | `fortnox_list_customers` | List/search customers |
+| `noxctl customers get <number>` | `fortnox_get_customer` | Get a single customer by customer number |
+| `noxctl customers create --name <name>` | `fortnox_create_customer` | Create a new customer (mutation) |
+| `noxctl customers update <number> --input <file>` | `fortnox_update_customer` | Update an existing customer (mutation) |
 
 ### Invoices
 
-| Tool | Description |
-|------|-------------|
-| `fortnox_list_invoices` | List/filter invoices |
-| `fortnox_get_invoice` | Get a single invoice |
-| `fortnox_create_invoice` | Create an invoice |
-| `fortnox_send_invoice` | Send invoice via email, print, or e-invoice |
-| `fortnox_bookkeep_invoice` | Book an invoice |
-| `fortnox_credit_invoice` | Credit an invoice |
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl invoices list [--filter <status>] [--customer <number>]` | `fortnox_list_invoices` | List/filter invoices. Filters: `cancelled`, `fullypaid`, `unpaid`, `unpaidoverdue`, `unbooked` |
+| `noxctl invoices get <docNumber>` | `fortnox_get_invoice` | Get a single invoice by document number |
+| `noxctl invoices create --customer <number> --input <file>` | `fortnox_create_invoice` | Create an invoice with line items (mutation) |
+| `noxctl invoices send <docNumber> [--method email\|print\|einvoice]` | `fortnox_send_invoice` | Send invoice via email (default), print, or e-invoice (mutation) |
+| `noxctl invoices bookkeep <docNumber>` | `fortnox_bookkeep_invoice` | Book an invoice (mutation) |
+| `noxctl invoices credit <docNumber>` | `fortnox_credit_invoice` | Credit an invoice (mutation) |
 
 ### Bookkeeping
 
-| Tool | Description |
-|------|-------------|
-| `fortnox_list_vouchers` | List vouchers |
-| `fortnox_create_voucher` | Create a voucher |
-| `fortnox_list_accounts` | View chart of accounts |
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl vouchers list [--series <s>] [--from <date>] [--to <date>]` | `fortnox_list_vouchers` | List vouchers, optionally filtered by series and date range |
+| `noxctl vouchers create --input <file>` | `fortnox_create_voucher` | Create a voucher with debit/credit rows (mutation) |
+| `noxctl accounts list [--search <term>]` | `fortnox_list_accounts` | View chart of accounts, search by name or number |
 
 ### Tax
 
-| Tool | Description |
-|------|-------------|
-| `fortnox_tax_report` | VAT summary for a period (tax declaration support) |
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl tax report --from <date> --to <date>` | `fortnox_tax_report` | VAT summary for a period (tax declaration support). Dates in `YYYY-MM-DD` format |
 
 ### Company
 
-| Tool | Description |
-|------|-------------|
-| `fortnox_company_info` | Company information and settings |
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl company info` | `fortnox_company_info` | Company name, org number, address, and settings |
 
 ## CLI output
 
@@ -157,13 +178,51 @@ MCP tools:
 
 ## Examples
 
-Ask Claude naturally:
+Ask Claude naturally — works in both Swedish and English:
 
 - "Skapa en faktura till kund 42 för 10 konsulttimmar á 1200 kr"
-- "Visa alla obetalda fakturor"
-- "Vad har vi för utgående moms Q1 2025?"
-- "Bokför kontorsmaterial för 1250 kr inkl moms"
-- "Skicka faktura 1001 via e-post"
+- "Create an invoice for customer 42: 10 consulting hours at 1200 SEK"
+- "Visa alla obetalda fakturor" / "Show all unpaid invoices"
+- "Vad har vi för utgående moms Q1 2025?" / "What's our outgoing VAT for Q1 2025?"
+- "Bokför kontorsmaterial för 1250 kr inkl moms" / "Book office supplies for 1250 SEK incl VAT"
+- "Skicka faktura 1001 via e-post" / "Send invoice 1001 by email"
+
+## Troubleshooting
+
+**"FORTNOX_CLIENT_ID and FORTNOX_CLIENT_SECRET must be set"**
+
+Environment variables were not passed to the command. Use `export` to set them in your shell first:
+
+```bash
+export FORTNOX_CLIENT_ID=<your-id>
+export FORTNOX_CLIENT_SECRET=<your-secret>
+```
+
+Then run setup again. This avoids issues with long commands wrapping across lines.
+
+**"Not authenticated. Run `noxctl setup`"**
+
+Credentials are missing or were not saved. Re-run the setup step. On macOS, check that Keychain Access is not blocking the `security` command. On Linux, ensure `secret-tool` is installed (`sudo apt install libsecret-tools`).
+
+**403 Forbidden from Fortnox API**
+
+Your app is missing required scopes. Go to [developer.fortnox.se](https://developer.fortnox.se/), open your app, and check that these are enabled under **Behörigheter** / **Permissions**:
+
+| Swedish (SV)         | English (EN)        |
+|----------------------|---------------------|
+| Bokföring            | Bookkeeping         |
+| Faktura              | Invoice             |
+| Företagsinformation  | Company Information |
+| Inställningar        | Settings            |
+| Kund                 | Customer            |
+
+**"Token refresh failed"**
+
+Your refresh token may have expired or been revoked. Re-run setup to re-authenticate.
+
+**Port 9876 already in use**
+
+Another process is using the OAuth callback port. Close it or wait for a previous setup attempt to finish, then try again.
 
 ## Development
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,7 +90,9 @@ program
         });
         try {
           const answer = (
-            await rlExisting.question('Re-run setup? This will replace your current credentials. [y/N] ')
+            await rlExisting.question(
+              'Re-run setup? This will replace your current credentials. [y/N] ',
+            )
           )
             .trim()
             .toLowerCase();
@@ -200,9 +202,7 @@ program
         }
 
         // Step 5: Service account question — default yes
-        const saAnswer = (
-          await rl.question('Did you enable service account authorization? [Y/n] ')
-        )
+        const saAnswer = (await rl.question('Did you enable service account authorization? [Y/n] '))
           .trim()
           .toLowerCase();
         serviceAccount = saAnswer === '' || saAnswer === 'y' || saAnswer === 'yes';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,8 +81,30 @@ program
     // Step 1: Check if already configured
     const existing = await loadCredentials();
     if (existing) {
-      console.log('You are already set up. Run `noxctl company info` to verify your connection.');
-      return;
+      console.log('Existing credentials found.');
+
+      if (process.stdin.isTTY && process.stdout.isTTY) {
+        const rlExisting = createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        try {
+          const answer = (
+            await rlExisting.question('Re-run setup? This will replace your current credentials. [y/N] ')
+          )
+            .trim()
+            .toLowerCase();
+          if (answer !== 'y' && answer !== 'yes') {
+            console.log('Run `noxctl company info` to verify your current connection.');
+            return;
+          }
+        } finally {
+          rlExisting.close();
+        }
+      } else {
+        console.log('Run `noxctl company info` to verify, or re-run interactively to reconfigure.');
+        return;
+      }
     }
 
     // Step 2: Welcome message
@@ -134,12 +156,42 @@ program
           process.exit(1);
         }
 
-        // Step 4: Prompt for Client Secret
+        // Step 4: Prompt for Client Secret (masked input)
         const envClientSecret = process.env.FORTNOX_CLIENT_SECRET;
-        const clientSecretPrompt = envClientSecret
-          ? 'Client Secret [env var set — press Enter to use it]: '
-          : 'Client Secret: ';
-        const clientSecretAnswer = (await rl.question(clientSecretPrompt)).trim();
+        if (envClientSecret) {
+          process.stdout.write('Client Secret [env var set — press Enter to use it]: ');
+        } else {
+          process.stdout.write('Client Secret: ');
+        }
+        const clientSecretAnswer = await new Promise<string>((resolve) => {
+          let buf = '';
+          const stdin = process.stdin;
+          const wasRaw = stdin.isRaw;
+          stdin.setRawMode(true);
+          stdin.resume();
+          stdin.setEncoding('utf-8');
+          const onData = (ch: string) => {
+            if (ch === '\r' || ch === '\n') {
+              stdin.setRawMode(wasRaw ?? false);
+              stdin.pause();
+              stdin.removeListener('data', onData);
+              process.stdout.write('\n');
+              resolve(buf.trim());
+            } else if (ch === '\u007f' || ch === '\b') {
+              if (buf.length > 0) {
+                buf = buf.slice(0, -1);
+                process.stdout.write('\b \b');
+              }
+            } else if (ch === '\u0003') {
+              // Ctrl-C
+              process.exit(1);
+            } else {
+              buf += ch;
+              process.stdout.write('*');
+            }
+          };
+          stdin.on('data', onData);
+        });
         clientSecret = clientSecretAnswer || envClientSecret || '';
 
         if (!clientSecret) {
@@ -209,8 +261,9 @@ program
           await new Promise<void>((resolve) => {
             execFile('claude', mcpArgs, (err) => {
               if (err) {
+                const fallbackCmd = ['claude', ...mcpArgs].join(' ');
                 console.log('Could not register automatically. Run this manually:');
-                console.log('  claude mcp add fortnox -- npx noxctl serve');
+                console.log(`  ${fallbackCmd}`);
               } else {
                 console.log('MCP server registered. Restart Claude Code to pick it up.');
               }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,159 @@ async function confirmMutation(
   }
 }
 
+// --- init (interactive setup wizard) ---
+program
+  .command('init')
+  .description('Interactive setup wizard — recommended onboarding path')
+  .action(async () => {
+    const { loadCredentials, runOAuthSetup } = await import('./auth.js');
+
+    // Step 1: Check if already configured
+    const existing = await loadCredentials();
+    if (existing) {
+      console.log('You are already set up. Run `noxctl company info` to verify your connection.');
+      return;
+    }
+
+    // Step 2: Welcome message
+    console.log('Welcome to noxctl setup!');
+    console.log('');
+    console.log("You'll need a Fortnox app from developer.fortnox.se with:");
+    console.log('  - Redirect URI: http://localhost:9876/callback');
+    console.log(
+      '  - Scopes (Behörigheter): Bokföring, Faktura, Företagsinformation, Inställningar, Kund',
+    );
+    console.log('  - Service account enabled (recommended)');
+    console.log('');
+    console.log('See the README for detailed portal instructions.');
+    console.log('');
+
+    const isTTY = process.stdin.isTTY && process.stdout.isTTY;
+
+    let clientId: string;
+    let clientSecret: string;
+    let serviceAccount: boolean;
+
+    if (!isTTY) {
+      // CI / non-interactive mode: fall back to env vars
+      clientId = process.env.FORTNOX_CLIENT_ID ?? '';
+      clientSecret = process.env.FORTNOX_CLIENT_SECRET ?? '';
+      serviceAccount = process.env.FORTNOX_SERVICE_ACCOUNT === '1';
+
+      if (!clientId || !clientSecret) {
+        console.error(
+          'Error: stdin is not a TTY. Set FORTNOX_CLIENT_ID and FORTNOX_CLIENT_SECRET env vars to run non-interactively.',
+        );
+        process.exit(1);
+      }
+    } else {
+      const rl = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+
+      try {
+        // Step 3: Prompt for Client ID
+        const envClientId = process.env.FORTNOX_CLIENT_ID;
+        const clientIdPrompt = envClientId ? `Client ID [${envClientId}]: ` : 'Client ID: ';
+        const clientIdAnswer = (await rl.question(clientIdPrompt)).trim();
+        clientId = clientIdAnswer || envClientId || '';
+
+        if (!clientId) {
+          console.error('Error: Client ID is required.');
+          process.exit(1);
+        }
+
+        // Step 4: Prompt for Client Secret
+        const envClientSecret = process.env.FORTNOX_CLIENT_SECRET;
+        const clientSecretPrompt = envClientSecret
+          ? 'Client Secret [env var set — press Enter to use it]: '
+          : 'Client Secret: ';
+        const clientSecretAnswer = (await rl.question(clientSecretPrompt)).trim();
+        clientSecret = clientSecretAnswer || envClientSecret || '';
+
+        if (!clientSecret) {
+          console.error('Error: Client Secret is required.');
+          process.exit(1);
+        }
+
+        // Step 5: Service account question — default yes
+        const saAnswer = (
+          await rl.question('Did you enable service account authorization? [Y/n] ')
+        )
+          .trim()
+          .toLowerCase();
+        serviceAccount = saAnswer === '' || saAnswer === 'y' || saAnswer === 'yes';
+      } finally {
+        rl.close();
+      }
+    }
+
+    // Step 6: Run OAuth flow
+    await runOAuthSetup({ clientId, clientSecret, serviceAccount });
+
+    // Step 7: Verify by fetching company info
+    try {
+      const { getCompanyInfo } = await import('./operations/company.js');
+      const data = await getCompanyInfo();
+      const company = data as Record<string, unknown>;
+      console.log('');
+      console.log('Connected successfully!');
+      if (company['CompanyName']) {
+        console.log(`  Company: ${company['CompanyName']}`);
+      }
+      if (company['OrganizationNumber']) {
+        console.log(`  Org number: ${company['OrganizationNumber']}`);
+      }
+    } catch {
+      console.log('');
+      console.log(
+        'OAuth completed. Could not verify company info — you can run `noxctl company info` manually.',
+      );
+    }
+
+    // Step 8: Offer to register MCP server with Claude Code
+    if (process.stdin.isTTY && process.stdout.isTTY) {
+      const rl2 = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+
+      try {
+        console.log('');
+        const mcpAnswer = (await rl2.question('Register the MCP server with Claude Code? [Y/n] '))
+          .trim()
+          .toLowerCase();
+        const doRegister = mcpAnswer === '' || mcpAnswer === 'y' || mcpAnswer === 'yes';
+
+        if (doRegister) {
+          const { execFile } = await import('node:child_process');
+          // Detect whether we're running via npx or from a local build.
+          // All arguments below are static constants — no user input is interpolated.
+          const argv0 = process.argv[1] ?? '';
+          const useNpx = argv0.includes('npx') || argv0.includes('.bin/noxctl');
+          const mcpArgs = useNpx
+            ? ['mcp', 'add', 'fortnox', '--', 'npx', 'noxctl', 'serve']
+            : ['mcp', 'add', 'fortnox', '--', 'node', argv0, 'serve'];
+
+          await new Promise<void>((resolve) => {
+            execFile('claude', mcpArgs, (err) => {
+              if (err) {
+                console.log('Could not register automatically. Run this manually:');
+                console.log('  claude mcp add fortnox -- npx noxctl serve');
+              } else {
+                console.log('MCP server registered. Restart Claude Code to pick it up.');
+              }
+              resolve();
+            });
+          });
+        }
+      } finally {
+        rl2.close();
+      }
+    }
+  });
+
 // --- setup ---
 program
   .command('setup')


### PR DESCRIPTION
## Summary

- **`noxctl init`** — interactive setup wizard that walks users through app creation, OAuth, verification, and MCP registration in one flow. Replaces the error-prone multi-step manual process.
- **README rewritten for dual audiences** (humans + AI agents): quick-reference block, bilingual portal instructions (SV/EN), CLI+MCP tool table, troubleshooting section, verification step.
- Existing `noxctl setup` preserved for backwards compatibility and CI use.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` — all 131 tests pass
- [ ] `node dist/cli.js init` — walks through interactive wizard on TTY
- [ ] `node dist/cli.js init` — falls back to env vars on non-TTY
- [ ] `node dist/cli.js init` — detects existing credentials and exits early
- [ ] `node dist/cli.js setup` — still works as before
- [ ] `node dist/cli.js company info` — verification step works after setup
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)