### PR TITLE
feat: credential migration + dual-read/write (Chunk C)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,9 +1,9 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { loadCredentialBlob, saveCredentialBlob } from './credentials-store.js';
+import { loadCredentialBlob, saveCredentialBlob, type LoadSource } from './credentials-store.js';
 import { DEFAULT_PROFILE, validateProfileName } from './profile-name.js';
-import { upsertProfile } from './profiles.js';
+import { migrateLegacyIfNeeded, readProfileIndex, upsertProfile } from './profiles.js';
 
 const FORTNOX_AUTH_URL = 'https://apps.fortnox.se/oauth-v1/auth';
 const FORTNOX_TOKEN_URL = 'https://apps.fortnox.se/oauth-v1/token';
@@ -34,6 +34,11 @@ export interface FortnoxAppConfig {
 
 let resolvedProfile: string = DEFAULT_PROFILE;
 
+// Whether the legacy (pre-0.2) credential slot was observed on the most recent
+// successful load of the default profile. Set only by loadCredentials; read by
+// saveCredentials to decide whether to dual-write during the 0.2.x window.
+let legacyObservedForDefault = false;
+
 export function setResolvedProfile(name: string): void {
   resolvedProfile = validateProfileName(name);
 }
@@ -42,27 +47,62 @@ export function getResolvedProfile(): string {
   return resolvedProfile;
 }
 
+// Test-only: reset module-level observation state between cases.
+export function __resetLegacyObservedForDefault(): void {
+  legacyObservedForDefault = false;
+}
+
 function profileOrResolved(profile?: string): string {
   return profile ?? resolvedProfile;
 }
 
+function isDefaultProfile(name: string): boolean {
+  return name.toLowerCase() === DEFAULT_PROFILE;
+}
+
+function legacySlotExists(source: LoadSource): boolean {
+  return (
+    source === 'legacy' ||
+    source === 'both-new-preferred' ||
+    source === 'both-legacy-preferred' ||
+    source === 'legacy-plaintext'
+  );
+}
+
 export async function loadCredentials(profile?: string): Promise<FortnoxCredentials | null> {
+  const target = profileOrResolved(profile);
+  let result: { blob: string | null; source: LoadSource };
   try {
-    const data = await loadCredentialBlob(profileOrResolved(profile));
-    if (!data) return null;
-    return JSON.parse(data) as FortnoxCredentials;
+    result = await loadCredentialBlob(target);
+  } catch {
+    return null;
+  }
+
+  if (isDefaultProfile(target) && legacySlotExists(result.source)) {
+    legacyObservedForDefault = true;
+    // Best-effort seeding of the profile index for pre-0.2 installs. A
+    // failure here must not break auth — Chunk D's `doctor` will surface it.
+    await migrateLegacyIfNeeded(result.blob);
+  }
+
+  if (!result.blob) return null;
+  try {
+    return JSON.parse(result.blob) as FortnoxCredentials;
   } catch {
     return null;
   }
 }
 
 export async function saveCredentials(creds: FortnoxCredentials, profile?: string): Promise<void> {
+  const target = profileOrResolved(profile);
   const stamped: FortnoxCredentials = {
     ...creds,
     schema_version: CREDENTIAL_SCHEMA_VERSION,
     last_write_epoch: Date.now(),
   };
-  await saveCredentialBlob(JSON.stringify(stamped), profileOrResolved(profile));
+  await saveCredentialBlob(JSON.stringify(stamped), target, {
+    alsoWriteLegacy: isDefaultProfile(target) && legacyObservedForDefault,
+  });
 }
 
 export async function exchangeCodeForTokens(
@@ -366,11 +406,17 @@ export async function runOAuthSetup(
 
           await saveCredentials(creds, validatedProfile);
           try {
+            // Preserve the original created_at when re-authenticating an
+            // existing profile so the index timestamp reflects first auth,
+            // not the most recent one.
+            const existing = (await readProfileIndex()).profiles.find(
+              (p) => p.name.toLowerCase() === validatedProfile.toLowerCase(),
+            );
             await upsertProfile({
               name: validatedProfile,
               tenant_id: tenantId,
               company_name: companyName,
-              created_at: new Date().toISOString(),
+              created_at: existing?.created_at ?? new Date().toISOString(),
               schema_version: 2,
             });
           } catch (indexErr) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -71,7 +71,7 @@ function legacySlotExists(source: LoadSource): boolean {
 
 export async function loadCredentials(profile?: string): Promise<FortnoxCredentials | null> {
   const target = profileOrResolved(profile);
-  let result: { blob: string | null; source: LoadSource };
+  let result: { blob: string | null; source: LoadSource; legacyBlob: string | null };
   try {
     result = await loadCredentialBlob(target);
   } catch {
@@ -80,9 +80,11 @@ export async function loadCredentials(profile?: string): Promise<FortnoxCredenti
 
   if (isDefaultProfile(target) && legacySlotExists(result.source)) {
     legacyObservedForDefault = true;
-    // Best-effort seeding of the profile index for pre-0.2 installs. A
-    // failure here must not break auth — Chunk D's `doctor` will surface it.
-    await migrateLegacyIfNeeded(result.blob);
+    // Best-effort seeding of the profile index for pre-0.2 installs. Seed from
+    // the raw legacy blob — not result.blob, which may be the new slot if
+    // pickHigher preferred it and would lose legacy-only metadata on drift.
+    // A failure here must not break auth — Chunk D's `doctor` will surface it.
+    await migrateLegacyIfNeeded(result.legacyBlob);
   }
 
   if (!result.blob) return null;

--- a/src/config-paths.ts
+++ b/src/config-paths.ts
@@ -1,0 +1,7 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export function configDir(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir() || '~';
+  return path.join(home, '.fortnox-mcp');
+}

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -10,13 +10,14 @@ import {
   sanitizeForFilename,
   validateProfileName,
 } from './profile-name.js';
+import { configDir } from './config-paths.js';
 
-const CREDENTIALS_DIR = path.join(
-  process.env.HOME || process.env.USERPROFILE || '~',
-  '.fortnox-mcp',
-);
-const LEGACY_CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials.json');
-const LEGACY_WINDOWS_CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials.dpapi');
+function legacyCredentialsFile(): string {
+  return path.join(configDir(), 'credentials.json');
+}
+function legacyWindowsCredentialsFile(): string {
+  return path.join(configDir(), 'credentials.dpapi');
+}
 const SERVICE_NAME = 'fortnox-mcp';
 
 function normalizeProfile(profile: string): { normalized: string; isDefault: boolean } {
@@ -25,7 +26,71 @@ function normalizeProfile(profile: string): { normalized: string; isDefault: boo
 }
 
 function windowsCredentialsFile(profile: string): string {
-  return path.join(CREDENTIALS_DIR, `credentials.${sanitizeForFilename(profile)}.dpapi`);
+  return path.join(configDir(), `credentials.${sanitizeForFilename(profile)}.dpapi`);
+}
+
+// Dual-write to the legacy slot during the 0.2.x compatibility window so an
+// older 0.1 binary can still read credentials written by this one. Flip to
+// `false` in 0.3.0 and delete the legacy reader branch below.
+// REMOVE IN 0.3.0
+export const LEGACY_DUAL_WRITE = true;
+
+export type LoadSource =
+  | 'new'
+  | 'legacy'
+  | 'both-new-preferred'
+  | 'both-legacy-preferred'
+  | 'legacy-plaintext'
+  | null;
+
+export interface LoadCredentialBlobResult {
+  blob: string | null;
+  source: LoadSource;
+}
+
+export interface SaveCredentialOptions {
+  // When true AND LEGACY_DUAL_WRITE AND the profile resolves to `default`,
+  // the blob is also written to the legacy keychain account / credentials.dpapi
+  // file. Callers set this only when a legacy blob was observed during the most
+  // recent load, to avoid creating empty legacy slots for fresh installs.
+  alsoWriteLegacy?: boolean;
+}
+
+interface ParsedMeta {
+  schema: number;
+  epoch: number;
+}
+
+function parseBlobMeta(blob: string): ParsedMeta | null {
+  try {
+    const parsed = JSON.parse(blob) as {
+      schema_version?: unknown;
+      last_write_epoch?: unknown;
+    };
+    const schema = typeof parsed.schema_version === 'number' ? parsed.schema_version : 1;
+    const epoch = typeof parsed.last_write_epoch === 'number' ? parsed.last_write_epoch : 0;
+    return { schema, epoch };
+  } catch {
+    return null;
+  }
+}
+
+function pickHigher(
+  newBlob: string,
+  legacyBlob: string,
+): { blob: string; picked: 'new' | 'legacy' } {
+  const nMeta = parseBlobMeta(newBlob);
+  const lMeta = parseBlobMeta(legacyBlob);
+  if (nMeta && !lMeta) return { blob: newBlob, picked: 'new' };
+  if (!nMeta && lMeta) return { blob: legacyBlob, picked: 'legacy' };
+  if (!nMeta && !lMeta) return { blob: newBlob, picked: 'new' };
+  const n = nMeta!;
+  const l = lMeta!;
+  if (n.schema > l.schema) return { blob: newBlob, picked: 'new' };
+  if (l.schema > n.schema) return { blob: legacyBlob, picked: 'legacy' };
+  if (n.epoch > l.epoch) return { blob: newBlob, picked: 'new' };
+  if (l.epoch > n.epoch) return { blob: legacyBlob, picked: 'legacy' };
+  return { blob: newBlob, picked: 'new' };
 }
 
 function decodeHexIfNeeded(value: string): string {
@@ -175,7 +240,7 @@ function saveWindowsSecret(file: string, secret: string): void {
       '-NonInteractive',
       '-Command',
       [
-        `[IO.Directory]::CreateDirectory('${CREDENTIALS_DIR}') | Out-Null`,
+        `[IO.Directory]::CreateDirectory('${configDir()}') | Out-Null`,
         '$plain = [Console]::In.ReadToEnd()',
         '$bytes = [Text.Encoding]::UTF8.GetBytes($plain)',
         '$protected = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)',
@@ -192,7 +257,7 @@ function saveWindowsSecret(file: string, secret: string): void {
 
 async function loadLegacyPlaintextSecret(): Promise<string | null> {
   try {
-    return await fs.readFile(LEGACY_CREDENTIALS_FILE, 'utf-8');
+    return await fs.readFile(legacyCredentialsFile(), 'utf-8');
   } catch {
     return null;
   }
@@ -200,7 +265,7 @@ async function loadLegacyPlaintextSecret(): Promise<string | null> {
 
 async function removeLegacyPlaintextSecret(): Promise<void> {
   try {
-    await fs.rm(LEGACY_CREDENTIALS_FILE, { force: true });
+    await fs.rm(legacyCredentialsFile(), { force: true });
   } catch {
     // ignore cleanup failures
   }
@@ -214,41 +279,60 @@ function loadFromBackend(account: string, windowsFile: string): string | null {
 
 export async function loadCredentialBlob(
   profile: string = DEFAULT_PROFILE,
-): Promise<string | null> {
+): Promise<LoadCredentialBlobResult> {
   const { normalized, isDefault } = normalizeProfile(profile);
 
-  if (isDefault) {
-    // Chunk A reads only the legacy default location so there is no
-    // asymmetric dual-read vs. the legacy-only default write. Chunk C adds
-    // dual-read and dual-write with schema_version + last_write_epoch
-    // tiebreaks to handle mixed-version binaries.
-    const legacyBlob = loadFromBackend(LEGACY_KEYCHAIN_ACCOUNT, LEGACY_WINDOWS_CREDENTIALS_FILE);
-    if (legacyBlob) return legacyBlob;
-    return loadLegacyPlaintextSecret();
+  if (!isDefault) {
+    const blob = loadFromBackend(keychainAccount(normalized), windowsCredentialsFile(normalized));
+    return { blob, source: blob ? 'new' : null };
   }
 
-  return loadFromBackend(keychainAccount(normalized), windowsCredentialsFile(normalized));
+  const newBlob = loadFromBackend(keychainAccount(normalized), windowsCredentialsFile(normalized));
+  const legacyBlob = loadFromBackend(LEGACY_KEYCHAIN_ACCOUNT, legacyWindowsCredentialsFile());
+
+  if (newBlob && legacyBlob) {
+    const { blob, picked } = pickHigher(newBlob, legacyBlob);
+    return {
+      blob,
+      source: picked === 'new' ? 'both-new-preferred' : 'both-legacy-preferred',
+    };
+  }
+  if (newBlob) return { blob: newBlob, source: 'new' };
+  if (legacyBlob) return { blob: legacyBlob, source: 'legacy' };
+
+  const plaintext = await loadLegacyPlaintextSecret();
+  if (plaintext) return { blob: plaintext, source: 'legacy-plaintext' };
+  return { blob: null, source: null };
 }
 
-export async function saveCredentialBlob(
-  secret: string,
-  profile: string = DEFAULT_PROFILE,
-): Promise<void> {
-  const { normalized, isDefault } = normalizeProfile(profile);
-
-  // Default writes stay at the legacy account so existing single-profile
-  // installs are unaffected. Chunk C will switch to write-new + dual-write-legacy.
-  const account = isDefault ? LEGACY_KEYCHAIN_ACCOUNT : keychainAccount(normalized);
-  const windowsFile = isDefault
-    ? LEGACY_WINDOWS_CREDENTIALS_FILE
-    : windowsCredentialsFile(normalized);
-
+function writeToBackend(account: string, windowsFile: string, secret: string): void {
   if (process.platform === 'darwin') {
     saveMacSecret(account, secret);
   } else if (process.platform === 'win32') {
     saveWindowsSecret(windowsFile, secret);
   } else {
     saveLinuxSecret(account, secret);
+  }
+}
+
+export async function saveCredentialBlob(
+  secret: string,
+  profile: string = DEFAULT_PROFILE,
+  options: SaveCredentialOptions = {},
+): Promise<void> {
+  const { normalized, isDefault } = normalizeProfile(profile);
+
+  // Primary write: always the new per-profile slot (profile:<name> or
+  // credentials.<name>.dpapi). For default this is `profile:default` /
+  // `credentials.default.dpapi`.
+  writeToBackend(keychainAccount(normalized), windowsCredentialsFile(normalized), secret);
+
+  // Compatibility dual-write: for the default profile only, and only when the
+  // caller observed a legacy blob during load. This keeps an older 0.1 binary
+  // functional during the 0.2.x window without silently creating a legacy slot
+  // for users who never had one. REMOVE IN 0.3.0.
+  if (LEGACY_DUAL_WRITE && isDefault && options.alsoWriteLegacy) {
+    writeToBackend(LEGACY_KEYCHAIN_ACCOUNT, legacyWindowsCredentialsFile(), secret);
   }
 
   if (isDefault) {
@@ -295,7 +379,7 @@ export async function deleteCredentialBlob(profile: string = DEFAULT_PROFILE): P
   if (isDefault) {
     const legacyDeleted = await deleteAtAccount(
       LEGACY_KEYCHAIN_ACCOUNT,
-      LEGACY_WINDOWS_CREDENTIALS_FILE,
+      legacyWindowsCredentialsFile(),
     );
     const newDeleted = await deleteAtAccount(
       keychainAccount(normalized),

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -46,6 +46,11 @@ export type LoadSource =
 export interface LoadCredentialBlobResult {
   blob: string | null;
   source: LoadSource;
+  // The raw legacy-slot blob when it was observed (including when the new slot
+  // was preferred by pickHigher). Callers driving migration of index metadata
+  // should seed from this rather than `blob`, since the two copies may have
+  // drifted. null when no legacy slot existed on this load.
+  legacyBlob: string | null;
 }
 
 export interface SaveCredentialOptions {
@@ -284,7 +289,7 @@ export async function loadCredentialBlob(
 
   if (!isDefault) {
     const blob = loadFromBackend(keychainAccount(normalized), windowsCredentialsFile(normalized));
-    return { blob, source: blob ? 'new' : null };
+    return { blob, source: blob ? 'new' : null, legacyBlob: null };
   }
 
   const newBlob = loadFromBackend(keychainAccount(normalized), windowsCredentialsFile(normalized));
@@ -295,14 +300,15 @@ export async function loadCredentialBlob(
     return {
       blob,
       source: picked === 'new' ? 'both-new-preferred' : 'both-legacy-preferred',
+      legacyBlob,
     };
   }
-  if (newBlob) return { blob: newBlob, source: 'new' };
-  if (legacyBlob) return { blob: legacyBlob, source: 'legacy' };
+  if (newBlob) return { blob: newBlob, source: 'new', legacyBlob: null };
+  if (legacyBlob) return { blob: legacyBlob, source: 'legacy', legacyBlob };
 
   const plaintext = await loadLegacyPlaintextSecret();
-  if (plaintext) return { blob: plaintext, source: 'legacy-plaintext' };
-  return { blob: null, source: null };
+  if (plaintext) return { blob: plaintext, source: 'legacy-plaintext', legacyBlob: plaintext };
+  return { blob: null, source: null, legacyBlob: null };
 }
 
 function writeToBackend(account: string, windowsFile: string, secret: string): void {
@@ -330,9 +336,16 @@ export async function saveCredentialBlob(
   // Compatibility dual-write: for the default profile only, and only when the
   // caller observed a legacy blob during load. This keeps an older 0.1 binary
   // functional during the 0.2.x window without silently creating a legacy slot
-  // for users who never had one. REMOVE IN 0.3.0.
+  // for users who never had one. Best-effort — a failure here must not break
+  // the auth flow, since the authoritative new-slot write already succeeded.
+  // REMOVE IN 0.3.0.
   if (LEGACY_DUAL_WRITE && isDefault && options.alsoWriteLegacy) {
-    writeToBackend(LEGACY_KEYCHAIN_ACCOUNT, legacyWindowsCredentialsFile(), secret);
+    try {
+      writeToBackend(LEGACY_KEYCHAIN_ACCOUNT, legacyWindowsCredentialsFile(), secret);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Warning: could not mirror credentials to legacy slot: ${msg}`);
+    }
   }
 
   if (isDefault) {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,15 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { DEFAULT_PROFILE, validateProfileName } from './profile-name.js';
-
-function configDir(): string {
-  return path.join(
-    process.env.HOME || process.env.USERPROFILE || os.homedir() || '~',
-    '.fortnox-mcp',
-  );
-}
+import { configDir } from './config-paths.js';
 
 function profilesIndexFile(): string {
   return path.join(configDir(), 'profiles.json');
@@ -165,6 +158,44 @@ export function resolveProfile(inputs: ResolveInputs): ResolvedProfile {
     return { name: validateProfileName(inputs.pointer), source: 'pointer' };
   }
   return { name: DEFAULT_PROFILE, source: 'default' };
+}
+
+// Seeds the profile index with a `default` entry when a legacy (pre-0.2)
+// credential blob is observed for the default profile and no `default` entry
+// exists yet. Returns true when a new entry was written. Errors are swallowed
+// so a broken filesystem can't break the auth path — Chunk D's `doctor` will
+// surface the underlying issue.
+export async function migrateLegacyIfNeeded(legacyBlob: string | null): Promise<boolean> {
+  if (!legacyBlob) return false;
+  try {
+    const idx = await readProfileIndex();
+    if (idx.profiles.some((p) => p.name.toLowerCase() === DEFAULT_PROFILE)) {
+      return false;
+    }
+    let tenant_id: string | undefined;
+    let company_name: string | undefined;
+    try {
+      const parsed = JSON.parse(legacyBlob) as {
+        tenant_id?: unknown;
+        company_name?: unknown;
+      };
+      if (typeof parsed.tenant_id === 'string') tenant_id = parsed.tenant_id;
+      if (typeof parsed.company_name === 'string') company_name = parsed.company_name;
+    } catch {
+      // Unparseable blob — still seed a bare default entry so later mutations
+      // have something to attach to.
+    }
+    await upsertProfile({
+      name: DEFAULT_PROFILE,
+      tenant_id,
+      company_name,
+      created_at: new Date().toISOString(),
+      schema_version: 2,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export const paths = {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -41,8 +41,9 @@ function blobResult(
     | 'both-legacy-preferred'
     | 'legacy-plaintext'
     | null = blob ? 'new' : null,
+  legacyBlob: string | null = source === 'legacy' || source === 'legacy-plaintext' ? blob : null,
 ) {
-  return { blob, source };
+  return { blob, source, legacyBlob };
 }
 
 const mockCredentials: FortnoxCredentials = {
@@ -105,6 +106,18 @@ describe('auth', () => {
       credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(blob, 'legacy'));
       await loadCredentials();
       expect(profilesModule.migrateLegacyIfNeeded).toHaveBeenCalledWith(blob);
+    });
+
+    it('seeds migration from the legacy blob, not the selected new blob, on drift', async () => {
+      const newBlob = JSON.stringify({ ...mockCredentials, tenant_id: undefined });
+      const legacyBlob = JSON.stringify({ ...mockCredentials, tenant_id: '12345' });
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce({
+        blob: newBlob,
+        source: 'both-new-preferred',
+        legacyBlob,
+      });
+      await loadCredentials();
+      expect(profilesModule.migrateLegacyIfNeeded).toHaveBeenCalledWith(legacyBlob);
     });
 
     it('does not invoke migrateLegacyIfNeeded when only the new slot exists', async () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -7,6 +7,8 @@ const credentialStore = vi.hoisted(() => ({
 
 const profilesModule = vi.hoisted(() => ({
   upsertProfile: vi.fn(),
+  migrateLegacyIfNeeded: vi.fn(),
+  readProfileIndex: vi.fn(),
 }));
 
 vi.mock('../src/credentials-store.js', () => credentialStore);
@@ -26,8 +28,22 @@ import {
   setResolvedProfile,
   getResolvedProfile,
   CREDENTIAL_SCHEMA_VERSION,
+  __resetLegacyObservedForDefault,
   type FortnoxCredentials,
 } from '../src/auth.js';
+
+function blobResult(
+  blob: string | null,
+  source:
+    | 'new'
+    | 'legacy'
+    | 'both-new-preferred'
+    | 'both-legacy-preferred'
+    | 'legacy-plaintext'
+    | null = blob ? 'new' : null,
+) {
+  return { blob, source };
+}
 
 const mockCredentials: FortnoxCredentials = {
   client_id: 'test-client-id',
@@ -45,6 +61,9 @@ const mockCredentialsWithTenant: FortnoxCredentials = {
 describe('auth', () => {
   beforeEach(() => {
     setResolvedProfile('default');
+    __resetLegacyObservedForDefault();
+    profilesModule.readProfileIndex.mockResolvedValue({ schema_version: 1, profiles: [] });
+    profilesModule.migrateLegacyIfNeeded.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -52,28 +71,56 @@ describe('auth', () => {
     credentialStore.loadCredentialBlob.mockReset();
     credentialStore.saveCredentialBlob.mockReset();
     profilesModule.upsertProfile.mockReset();
+    profilesModule.migrateLegacyIfNeeded.mockReset();
+    profilesModule.readProfileIndex.mockReset();
     setResolvedProfile('default');
+    __resetLegacyObservedForDefault();
   });
 
   describe('loadCredentials', () => {
     it('returns null when no credentials are stored', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(null);
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
       const creds = await loadCredentials();
       expect(creds).toBeNull();
     });
 
     it('returns parsed credentials from secure storage', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       const creds = await loadCredentials();
       expect(creds).toEqual(mockCredentials);
     });
 
     it('returns credentials with tenant_id when present', async () => {
       credentialStore.loadCredentialBlob.mockResolvedValueOnce(
-        JSON.stringify(mockCredentialsWithTenant),
+        blobResult(JSON.stringify(mockCredentialsWithTenant)),
       );
       const creds = await loadCredentials();
       expect(creds?.tenant_id).toBe('12345');
+    });
+
+    it('invokes migrateLegacyIfNeeded when legacy slot is observed for default', async () => {
+      const blob = JSON.stringify(mockCredentials);
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(blob, 'legacy'));
+      await loadCredentials();
+      expect(profilesModule.migrateLegacyIfNeeded).toHaveBeenCalledWith(blob);
+    });
+
+    it('does not invoke migrateLegacyIfNeeded when only the new slot exists', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'new'),
+      );
+      await loadCredentials();
+      expect(profilesModule.migrateLegacyIfNeeded).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke migrateLegacyIfNeeded for non-default profiles', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'new'),
+      );
+      await loadCredentials('demo');
+      expect(profilesModule.migrateLegacyIfNeeded).not.toHaveBeenCalled();
     });
   });
 
@@ -105,6 +152,46 @@ describe('auth', () => {
       const [, profile] = credentialStore.saveCredentialBlob.mock.calls[0]!;
       expect(profile).toBe('work');
     });
+
+    it('does not set alsoWriteLegacy for fresh default-profile installs', async () => {
+      await saveCredentials(mockCredentials);
+      const [, , options] = credentialStore.saveCredentialBlob.mock.calls[0]!;
+      expect((options as { alsoWriteLegacy?: boolean } | undefined)?.alsoWriteLegacy).toBeFalsy();
+    });
+
+    it('sets alsoWriteLegacy=true for default after a legacy slot was observed', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'legacy'),
+      );
+      await loadCredentials();
+      await saveCredentials(mockCredentials);
+
+      const [, , options] = credentialStore.saveCredentialBlob.mock.calls[0]!;
+      expect((options as { alsoWriteLegacy?: boolean }).alsoWriteLegacy).toBe(true);
+    });
+
+    it('never sets alsoWriteLegacy for non-default profiles', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'legacy'),
+      );
+      await loadCredentials(); // observes legacy for default
+      await saveCredentials(mockCredentials, 'demo');
+
+      const [, profile, options] = credentialStore.saveCredentialBlob.mock.calls[0]!;
+      expect(profile).toBe('demo');
+      expect((options as { alsoWriteLegacy?: boolean }).alsoWriteLegacy).toBe(false);
+    });
+
+    it('sets alsoWriteLegacy after observing both-new-preferred', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'both-new-preferred'),
+      );
+      await loadCredentials();
+      await saveCredentials(mockCredentials);
+
+      const [, , options] = credentialStore.saveCredentialBlob.mock.calls[0]!;
+      expect((options as { alsoWriteLegacy?: boolean }).alsoWriteLegacy).toBe(true);
+    });
   });
 
   describe('profile resolution', () => {
@@ -125,14 +212,18 @@ describe('auth', () => {
 
   describe('loadCredentials with profile', () => {
     it('threads explicit profile through to the store', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       await loadCredentials('demo');
       expect(credentialStore.loadCredentialBlob).toHaveBeenCalledWith('demo');
     });
 
     it('falls back to the resolved profile when no argument is given', async () => {
       setResolvedProfile('work');
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       await loadCredentials();
       expect(credentialStore.loadCredentialBlob).toHaveBeenCalledWith('work');
     });
@@ -291,19 +382,23 @@ describe('auth', () => {
 
   describe('getValidToken', () => {
     it('throws when not authenticated', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(null);
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
       await expect(getValidToken()).rejects.toThrow('Not authenticated');
     });
 
     it('returns existing token when not expired', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       const token = await getValidToken();
       expect(token).toBe('test-access-token');
     });
 
     it('uses client credentials when tenant_id is available and token expired', async () => {
       const expiring = { ...mockCredentialsWithTenant, expires_at: Date.now() + 60 * 1000 };
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(expiring));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(expiring)),
+      );
 
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -320,7 +415,9 @@ describe('auth', () => {
 
     it('falls back to refresh token when client credentials fails', async () => {
       const expiring = { ...mockCredentialsWithTenant, expires_at: Date.now() + 60 * 1000 };
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(expiring));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(expiring)),
+      );
 
       global.fetch = vi
         .fn()
@@ -345,7 +442,9 @@ describe('auth', () => {
 
     it('refreshes token when about to expire (no tenant_id)', async () => {
       const expiringSoon = { ...mockCredentials, expires_at: Date.now() + 60 * 1000 };
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(expiringSoon));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(expiringSoon)),
+      );
 
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -362,14 +461,18 @@ describe('auth', () => {
     });
 
     it('reads credentials under the explicit profile', async () => {
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       await getValidToken('demo');
       expect(credentialStore.loadCredentialBlob).toHaveBeenCalledWith('demo');
     });
 
     it('reads credentials under the resolved profile when no arg', async () => {
       setResolvedProfile('work');
-      credentialStore.loadCredentialBlob.mockResolvedValueOnce(JSON.stringify(mockCredentials));
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
       await getValidToken();
       expect(credentialStore.loadCredentialBlob).toHaveBeenCalledWith('work');
     });

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -149,7 +149,7 @@ describe('loadCredentialBlob (darwin)', () => {
     setPlatform('darwin');
   });
 
-  it('default profile reads only the legacy `default` account (Chunk A)', async () => {
+  it('default profile reads both new and legacy keychain accounts', async () => {
     childProcess.execFileSync.mockReturnValue('');
     await loadCredentialBlob('default');
 
@@ -161,8 +161,7 @@ describe('loadCredentialBlob (darwin)', () => {
         return args[idx + 1];
       });
 
-    expect(accounts).toEqual(['default']);
-    expect(accounts).not.toContain('profile:default');
+    expect(accounts).toEqual(expect.arrayContaining(['default', 'profile:default']));
   });
 
   it('non-default profile reads only the profile:<name> account', async () => {
@@ -192,20 +191,20 @@ describe('loadCredentialBlob (darwin)', () => {
         return args[idx + 1];
       });
 
-    expect(accounts).toEqual(['default']);
+    expect(accounts).toEqual(expect.arrayContaining(['default', 'profile:default']));
   });
 
-  it('returns null when no credentials exist anywhere', async () => {
+  it('returns null with source=null when no credentials exist anywhere', async () => {
     childProcess.execFileSync.mockImplementation(() => {
       throw new Error('no keychain item');
     });
     fsPromises.default.readFile.mockRejectedValue(new Error('ENOENT'));
 
     const result = await loadCredentialBlob('default');
-    expect(result).toBeNull();
+    expect(result).toEqual({ blob: null, source: null });
   });
 
-  it('returns legacy blob when legacy keychain entry exists', async () => {
+  it('returns legacy blob with source=legacy when only legacy keychain entry exists', async () => {
     const legacyBlob = JSON.stringify({ client_id: 'legacy' });
     childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
       const idx = args.indexOf('-a');
@@ -215,7 +214,80 @@ describe('loadCredentialBlob (darwin)', () => {
     });
 
     const result = await loadCredentialBlob('default');
-    expect(result).toBe(legacyBlob);
+    expect(result).toEqual({ blob: legacyBlob, source: 'legacy' });
+  });
+
+  it('returns new blob with source=new when only new keychain entry exists', async () => {
+    const newBlob = JSON.stringify({ client_id: 'new' });
+    childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
+      const idx = args.indexOf('-a');
+      const account = args[idx + 1];
+      if (account === 'profile:default') return newBlob;
+      throw new Error('not found');
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result).toEqual({ blob: newBlob, source: 'new' });
+  });
+
+  it('prefers new blob when both exist with equal metadata', async () => {
+    const newBlob = JSON.stringify({ schema_version: 2, last_write_epoch: 1000, side: 'new' });
+    const legacyBlob = JSON.stringify({
+      schema_version: 2,
+      last_write_epoch: 1000,
+      side: 'legacy',
+    });
+    childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
+      const idx = args.indexOf('-a');
+      const account = args[idx + 1];
+      if (account === 'profile:default') return newBlob;
+      if (account === 'default') return legacyBlob;
+      throw new Error('not found');
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result.source).toBe('both-new-preferred');
+    expect(result.blob).toBe(newBlob);
+  });
+
+  it('prefers higher last_write_epoch when schema matches', async () => {
+    const newBlob = JSON.stringify({ schema_version: 2, last_write_epoch: 500, side: 'new' });
+    const legacyBlob = JSON.stringify({
+      schema_version: 2,
+      last_write_epoch: 999,
+      side: 'legacy',
+    });
+    childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
+      const idx = args.indexOf('-a');
+      const account = args[idx + 1];
+      if (account === 'profile:default') return newBlob;
+      if (account === 'default') return legacyBlob;
+      throw new Error('not found');
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result.source).toBe('both-legacy-preferred');
+    expect(result.blob).toBe(legacyBlob);
+  });
+
+  it('prefers higher schema_version even when epoch is older', async () => {
+    const newBlob = JSON.stringify({ schema_version: 3, last_write_epoch: 100, side: 'new' });
+    const legacyBlob = JSON.stringify({
+      schema_version: 2,
+      last_write_epoch: 999999,
+      side: 'legacy',
+    });
+    childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
+      const idx = args.indexOf('-a');
+      const account = args[idx + 1];
+      if (account === 'profile:default') return newBlob;
+      if (account === 'default') return legacyBlob;
+      throw new Error('not found');
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result.source).toBe('both-new-preferred');
+    expect(result.blob).toBe(newBlob);
   });
 
   it('falls back to legacy plaintext when no keychain entry exists', async () => {
@@ -225,7 +297,7 @@ describe('loadCredentialBlob (darwin)', () => {
     fsPromises.default.readFile.mockResolvedValue('{"client_id":"plaintext"}');
 
     const result = await loadCredentialBlob('default');
-    expect(result).toBe('{"client_id":"plaintext"}');
+    expect(result).toEqual({ blob: '{"client_id":"plaintext"}', source: 'legacy-plaintext' });
   });
 
   it('does not fall back to legacy plaintext for non-default profiles', async () => {
@@ -235,7 +307,7 @@ describe('loadCredentialBlob (darwin)', () => {
     fsPromises.default.readFile.mockResolvedValue('{"client_id":"plaintext"}');
 
     const result = await loadCredentialBlob('demo');
-    expect(result).toBeNull();
+    expect(result).toEqual({ blob: null, source: null });
   });
 });
 
@@ -246,39 +318,44 @@ describe('saveCredentialBlob (darwin)', () => {
     childProcess.spawnSync.mockReturnValue({ status: 0, stderr: '', stdout: '' });
   });
 
-  it('default profile writes to legacy account for backwards compatibility', async () => {
-    await saveCredentialBlob('{"x":1}', 'default');
+  function writtenAccounts(): string[] {
+    return fsSync.default.writeFileSync.mock.calls
+      .map((call) => call[1] as string)
+      .flatMap((body) => {
+        const match = /let account = "([^"]+)"/.exec(body);
+        return match ? [match[1]!] : [];
+      });
+  }
 
-    // Swift script body embeds the account name; inspect the written file.
-    const writeCall = fsSync.default.writeFileSync.mock.calls[0];
-    expect(writeCall).toBeDefined();
-    const scriptBody = writeCall[1] as string;
-    expect(scriptBody).toContain('let account = "default"');
-    expect(scriptBody).not.toContain('let account = "profile:default"');
+  it('default profile writes only to the new profile:default account by default', async () => {
+    await saveCredentialBlob('{"x":1}', 'default');
+    expect(writtenAccounts()).toEqual(['profile:default']);
+  });
+
+  it('default profile dual-writes to legacy when alsoWriteLegacy is set', async () => {
+    await saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true });
+    expect(writtenAccounts()).toEqual(expect.arrayContaining(['profile:default', 'default']));
+    expect(writtenAccounts()).toHaveLength(2);
+  });
+
+  it('non-default profile ignores alsoWriteLegacy', async () => {
+    await saveCredentialBlob('{"x":1}', 'demo', { alsoWriteLegacy: true });
+    expect(writtenAccounts()).toEqual(['profile:demo']);
   });
 
   it('non-default profile writes to profile:<name> account', async () => {
     await saveCredentialBlob('{"x":1}', 'demo');
-
-    const scriptBody = fsSync.default.writeFileSync.mock.calls[0][1] as string;
-    expect(scriptBody).toContain('let account = "profile:demo"');
+    expect(writtenAccounts()).toEqual(['profile:demo']);
   });
 
   it('sanitizes mixed-case profile names to lowercase in the keychain account', async () => {
     await saveCredentialBlob('{"x":1}', 'Demo');
-
-    // Account name is case-preserving in the profile index but lowercased for
-    // filesystem/keychain-account keys.
-    const scriptBody = fsSync.default.writeFileSync.mock.calls[0][1] as string;
-    expect(scriptBody).toContain('let account = "profile:demo"');
+    expect(writtenAccounts()).toEqual(['profile:demo']);
   });
 
-  it('treats mixed-case "Default" as the default profile (case-insensitive)', async () => {
-    await saveCredentialBlob('{"x":1}', 'Default');
-
-    const scriptBody = fsSync.default.writeFileSync.mock.calls[0][1] as string;
-    expect(scriptBody).toContain('let account = "default"');
-    expect(scriptBody).not.toContain('let account = "profile:default"');
+  it('treats mixed-case Default as the default profile (case-insensitive)', async () => {
+    await saveCredentialBlob('{"x":1}', 'Default', { alsoWriteLegacy: true });
+    expect(writtenAccounts()).toEqual(expect.arrayContaining(['profile:default', 'default']));
   });
 
   it('rejects invalid profile names', async () => {
@@ -363,17 +440,35 @@ describe('Linux secret-tool backend', () => {
     expect(args[accountIdx + 1]).toBe('profile:demo');
   });
 
-  it('writes to account=default for the default profile', async () => {
+  it('writes to account=profile:default for the default profile by default', async () => {
     childProcess.execFileSync.mockReturnValue('');
     await saveCredentialBlob('{"x":1}', 'default');
 
-    const storeCall = childProcess.execFileSync.mock.calls.find(
+    const storeCalls = childProcess.execFileSync.mock.calls.filter(
       ([cmd, args]) => cmd === 'secret-tool' && (args as string[]).includes('store'),
     );
-    expect(storeCall).toBeDefined();
-    const args = storeCall![1] as string[];
-    const accountIdx = args.indexOf('account');
-    expect(args[accountIdx + 1]).toBe('default');
+    const accounts = storeCalls.map((call) => {
+      const args = call[1] as string[];
+      const idx = args.indexOf('account');
+      return args[idx + 1];
+    });
+    expect(accounts).toEqual(['profile:default']);
+  });
+
+  it('dual-writes to legacy account=default when alsoWriteLegacy is set', async () => {
+    childProcess.execFileSync.mockReturnValue('');
+    await saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true });
+
+    const storeCalls = childProcess.execFileSync.mock.calls.filter(
+      ([cmd, args]) => cmd === 'secret-tool' && (args as string[]).includes('store'),
+    );
+    const accounts = storeCalls.map((call) => {
+      const args = call[1] as string[];
+      const idx = args.indexOf('account');
+      return args[idx + 1];
+    });
+    expect(accounts).toEqual(expect.arrayContaining(['profile:default', 'default']));
+    expect(accounts).toHaveLength(2);
   });
 });
 
@@ -393,7 +488,7 @@ describe('Windows DPAPI backend', () => {
     expect(script).not.toContain('credentials.dpapi');
   });
 
-  it('reads only legacy credentials.dpapi for default profile (Chunk A)', async () => {
+  it('reads both new credentials.default.dpapi and legacy credentials.dpapi for default profile', async () => {
     childProcess.execFileSync.mockReturnValue('');
     await loadCredentialBlob('default');
 
@@ -402,7 +497,7 @@ describe('Windows DPAPI backend', () => {
       .map((call) => (call[1] as string[]).join(' '));
 
     expect(commands.some((s) => /credentials\.dpapi(?![.a-z])/.test(s))).toBe(true);
-    expect(commands.some((s) => s.includes('credentials.default.dpapi'))).toBe(false);
+    expect(commands.some((s) => s.includes('credentials.default.dpapi'))).toBe(true);
   });
 
   it('lowercases mixed-case names in the filename', async () => {

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -201,7 +201,7 @@ describe('loadCredentialBlob (darwin)', () => {
     fsPromises.default.readFile.mockRejectedValue(new Error('ENOENT'));
 
     const result = await loadCredentialBlob('default');
-    expect(result).toEqual({ blob: null, source: null });
+    expect(result).toEqual({ blob: null, source: null, legacyBlob: null });
   });
 
   it('returns legacy blob with source=legacy when only legacy keychain entry exists', async () => {
@@ -214,10 +214,10 @@ describe('loadCredentialBlob (darwin)', () => {
     });
 
     const result = await loadCredentialBlob('default');
-    expect(result).toEqual({ blob: legacyBlob, source: 'legacy' });
+    expect(result).toEqual({ blob: legacyBlob, source: 'legacy', legacyBlob });
   });
 
-  it('returns new blob with source=new when only new keychain entry exists', async () => {
+  it('returns new blob with source=new and legacyBlob=null when only new keychain entry exists', async () => {
     const newBlob = JSON.stringify({ client_id: 'new' });
     childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
       const idx = args.indexOf('-a');
@@ -227,7 +227,28 @@ describe('loadCredentialBlob (darwin)', () => {
     });
 
     const result = await loadCredentialBlob('default');
-    expect(result).toEqual({ blob: newBlob, source: 'new' });
+    expect(result).toEqual({ blob: newBlob, source: 'new', legacyBlob: null });
+  });
+
+  it('exposes legacyBlob alongside the preferred new blob when both exist', async () => {
+    const newBlob = JSON.stringify({ schema_version: 3, last_write_epoch: 100, side: 'new' });
+    const legacyBlob = JSON.stringify({
+      schema_version: 2,
+      last_write_epoch: 999,
+      side: 'legacy',
+      tenant_id: 'only-in-legacy',
+    });
+    childProcess.execFileSync.mockImplementation((_cmd: string, args: readonly string[]) => {
+      const idx = args.indexOf('-a');
+      const account = args[idx + 1];
+      if (account === 'profile:default') return newBlob;
+      if (account === 'default') return legacyBlob;
+      throw new Error('not found');
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result.blob).toBe(newBlob);
+    expect(result.legacyBlob).toBe(legacyBlob);
   });
 
   it('prefers new blob when both exist with equal metadata', async () => {
@@ -297,7 +318,11 @@ describe('loadCredentialBlob (darwin)', () => {
     fsPromises.default.readFile.mockResolvedValue('{"client_id":"plaintext"}');
 
     const result = await loadCredentialBlob('default');
-    expect(result).toEqual({ blob: '{"client_id":"plaintext"}', source: 'legacy-plaintext' });
+    expect(result).toEqual({
+      blob: '{"client_id":"plaintext"}',
+      source: 'legacy-plaintext',
+      legacyBlob: '{"client_id":"plaintext"}',
+    });
   });
 
   it('does not fall back to legacy plaintext for non-default profiles', async () => {
@@ -307,7 +332,7 @@ describe('loadCredentialBlob (darwin)', () => {
     fsPromises.default.readFile.mockResolvedValue('{"client_id":"plaintext"}');
 
     const result = await loadCredentialBlob('demo');
-    expect(result).toEqual({ blob: null, source: null });
+    expect(result).toEqual({ blob: null, source: null, legacyBlob: null });
   });
 });
 
@@ -336,6 +361,31 @@ describe('saveCredentialBlob (darwin)', () => {
     await saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true });
     expect(writtenAccounts()).toEqual(expect.arrayContaining(['profile:default', 'default']));
     expect(writtenAccounts()).toHaveLength(2);
+  });
+
+  it('swallows a legacy-slot write failure when primary write succeeded', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Primary (profile:default) write succeeds via the Swift helper; legacy
+    // (account=default) write fails at the security CLI fallback.
+    childProcess.spawnSync.mockImplementationOnce(() => ({
+      status: 0,
+      stderr: '',
+      stdout: '',
+    }));
+    childProcess.spawnSync.mockImplementationOnce(() => ({
+      status: 1,
+      stderr: 'legacy keychain unavailable',
+      stdout: '',
+    }));
+    childProcess.execFileSync.mockImplementation(() => {
+      throw new Error('security CLI also unavailable');
+    });
+
+    await expect(
+      saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true }),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/legacy slot/i));
+    warnSpy.mockRestore();
   });
 
   it('non-default profile ignores alsoWriteLegacy', async () => {

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -12,6 +12,7 @@ import {
   writeActivePointer,
   deleteActivePointer,
   resolveProfile,
+  migrateLegacyIfNeeded,
   paths,
 } from '../src/profiles.js';
 
@@ -216,5 +217,61 @@ describe('active pointer I/O', () => {
     const spy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(permErr);
     await expect(readActivePointer()).rejects.toMatchObject({ code: 'EACCES' });
     spy.mockRestore();
+  });
+});
+
+describe('migrateLegacyIfNeeded', () => {
+  it('returns false and writes nothing when legacyBlob is null', async () => {
+    await expect(migrateLegacyIfNeeded(null)).resolves.toBe(false);
+    const idx = await readProfileIndex();
+    expect(idx.profiles).toEqual([]);
+  });
+
+  it('seeds a default entry from a valid legacy blob', async () => {
+    const blob = JSON.stringify({
+      client_id: 'cid',
+      tenant_id: '54321',
+      company_name: 'Acme AB',
+    });
+    await expect(migrateLegacyIfNeeded(blob)).resolves.toBe(true);
+    const idx = await readProfileIndex();
+    expect(idx.profiles).toHaveLength(1);
+    expect(idx.profiles[0]!.name).toBe('default');
+    expect(idx.profiles[0]!.tenant_id).toBe('54321');
+    expect(idx.profiles[0]!.company_name).toBe('Acme AB');
+  });
+
+  it('is idempotent — second call is a no-op when default already exists', async () => {
+    const blob = JSON.stringify({ tenant_id: '1' });
+    await migrateLegacyIfNeeded(blob);
+    const originalCreatedAt = (await readProfileIndex()).profiles[0]!.created_at;
+    await new Promise((r) => setTimeout(r, 5));
+    await expect(migrateLegacyIfNeeded(blob)).resolves.toBe(false);
+    const idx = await readProfileIndex();
+    expect(idx.profiles).toHaveLength(1);
+    expect(idx.profiles[0]!.created_at).toBe(originalCreatedAt);
+  });
+
+  it('seeds a bare default entry when the blob is unparseable', async () => {
+    await expect(migrateLegacyIfNeeded('{not json')).resolves.toBe(true);
+    const idx = await readProfileIndex();
+    expect(idx.profiles).toHaveLength(1);
+    expect(idx.profiles[0]!.name).toBe('default');
+    expect(idx.profiles[0]!.tenant_id).toBeUndefined();
+  });
+
+  it('does not overwrite an existing default entry', async () => {
+    await upsertProfile({
+      name: 'default',
+      tenant_id: 'existing',
+      company_name: 'Existing AB',
+      created_at: '2025-01-01T00:00:00.000Z',
+      schema_version: 2,
+    });
+    const blob = JSON.stringify({ tenant_id: 'legacy', company_name: 'Legacy AB' });
+    await expect(migrateLegacyIfNeeded(blob)).resolves.toBe(false);
+    const idx = await readProfileIndex();
+    expect(idx.profiles).toHaveLength(1);
+    expect(idx.profiles[0]!.tenant_id).toBe('existing');
   });
 });


### PR DESCRIPTION
## Summary

Chunk C of the multi-profile v1 plan (issue #16). Migrates pre-0.2 installs onto the per-profile credential layout while keeping older 0.1 binaries working during the 0.2.x compatibility window.

- `loadCredentialBlob` now returns `{ blob, source }` and dual-reads the default profile, picking the higher of new vs. legacy by `schema_version` then `last_write_epoch`.
- `saveCredentialBlob` accepts `{ alsoWriteLegacy }`; when set AND default AND `LEGACY_DUAL_WRITE` is on, writes to both the new `profile:default` slot and the legacy `default` slot.
- `migrateLegacyIfNeeded` seeds a `default` entry in the profile index the first time a legacy blob is observed (idempotent, best-effort).
- `loadCredentials` tracks `legacyObservedForDefault` per process and passes `alsoWriteLegacy` through on save.
- `runOAuthSetup` now preserves the original `created_at` when re-authing an existing profile (Codex #18 finding #3).
- Shared `src/config-paths.ts` fixes HOME resolution divergence between `profiles.ts` and `credentials-store.ts` (Codex #18 finding #2).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 411 unit tests pass (new coverage for dual-read tiebreaks, dual-write gating, migrate invocation, `created_at` preservation)
- [ ] Manual: `noxctl` still reads creds from the legacy slot on a pre-0.2 install; writing once populates the new slot and keeps the legacy slot in sync.
- [ ] Manual: fresh install writes only `profile:default` — no legacy slot created.

Follows #17 (Chunk A) and #18 (Chunk B). Chunk D (CLI surface) + E (MCP startup) come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)