### PR TITLE
feat: CLI multi-profile surface (Chunk D)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -406,28 +406,23 @@ export async function runOAuthSetup(
             company_name: companyName,
           };
 
+          // Preserve the original created_at when re-authenticating an existing
+          // profile so the index timestamp reflects first auth, not the most
+          // recent one. Upsert BEFORE saveCredentials so a filesystem failure
+          // here can't leave a credential blob without a matching index entry —
+          // `logout --all` enumerates via the index, so a silent orphan would
+          // mean creds in the keychain that bulk-logout can't see.
+          const existing = (await readProfileIndex()).profiles.find(
+            (p) => p.name.toLowerCase() === validatedProfile.toLowerCase(),
+          );
+          await upsertProfile({
+            name: validatedProfile,
+            tenant_id: tenantId,
+            company_name: companyName,
+            created_at: existing?.created_at ?? new Date().toISOString(),
+            schema_version: 2,
+          });
           await saveCredentials(creds, validatedProfile);
-          try {
-            // Preserve the original created_at when re-authenticating an
-            // existing profile so the index timestamp reflects first auth,
-            // not the most recent one.
-            const existing = (await readProfileIndex()).profiles.find(
-              (p) => p.name.toLowerCase() === validatedProfile.toLowerCase(),
-            );
-            await upsertProfile({
-              name: validatedProfile,
-              tenant_id: tenantId,
-              company_name: companyName,
-              created_at: existing?.created_at ?? new Date().toISOString(),
-              schema_version: 2,
-            });
-          } catch (indexErr) {
-            // Credentials already saved — treat index write as best-effort so a
-            // filesystem hiccup under ~/.fortnox-mcp doesn't abort `noxctl init`.
-            // Chunk D's `doctor` / `profile use` will surface a broken index.
-            const msg = indexErr instanceof Error ? indexErr.message : String(indexErr);
-            console.warn(`Warning: could not update profile index: ${msg}`);
-          }
 
           const tenantMsg = tenantId
             ? ' Client credentials flow enabled.'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,16 @@ import {
   formatFinancialReport,
 } from './formatter.js';
 import {
+  readActivePointer,
+  writeActivePointer,
+  deleteActivePointer,
+  readProfileIndex,
+  resolveProfile,
+  type ResolvedProfile,
+} from './profiles.js';
+import { setResolvedProfile } from './auth.js';
+import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
+import {
   invoiceListColumns,
   invoiceDetailColumns,
   invoiceConfirmColumns,
@@ -59,10 +69,67 @@ program
     new Option('-o, --output <format>', 'Output format')
       .choices(['json', 'table'])
       .default(undefined),
+  )
+  .option(
+    '--profile <name>',
+    'Profile to operate on (overrides NOXCTL_PROFILE and active pointer)',
   );
 
 function json(): boolean {
   return isJsonMode(program.opts());
+}
+
+let resolvedProfileInfo: ResolvedProfile = { name: DEFAULT_PROFILE, source: 'default' };
+
+export function getResolvedProfileInfo(): ResolvedProfile {
+  return resolvedProfileInfo;
+}
+
+// Commands that don't need (and shouldn't require) a resolved profile.
+const PROFILE_RESOLUTION_SKIP = new Set(['help']);
+
+program.hook('preAction', async (thisCommand, actionCommand) => {
+  const name = actionCommand.name();
+  if (PROFILE_RESOLUTION_SKIP.has(name)) return;
+
+  const flag = (program.opts().profile as string | undefined) ?? undefined;
+  const env = process.env['NOXCTL_PROFILE'] ?? undefined;
+  let pointer: string | null = null;
+  try {
+    pointer = await readActivePointer();
+  } catch {
+    pointer = null;
+  }
+
+  try {
+    resolvedProfileInfo = resolveProfile({ flag, env, pointer });
+  } catch (err) {
+    if (err instanceof InvalidProfileNameError) {
+      console.error(err.message);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  setResolvedProfile(resolvedProfileInfo.name);
+
+  if (
+    resolvedProfileInfo.name.toLowerCase() !== DEFAULT_PROFILE &&
+    process.stderr.isTTY &&
+    name !== 'current'
+  ) {
+    process.stderr.write(`[profile: ${resolvedProfileInfo.name}]\n`);
+  }
+});
+
+async function fetchCompanyHint(): Promise<string | undefined> {
+  try {
+    const { loadCredentials } = await import('./auth.js');
+    const creds = await loadCredentials();
+    return creds?.company_name;
+  } catch {
+    return undefined;
+  }
 }
 
 async function confirmMutation(
@@ -85,13 +152,16 @@ async function confirmMutation(
     throw new Error(`Confirmation required to ${action}. Re-run with --yes, or --dry-run first.`);
   }
 
+  const company = await fetchCompanyHint();
+  const suffix = company ? ` (${company})` : '';
+
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   try {
-    const answer = await rl.question(`${action}. Continue? [y/N] `);
+    const answer = await rl.question(`${action}. Continue?${suffix} [y/N] `);
     return ['y', 'yes'].includes(answer.trim().toLowerCase());
   } finally {
     rl.close();
@@ -102,11 +172,24 @@ async function confirmMutation(
 program
   .command('init')
   .description('Interactive setup wizard — recommended onboarding path')
-  .action(async () => {
+  .option(
+    '--profile <name>',
+    'Profile to create/re-auth (defaults to resolved profile or "default")',
+  )
+  .action(async (initOpts: { profile?: string }) => {
     const { loadCredentials, runOAuthSetup } = await import('./auth.js');
+    const { validateProfileName } = await import('./profile-name.js');
+
+    let targetProfile: string;
+    try {
+      targetProfile = validateProfileName(initOpts.profile ?? resolvedProfileInfo.name);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(2);
+    }
 
     // Step 1: Check if already configured
-    const existing = await loadCredentials();
+    const existing = await loadCredentials(targetProfile);
     if (existing) {
       console.log('Existing credentials found.');
 
@@ -253,7 +336,20 @@ program
     }
 
     // Step 6: Run OAuth flow
-    await runOAuthSetup({ clientId, clientSecret, serviceAccount });
+    await runOAuthSetup({ clientId, clientSecret, serviceAccount }, targetProfile);
+
+    // Step 6b: Set the active pointer if this is the first profile or no pointer exists.
+    try {
+      const idx = await readProfileIndex();
+      const existingPointer = await readActivePointer();
+      const firstProfile = idx.profiles.length <= 1;
+      if (firstProfile || !existingPointer) {
+        await writeActivePointer(targetProfile);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Warning: could not update active profile pointer: ${msg}`);
+    }
 
     // Step 7: Verify by fetching company info
     try {
@@ -346,28 +442,146 @@ program
 // --- logout ---
 program
   .command('logout')
-  .description('Remove stored Fortnox credentials')
+  .description('Remove stored Fortnox credentials for the resolved profile')
   .option('-y, --yes', 'Skip confirmation prompt')
-  .action(async (opts: { yes?: boolean }) => {
-    const { loadCredentials } = await import('./auth.js');
+  .option('--all', 'Remove credentials for every profile (and the legacy slot)')
+  .action(async (opts: { yes?: boolean; all?: boolean; dryRun?: boolean }) => {
     const { deleteCredentialBlob } = await import('./credentials-store.js');
+    const { removeProfile } = await import('./profiles.js');
 
-    const existing = await loadCredentials();
+    if (opts.all) {
+      if (!(await confirmMutation('Remove stored Fortnox credentials for ALL profiles', opts))) {
+        return;
+      }
+
+      const idx = await readProfileIndex();
+      const names = new Set<string>(idx.profiles.map((p) => p.name));
+      names.add(DEFAULT_PROFILE);
+
+      let removedAny = false;
+      for (const name of names) {
+        const deleted = await deleteCredentialBlob(name);
+        if (deleted) removedAny = true;
+        try {
+          await removeProfile(name);
+        } catch {
+          // best-effort — index cleanup must not abort logout
+        }
+      }
+      try {
+        await deleteActivePointer();
+      } catch {
+        // ignore
+      }
+
+      if (removedAny) {
+        console.log('Removed credentials for all profiles.');
+      } else {
+        console.log('No credentials found to remove.');
+      }
+      return;
+    }
+
+    const target = resolvedProfileInfo.name;
+    const { loadCredentials } = await import('./auth.js');
+
+    const existing = await loadCredentials(target);
     if (!existing) {
-      console.log('No credentials found. Nothing to remove.');
+      console.log(`No credentials found for profile "${target}". Nothing to remove.`);
       return;
     }
 
-    if (!(await confirmMutation('Remove stored Fortnox credentials', opts))) {
+    if (!(await confirmMutation(`Remove stored credentials for profile "${target}"`, opts))) {
       return;
     }
 
-    const deleted = await deleteCredentialBlob();
+    const deleted = await deleteCredentialBlob(target);
+
+    try {
+      await removeProfile(target);
+    } catch {
+      // best-effort
+    }
+
+    try {
+      const pointer = await readActivePointer();
+      if (pointer && pointer.toLowerCase() === target.toLowerCase()) {
+        await deleteActivePointer();
+      }
+    } catch {
+      // ignore
+    }
+
     if (deleted) {
-      console.log('Credentials removed.');
+      console.log(`Credentials for profile "${target}" removed.`);
     } else {
       console.log('Could not remove credentials from the system keychain.');
       console.log('They may have already been removed, or you may need to remove them manually.');
+    }
+  });
+
+// --- profile ---
+const profile = program.command('profile').description('Manage noxctl profiles');
+
+profile
+  .command('use <name>')
+  .description('Set the active profile (writes ~/.fortnox-mcp/active-profile)')
+  .action(async (name: string) => {
+    const { validateProfileName } = await import('./profile-name.js');
+    let validated: string;
+    try {
+      validated = validateProfileName(name);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(2);
+    }
+
+    const { loadCredentials } = await import('./auth.js');
+    const creds = await loadCredentials(validated);
+    if (!creds) {
+      console.error(
+        `No credentials found for profile "${validated}". Run \`noxctl init --profile ${validated}\` first.`,
+      );
+      process.exit(1);
+    }
+
+    await writeActivePointer(validated);
+    if (json()) {
+      console.log(JSON.stringify({ name: validated, source: 'pointer' }));
+    } else {
+      console.log(`Active profile set to "${validated}".`);
+    }
+  });
+
+profile
+  .command('current')
+  .description('Show the currently resolved profile and where it came from')
+  .action(() => {
+    if (json()) {
+      console.log(JSON.stringify(resolvedProfileInfo));
+    } else {
+      console.log(`${resolvedProfileInfo.name} (source: ${resolvedProfileInfo.source})`);
+    }
+  });
+
+profile
+  .command('list')
+  .description('List known profiles from the index')
+  .action(async () => {
+    const idx = await readProfileIndex();
+    if (json()) {
+      console.log(JSON.stringify(idx.profiles, null, 2));
+      return;
+    }
+    if (idx.profiles.length === 0) {
+      console.log('No profiles registered. Run `noxctl init` to create one.');
+      return;
+    }
+    for (const p of idx.profiles) {
+      const marker = p.name.toLowerCase() === resolvedProfileInfo.name.toLowerCase() ? '*' : ' ';
+      const company = p.company_name ? ` — ${p.company_name}` : '';
+      const tenant = p.tenant_id ? ` [tenant ${p.tenant_id}]` : '';
+      console.log(`${marker} ${p.name}${company}${tenant}`);
     }
   });
 
@@ -407,14 +621,58 @@ program
           : 'Linux Secret Service';
     pass('Credential store', storeBackend);
 
+    // 2b. Profile resolution
+    pass('Profile', `${resolvedProfileInfo.name} (source: ${resolvedProfileInfo.source})`);
+
+    // 2c. Active pointer health — surface a corrupt pointer file even though
+    // readActivePointer() degrades silently.
+    try {
+      const { paths } = await import('./profiles.js');
+      const fsp = await import('node:fs/promises');
+      const raw = await fsp.readFile(paths.activePointerFile, 'utf-8').catch(() => null);
+      if (raw !== null) {
+        const trimmed = raw.trim();
+        if (trimmed.length > 0) {
+          const { validateProfileName } = await import('./profile-name.js');
+          try {
+            validateProfileName(trimmed);
+            const idx = await readProfileIndex();
+            const known = idx.profiles.some((p) => p.name.toLowerCase() === trimmed.toLowerCase());
+            if (known) {
+              pass('Active pointer', trimmed);
+            } else {
+              fail(
+                'Active pointer',
+                `points to unknown profile "${trimmed}" — run \`noxctl profile use <name>\` to fix`,
+              );
+            }
+          } catch {
+            fail('Active pointer', 'contains an invalid name — delete to reset');
+          }
+        }
+      }
+    } catch {
+      // best-effort diagnostic — don't block doctor on filesystem issues
+    }
+
     // 3. Credentials exist
     const creds = await loadCredentials();
     if (!creds) {
-      fail('Credentials', 'not found — run `noxctl init` to set up');
+      fail(
+        'Credentials',
+        `not found for profile "${resolvedProfileInfo.name}" — run \`noxctl init${
+          resolvedProfileInfo.name === DEFAULT_PROFILE
+            ? ''
+            : ` --profile ${resolvedProfileInfo.name}`
+        }\` to set up`,
+      );
       console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
       return;
     }
     pass('Credentials', 'found');
+    if (creds.company_name) {
+      pass('Company (cached)', creds.company_name);
+    }
 
     // 4. Client ID present
     if (creds.client_id) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,6 +188,15 @@ program
       process.exit(2);
     }
 
+    // If `init --profile <name>` names a different profile than the preAction
+    // hook resolved, rebind the in-process resolved profile so downstream work
+    // (verification via getCompanyInfo, runOAuthSetup's internal saveCredentials
+    // call chain) targets the profile being initialized — not a stale pointer.
+    if (targetProfile.toLowerCase() !== resolvedProfileInfo.name.toLowerCase()) {
+      setResolvedProfile(targetProfile);
+      resolvedProfileInfo = { name: targetProfile, source: 'flag' };
+    }
+
     // Step 1: Check if already configured
     const existing = await loadCredentials(targetProfile);
     if (existing) {

--- a/tests/cli-profile.test.ts
+++ b/tests/cli-profile.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const CLI_PATH = path.resolve('dist/cli.js');
+
+let tmpHome: string;
+let cfgDir: string;
+let activePointerFile: string;
+let profilesIndexFile: string;
+
+function run(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): { stdout: string; stderr: string; status: number } {
+  const mergedEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: tmpHome,
+    USERPROFILE: tmpHome,
+    ...env,
+  };
+  if (!('NOXCTL_PROFILE' in env)) delete mergedEnv.NOXCTL_PROFILE;
+
+  const opts: ExecFileSyncOptions = {
+    encoding: 'utf-8',
+    timeout: 10000,
+    env: mergedEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], opts) as string;
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as {
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+      status?: number;
+    };
+    return {
+      stdout: (e.stdout?.toString() ?? '') as string,
+      stderr: (e.stderr?.toString() ?? '') as string,
+      status: e.status ?? 1,
+    };
+  }
+}
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'noxctl-cli-profile-'));
+  cfgDir = path.join(tmpHome, '.fortnox-mcp');
+  activePointerFile = path.join(cfgDir, 'active-profile');
+  profilesIndexFile = path.join(cfgDir, 'profiles.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+// Note: stdout is piped in these tests, so isJsonMode defaults to JSON.
+// The human-readable format is exercised via `--output table`.
+
+describe('profile current', () => {
+  it('prints default/default when nothing is set', () => {
+    const res = run(['profile', 'current']);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'default', source: 'default' });
+  });
+
+  it('reports flag source when --profile is passed', () => {
+    const res = run(['--profile', 'work', 'profile', 'current']);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'work', source: 'flag' });
+  });
+
+  it('reports env source when NOXCTL_PROFILE is set', () => {
+    const res = run(['profile', 'current'], { NOXCTL_PROFILE: 'work' });
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'work', source: 'env' });
+  });
+
+  it('reports pointer source when active-profile file exists', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(activePointerFile, 'work\n');
+    const res = run(['profile', 'current']);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'work', source: 'pointer' });
+  });
+
+  it('prefers flag over env and pointer', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(activePointerFile, 'point\n');
+    const res = run(['--profile', 'flagwin', 'profile', 'current'], {
+      NOXCTL_PROFILE: 'envlose',
+    });
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'flagwin', source: 'flag' });
+  });
+
+  it('prefers env over pointer when no flag is set', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(activePointerFile, 'point\n');
+    const res = run(['profile', 'current'], { NOXCTL_PROFILE: 'envwin' });
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'envwin', source: 'env' });
+  });
+
+  it('emits human-readable output when --output table is passed', () => {
+    const res = run(['--output', 'table', '--profile', 'work', 'profile', 'current']);
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe('work (source: flag)');
+  });
+
+  it('falls back to default when active-profile contains an invalid name', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(activePointerFile, 'has space\n');
+    const res = run(['profile', 'current']);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual({ name: 'default', source: 'default' });
+  });
+
+  it('exits non-zero when --profile value is invalid', () => {
+    const res = run(['--profile', 'bad name!', 'profile', 'current']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain('invalid profile name');
+  });
+});
+
+describe('profile list', () => {
+  it('emits an empty JSON array when no profiles registered (pipe mode)', () => {
+    const res = run(['profile', 'list']);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.trim())).toEqual([]);
+  });
+
+  it('shows a friendly message with --output table when no profiles', () => {
+    const res = run(['--output', 'table', 'profile', 'list']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('No profiles registered');
+  });
+
+  it('emits JSON with all profile metadata (pipe mode)', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(
+      profilesIndexFile,
+      JSON.stringify({
+        schema_version: 1,
+        profiles: [
+          {
+            name: 'default',
+            company_name: 'Acme AB',
+            tenant_id: '12345',
+            created_at: '2026-01-01T00:00:00.000Z',
+            schema_version: 2,
+          },
+          { name: 'work', created_at: '2026-01-02T00:00:00.000Z', schema_version: 2 },
+        ],
+      }),
+    );
+    const res = run(['profile', 'list']);
+    expect(res.status).toBe(0);
+    const parsed = JSON.parse(res.stdout) as Array<{ name: string; company_name?: string }>;
+    expect(parsed.map((p) => p.name)).toEqual(['default', 'work']);
+    expect(parsed[0]!.company_name).toBe('Acme AB');
+  });
+
+  it('renders a human-readable listing with --output table', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(
+      profilesIndexFile,
+      JSON.stringify({
+        schema_version: 1,
+        profiles: [
+          {
+            name: 'default',
+            company_name: 'Acme AB',
+            tenant_id: '12345',
+            created_at: '2026-01-01T00:00:00.000Z',
+            schema_version: 2,
+          },
+        ],
+      }),
+    );
+    const res = run(['--output', 'table', 'profile', 'list']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('Acme AB');
+    expect(res.stdout).toContain('tenant 12345');
+  });
+});
+
+describe('profile use', () => {
+  it('refuses to switch to a profile without credentials', () => {
+    const res = run(['profile', 'use', 'work']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('No credentials found for profile "work"');
+  });
+
+  it('rejects an invalid profile name', () => {
+    const res = run(['profile', 'use', 'bad name!']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain('invalid profile name');
+  });
+});
+
+describe('stderr profile indicator', () => {
+  it('is absent in non-TTY output (test runs without a TTY)', () => {
+    const res = run(['--profile', 'work', 'profile', 'current']);
+    expect(res.stderr).not.toContain('[profile:');
+  });
+});

--- a/tests/cli-profile.test.ts
+++ b/tests/cli-profile.test.ts
@@ -208,3 +208,35 @@ describe('stderr profile indicator', () => {
     expect(res.stderr).not.toContain('[profile:');
   });
 });
+
+describe('logout --all', () => {
+  it('reports nothing to remove when no profiles are registered', () => {
+    const res = run(['logout', '--all', '--yes']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('No credentials found');
+  });
+
+  it('clears the index and active pointer even when credentials are absent', async () => {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(
+      profilesIndexFile,
+      JSON.stringify({
+        schema_version: 1,
+        profiles: [
+          { name: 'default', created_at: '2026-01-01T00:00:00.000Z', schema_version: 2 },
+          { name: 'work', created_at: '2026-01-02T00:00:00.000Z', schema_version: 2 },
+        ],
+      }),
+    );
+    await fs.writeFile(activePointerFile, 'work\n');
+
+    const res = run(['logout', '--all', '--yes']);
+    expect(res.status).toBe(0);
+
+    const idxAfter = JSON.parse(await fs.readFile(profilesIndexFile, 'utf-8')) as {
+      profiles: unknown[];
+    };
+    expect(idxAfter.profiles).toEqual([]);
+    await expect(fs.access(activePointerFile)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -84,15 +84,38 @@ describe('CLI smoke tests', () => {
     expect(output).toContain('Check setup');
   });
 
-  it('noxctl logout --help shows --yes option', () => {
+  it('noxctl logout --help shows --yes and --all options', () => {
     const output = execFileSync('node', [CLI_PATH, 'logout', '--help'], execOpts) as string;
     expect(output).toContain('--yes');
+    expect(output).toContain('--all');
     expect(output).toContain('Remove stored');
   });
 
-  it('noxctl init --help exits 0', () => {
+  it('noxctl init --help shows --profile option', () => {
     const output = execFileSync('node', [CLI_PATH, 'init', '--help'], execOpts) as string;
     expect(output).toContain('Interactive setup');
+    expect(output).toContain('--profile');
+  });
+
+  it('noxctl --help mentions --profile global option', () => {
+    const output = execFileSync('node', [CLI_PATH, '--help'], execOpts) as string;
+    expect(output).toContain('--profile');
+  });
+
+  it('noxctl profile --help shows subcommands', () => {
+    const output = execFileSync('node', [CLI_PATH, 'profile', '--help'], execOpts) as string;
+    expect(output).toContain('use');
+    expect(output).toContain('current');
+    expect(output).toContain('list');
+  });
+
+  it('noxctl profile current --help exits 0', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'profile', 'current', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('resolved profile');
   });
 
   it('noxctl supplier-invoices --help shows subcommands', () => {


### PR DESCRIPTION
## Summary
- Adds the user-visible multi-profile surface: `--profile <name>` global flag, `NOXCTL_PROFILE` env, active-pointer resolution via `resolveProfile()` in a Commander `preAction` hook.
- New `profile` command group: `use <name>`, `current`, `list`.
- `init --profile <name>` sets the active pointer when first profile or no pointer exists.
- `logout` now per-profile; `logout --all` iterates the index and clears the legacy slot + pointer.
- `doctor` surfaces resolved profile + source + cached company name, and flags a corrupt or unknown active-pointer (Codex PR #18 finding #1).
- `confirmMutation` lazily loads credentials and appends cached `company_name` to the prompt so mutations show which tenant you're hitting.
- Stderr-only TTY-only `[profile: <name>]` indicator when non-default.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 433/433 passing (new `tests/cli-profile.test.ts` covers precedence, invalid names, JSON vs table, `profile use` rejection, stderr indicator; extended `tests/cli.test.ts` smoke tests)
- [x] Manual smoke: `profile current` respects flag > env > pointer, falls back to default on corrupt pointer
- [ ] Codex cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)