### PR TITLE
feat: MCP server startup profile binding (Chunk E)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,31 +1,25 @@
 # Project Status
 
 **Last session:** 2026-04-20
-**Branch:** main
+**Branch:** chunk-e-mcp-profile-binding
 
 ## Completed This Session
 
-- **Chunk C PR #20 merged** (f981eaf) — credential migration + dual-read/write
-  - Codex review on PR #20; medium (legacy-write fatal) + low (migrate from raw legacyBlob) fixed before merge
-- **Chunk D implemented on branch `chunk-d-cli-surface`** (not yet pushed/PR'd)
-  - `--profile <name>` global flag + Commander `preAction` hook resolving flag/env/pointer via `resolveProfile`
-  - `setResolvedProfile()` called so every downstream op picks up the resolution
-  - Stderr TTY-only `[profile: <name>]` indicator when non-default
-  - New `profile` command group: `use <name>`, `current`, `list`
-  - `init --profile <name>` — sets active pointer when first profile OR no pointer exists
-  - `logout` now per-profile; `logout --all` iterates index + deletes legacy slot + pointer
-  - `doctor` shows resolved profile + source, company cached, and surfaces corrupt/unknown active-pointer (Codex #18 finding #1)
-  - `confirmMutation` appends cached `company_name` to the prompt via lazy credential load
-  - Tests: extended `tests/cli.test.ts` smoke tests; new `tests/cli-profile.test.ts` covers precedence, `profile use` rejection, JSON vs table output
+- **Chunk E implemented on branch `chunk-e-mcp-profile-binding`** (not yet pushed/PR'd)
+  - `src/index.ts` — new `resolveStartupProfile()` and `bindStartupProfile()` (env `NOXCTL_PROFILE` + active pointer, no flag); `startMcpServer(options?)` accepts `{ profile? }`, binds via `setResolvedProfile`, emits `[profile: <name>]` stderr banner for non-default profile
+  - `src/cli.ts` — `serve` action forwards `resolvedProfileInfo.name` to `startMcpServer`, preserving `--profile` flag through the CLI→MCP boundary
+  - `src/fortnox-client.ts` — `FortnoxApiError` message prefixed with `[profile: <name>]` when non-default (single chokepoint surfaces profile in every tool error)
+  - `src/auth.ts` — `getValidToken` "Not authenticated" error includes profile name and suggests `noxctl init --profile <name>` when non-default
+  - Tests: new `tests/mcp-profile.test.ts` (resolveStartupProfile + bindStartupProfile precedence, banner, invalid-name fallback); extended `tests/fortnox-client.test.ts` (profile tag on error, default omits prefix); extended `tests/auth.test.ts` (tagged not-authenticated error)
 
 ## Verified Locally
 
 - `npm run build` clean
 - `npm run lint` clean
-- `npm test` — 433/433 passing
+- `npm test` — 448/448 passing (+13 new)
 
 ## Next Steps (priority order)
 
-1. **Chunk E** — MCP server startup profile binding (`src/index.ts`): read resolved profile at startup, expose in `startMcpServer()`, surface profile context in tool errors
+1. **Push branch + open PR** for Chunk E; request Codex review
 2. **Docs** — README profile section, MIGRATION.md (0.1→0.2 upgrade path), CHANGELOG entry
 3. **0.2.0 release** — bump `package.json`, `src/cli.ts` version string, `src/index.ts` server version, publish

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,25 +1,36 @@
 # Project Status
 
 **Last session:** 2026-04-20
-**Branch:** chunk-e-mcp-profile-binding
+**Branch:** chunk-e-mcp-profile-binding (PR #22 open)
 
 ## Completed This Session
 
-- **Chunk E implemented on branch `chunk-e-mcp-profile-binding`** (not yet pushed/PR'd)
-  - `src/index.ts` — new `resolveStartupProfile()` and `bindStartupProfile()` (env `NOXCTL_PROFILE` + active pointer, no flag); `startMcpServer(options?)` accepts `{ profile? }`, binds via `setResolvedProfile`, emits `[profile: <name>]` stderr banner for non-default profile
-  - `src/cli.ts` — `serve` action forwards `resolvedProfileInfo.name` to `startMcpServer`, preserving `--profile` flag through the CLI→MCP boundary
-  - `src/fortnox-client.ts` — `FortnoxApiError` message prefixed with `[profile: <name>]` when non-default (single chokepoint surfaces profile in every tool error)
-  - `src/auth.ts` — `getValidToken` "Not authenticated" error includes profile name and suggests `noxctl init --profile <name>` when non-default
-  - Tests: new `tests/mcp-profile.test.ts` (resolveStartupProfile + bindStartupProfile precedence, banner, invalid-name fallback); extended `tests/fortnox-client.test.ts` (profile tag on error, default omits prefix); extended `tests/auth.test.ts` (tagged not-authenticated error)
+- **Chunk E implemented, reviewed, and post-critique fixes applied**
+  - Initial implementation:
+    - `src/index.ts` — `resolveStartupProfile()` / `bindStartupProfile()` / `startMcpServer({ profile? })`; stderr banner for non-default
+    - `src/cli.ts` — `serve` action forwards `resolvedProfileInfo.name` to `startMcpServer`
+    - `src/fortnox-client.ts` — `FortnoxApiError` prefixed with `[profile: <name>]`
+    - `src/auth.ts` — `getValidToken` "Not authenticated" tagged with profile
+  - Post-critique fixes (addressing all 8 Codex debate action items):
+    - `src/profiles.ts` — typed `PointerOutcome` union + `readActivePointerOutcome()` with `AbortController`-based timeout (actually cancels the I/O)
+    - `src/index.ts` — `StartupProfileError` (codes: `invalid-pointer-content | pointer-read-error | pointer-timeout | invalid-env`); `resolveStartupProfile` fails closed on pointer faults unless env overrides; env invalid also fails closed
+    - `src/cli.ts` — preAction fails closed **only** when `name === 'serve'` AND no flag/env; `doctor` / `profile use` can still repair corrupt state; banner dedupe via `name === 'serve'` check (MCP owns the banner on `serve`)
+    - `src/auth.ts` — broadened profile-tagging to `refreshAccessToken` + `getTokenViaClientCredentials` (not just `FortnoxApiError`)
+    - `tests/mcp-integration-profile.test.ts` — in-process `Client` ↔ `Server` via `InMemoryTransport` asserts `[profile: staging]` surfaces in tool error; mirror test for default; CLI→MCP handoff seam test (sabotaged pointer + explicit profile option → must not read pointer)
+    - `tests/mcp-profile.test.ts` — replaced fail-open expectations with `StartupProfileError` assertions; added env-overrides-corrupt-pointer-with-warning test
+    - `tests/auth.test.ts` — tagging tests for refresh + client-credentials paths
+- **Adversarial review (Codex, gpt-5.4 xhigh, 2 rounds)**
+  - 5 Round-1 findings, 15 total critique points logged in `debate/mcp-profile-binding-critique-log.json`
+  - All actionable items implemented; "chokepoint" framing narrowed per Round 2 guidance
 
 ## Verified Locally
 
 - `npm run build` clean
 - `npm run lint` clean
-- `npm test` — 448/448 passing (+13 new)
+- `npm test` — **456/456 passing** (+21 net new vs main)
 
 ## Next Steps (priority order)
 
-1. **Push branch + open PR** for Chunk E; request Codex review
+1. **Push post-critique fixes to PR #22** and update PR description to narrow chokepoint framing
 2. **Docs** — README profile section, MIGRATION.md (0.1→0.2 upgrade path), CHANGELOG entry
 3. **0.2.0 release** — bump `package.json`, `src/cli.ts` version string, `src/index.ts` server version, publish

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -229,7 +229,11 @@ export async function getValidToken(profile?: string): Promise<string> {
   const target = profileOrResolved(profile);
   const creds = await loadCredentials(target);
   if (!creds) {
-    throw new Error('Not authenticated. Run `noxctl init` to connect your Fortnox account.');
+    const initCmd = isDefaultProfile(target)
+      ? '`noxctl init`'
+      : `\`noxctl init --profile ${target}\``;
+    const prefix = isDefaultProfile(target) ? '' : `[profile: ${target}] `;
+    throw new Error(`${prefix}Not authenticated. Run ${initCmd} to connect your Fortnox account.`);
   }
 
   // Token still valid — use it

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,6 +32,11 @@ export interface FortnoxAppConfig {
   serviceAccount?: boolean;
 }
 
+// Module-global resolved profile. This assumes a single-tenant process model
+// (one CLI invocation or one MCP stdio connection per Node process). Hosting
+// multiple Fortnox MCP servers in the same process is not supported — every
+// instance would share this state. Revisit if the MCP SDK grows request-local
+// context that handlers can read.
 let resolvedProfile: string = DEFAULT_PROFILE;
 
 // Whether the legacy (pre-0.2) credential slot was observed on the most recent
@@ -58,6 +63,10 @@ function profileOrResolved(profile?: string): string {
 
 function isDefaultProfile(name: string): boolean {
   return name.toLowerCase() === DEFAULT_PROFILE;
+}
+
+function profileTag(name: string): string {
+  return isDefaultProfile(name) ? '' : `[profile: ${name}] `;
 }
 
 function legacySlotExists(source: LoadSource): boolean {
@@ -144,8 +153,9 @@ export async function getTokenViaClientCredentials(
   creds: FortnoxCredentials,
   profile?: string,
 ): Promise<FortnoxCredentials> {
+  const tag = profileTag(profileOrResolved(profile));
   if (!creds.tenant_id) {
-    throw new Error('No tenant_id available — cannot use client credentials flow');
+    throw new Error(`${tag}No tenant_id available — cannot use client credentials flow`);
   }
 
   const body = new URLSearchParams({
@@ -166,7 +176,7 @@ export async function getTokenViaClientCredentials(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Client credentials token request failed (${response.status}): ${text}`);
+    throw new Error(`${tag}Client credentials token request failed (${response.status}): ${text}`);
   }
 
   const data = (await response.json()) as {
@@ -188,6 +198,7 @@ export async function refreshAccessToken(
   creds: FortnoxCredentials,
   profile?: string,
 ): Promise<FortnoxCredentials> {
+  const tag = profileTag(profileOrResolved(profile));
   const body = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: creds.refresh_token,
@@ -205,7 +216,7 @@ export async function refreshAccessToken(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Token refresh failed (${response.status}): ${text}`);
+    throw new Error(`${tag}Token refresh failed (${response.status}): ${text}`);
   }
 
   const data = (await response.json()) as {
@@ -232,8 +243,9 @@ export async function getValidToken(profile?: string): Promise<string> {
     const initCmd = isDefaultProfile(target)
       ? '`noxctl init`'
       : `\`noxctl init --profile ${target}\``;
-    const prefix = isDefaultProfile(target) ? '' : `[profile: ${target}] `;
-    throw new Error(`${prefix}Not authenticated. Run ${initCmd} to connect your Fortnox account.`);
+    throw new Error(
+      `${profileTag(target)}Not authenticated. Run ${initCmd} to connect your Fortnox account.`,
+    );
   }
 
   // Token still valid — use it

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -770,7 +770,7 @@ program
   .description('Start the MCP server (stdio transport)')
   .action(async () => {
     const { startMcpServer } = await import('./index.js');
-    await startMcpServer();
+    await startMcpServer({ profile: resolvedProfileInfo.name });
   });
 
 // --- invoices ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
 } from './formatter.js';
 import {
   readActivePointer,
+  readActivePointerOutcome,
   writeActivePointer,
   deleteActivePointer,
   readProfileIndex,
@@ -94,11 +95,28 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
 
   const flag = (program.opts().profile as string | undefined) ?? undefined;
   const env = process.env['NOXCTL_PROFILE'] ?? undefined;
+
+  // Typed pointer resolution so we can distinguish "no pointer" (silent
+  // default) from "pointer unreadable/corrupt" (must surface). 2s bound
+  // catches wedged filesystems; the AbortSignal cancels the underlying read.
+  const outcome = await readActivePointerOutcome({ timeoutMs: 2000 });
   let pointer: string | null = null;
-  try {
-    pointer = await readActivePointer();
-  } catch {
-    pointer = null;
+
+  if (outcome.kind === 'valid') {
+    pointer = outcome.name;
+  } else if (outcome.kind !== 'missing') {
+    const desc = describePointerFault(outcome);
+    // Only fail closed when the pointer is the winning source (no flag/env)
+    // AND we're about to start the MCP server. For any other command, warn
+    // loudly but continue so `doctor` / `profile use` can repair the state.
+    const wouldRelyOnPointer = !flag && !env;
+    if (wouldRelyOnPointer && name === 'serve') {
+      console.error(
+        `Active profile pointer ${desc}. Refusing to start MCP server with ambiguous profile. Run \`noxctl doctor\` or set NOXCTL_PROFILE explicitly.`,
+      );
+      process.exit(2);
+    }
+    process.stderr.write(`[warning: active-profile pointer ${desc}; ignoring]\n`);
   }
 
   try {
@@ -113,14 +131,34 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
 
   setResolvedProfile(resolvedProfileInfo.name);
 
+  // Banner ownership: MCP `serve` prints its own banner in bindStartupProfile
+  // so host logs (Claude Desktop) always see it. Suppress here to avoid a
+  // duplicate on TTY invocations like `noxctl --profile X serve`.
   if (
     resolvedProfileInfo.name.toLowerCase() !== DEFAULT_PROFILE &&
     process.stderr.isTTY &&
-    name !== 'current'
+    name !== 'current' &&
+    name !== 'serve'
   ) {
     process.stderr.write(`[profile: ${resolvedProfileInfo.name}]\n`);
   }
 });
+
+function describePointerFault(
+  outcome:
+    | { kind: 'invalid-content'; raw: string }
+    | { kind: 'read-error'; error: Error }
+    | { kind: 'timeout' },
+): string {
+  switch (outcome.kind) {
+    case 'invalid-content':
+      return `contains an invalid profile name: "${outcome.raw}"`;
+    case 'read-error':
+      return `could not be read (${outcome.error.message})`;
+    case 'timeout':
+      return 'read timed out';
+  }
+}
 
 async function fetchCompanyHint(): Promise<string | undefined> {
   try {

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -1,4 +1,5 @@
-import { getValidToken } from './auth.js';
+import { getResolvedProfile, getValidToken } from './auth.js';
+import { DEFAULT_PROFILE } from './profile-name.js';
 
 const BASE_URL = 'https://api.fortnox.se/3';
 
@@ -39,7 +40,9 @@ export class FortnoxApiError extends Error {
     endpoint?: string,
   ) {
     const hint = getErrorHint(statusCode, fortnoxMessage, endpoint);
-    const parts = [`Fortnox API error (${statusCode}): ${fortnoxMessage}`];
+    const profile = getResolvedProfile();
+    const profileTag = profile.toLowerCase() !== DEFAULT_PROFILE ? `[profile: ${profile}] ` : '';
+    const parts = [`${profileTag}Fortnox API error (${statusCode}): ${fortnoxMessage}`];
     if (hint) parts.push(`Hint: ${hint}`);
     super(parts.join('\n'));
     this.name = 'FortnoxApiError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { setResolvedProfile } from './auth.js';
+import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
+import { readActivePointer, resolveProfile } from './profiles.js';
 import { registerCustomerTools } from './tools/customers.js';
 import { registerInvoiceTools } from './tools/invoices.js';
 import { registerBookkeepingTools } from './tools/bookkeeping.js';
@@ -47,7 +50,51 @@ export function createServer(): McpServer {
   return server;
 }
 
-export async function startMcpServer(): Promise<void> {
+export interface StartMcpServerOptions {
+  /**
+   * When provided, binds the MCP session to this profile directly (skipping
+   * env/pointer resolution). The CLI `serve` action passes the profile it
+   * already resolved via its preAction hook so a `--profile` flag isn't lost.
+   */
+  profile?: string;
+}
+
+// Resolves the startup profile from env + active pointer when no explicit
+// profile is supplied. Mirrors the CLI preAction precedence minus the flag
+// (there's no Commander context at direct-run entry). An invalid name is
+// logged and falls back to the default rather than crashing the server.
+export async function resolveStartupProfile(): Promise<string> {
+  const env = process.env['NOXCTL_PROFILE'] ?? undefined;
+  let pointer: string | null = null;
+  try {
+    pointer = await readActivePointer();
+  } catch {
+    pointer = null;
+  }
+  try {
+    return resolveProfile({ env, pointer }).name;
+  } catch (err) {
+    if (err instanceof InvalidProfileNameError) {
+      process.stderr.write(`${err.message}\n`);
+      return DEFAULT_PROFILE;
+    }
+    throw err;
+  }
+}
+
+// Extracted from startMcpServer so tests can exercise profile binding without
+// spinning up the stdio transport (which blocks on stdin).
+export async function bindStartupProfile(options: StartMcpServerOptions = {}): Promise<string> {
+  const profile = options.profile ?? (await resolveStartupProfile());
+  setResolvedProfile(profile);
+  if (profile.toLowerCase() !== DEFAULT_PROFILE) {
+    process.stderr.write(`[profile: ${profile}]\n`);
+  }
+  return profile;
+}
+
+export async function startMcpServer(options: StartMcpServerOptions = {}): Promise<void> {
+  await bindStartupProfile(options);
   const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { setResolvedProfile } from './auth.js';
 import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
-import { readActivePointer, resolveProfile } from './profiles.js';
+import { readActivePointerOutcome, resolveProfile } from './profiles.js';
 import { registerCustomerTools } from './tools/customers.js';
 import { registerInvoiceTools } from './tools/invoices.js';
 import { registerBookkeepingTools } from './tools/bookkeeping.js';
@@ -59,24 +59,60 @@ export interface StartMcpServerOptions {
   profile?: string;
 }
 
-// Resolves the startup profile from env + active pointer when no explicit
-// profile is supplied. Mirrors the CLI preAction precedence minus the flag
-// (there's no Commander context at direct-run entry). An invalid name is
-// logged and falls back to the default rather than crashing the server.
+// Thrown by resolveStartupProfile when the profile cannot be resolved
+// unambiguously (corrupt/unreadable pointer with no env override, or an
+// invalid env var). startMcpServer translates this into a stderr-logged
+// non-zero exit so tests can observe it without terminating the test runner.
+export class StartupProfileError extends Error {
+  constructor(
+    public readonly code:
+      | 'invalid-pointer-content'
+      | 'pointer-read-error'
+      | 'pointer-timeout'
+      | 'invalid-env',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'StartupProfileError';
+  }
+}
+
+// Resolves the startup profile from env + active pointer. Mirrors the CLI
+// preAction precedence minus the flag (no Commander context at direct-run
+// entry). Pointer faults fail closed when no env override is present —
+// silently binding to `default` could route requests to the wrong tenant.
 export async function resolveStartupProfile(): Promise<string> {
   const env = process.env['NOXCTL_PROFILE'] ?? undefined;
-  let pointer: string | null = null;
-  try {
-    pointer = await readActivePointer();
-  } catch {
-    pointer = null;
+  const outcome = await readActivePointerOutcome({ timeoutMs: 2000 });
+
+  if (outcome.kind !== 'valid' && outcome.kind !== 'missing') {
+    const desc =
+      outcome.kind === 'invalid-content'
+        ? `contains an invalid profile name: "${outcome.raw}"`
+        : outcome.kind === 'read-error'
+          ? `could not be read (${outcome.error.message})`
+          : 'read timed out';
+    if (!env) {
+      throw new StartupProfileError(
+        outcome.kind === 'invalid-content'
+          ? 'invalid-pointer-content'
+          : outcome.kind === 'read-error'
+            ? 'pointer-read-error'
+            : 'pointer-timeout',
+        `Active profile pointer ${desc}. Refusing to start MCP server with ambiguous profile. Run \`noxctl doctor\` or set NOXCTL_PROFILE explicitly.`,
+      );
+    }
+    process.stderr.write(
+      `[warning: active-profile pointer ${desc}; using NOXCTL_PROFILE instead]\n`,
+    );
   }
+
+  const pointer = outcome.kind === 'valid' ? outcome.name : null;
   try {
     return resolveProfile({ env, pointer }).name;
   } catch (err) {
     if (err instanceof InvalidProfileNameError) {
-      process.stderr.write(`${err.message}\n`);
-      return DEFAULT_PROFILE;
+      throw new StartupProfileError('invalid-env', err.message);
     }
     throw err;
   }
@@ -94,7 +130,15 @@ export async function bindStartupProfile(options: StartMcpServerOptions = {}): P
 }
 
 export async function startMcpServer(options: StartMcpServerOptions = {}): Promise<void> {
-  await bindStartupProfile(options);
+  try {
+    await bindStartupProfile(options);
+  } catch (err) {
+    if (err instanceof StartupProfileError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
   const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -109,22 +109,69 @@ export async function removeProfile(name: string): Promise<void> {
   }
 }
 
-export async function readActivePointer(): Promise<string | null> {
+export type PointerOutcome =
+  | { kind: 'missing' }
+  | { kind: 'valid'; name: string }
+  | { kind: 'invalid-content'; raw: string }
+  | { kind: 'read-error'; error: Error }
+  | { kind: 'timeout' };
+
+export interface ReadActivePointerOptions {
+  // Bounded wait on the underlying fs.readFile. An AbortSignal cancels the
+  // OS-level read so a wedged filesystem (NFS, FUSE) does not leak a pending
+  // handle past the timeout — crucial because the MCP direct-run path runs
+  // this before connecting stdio.
+  timeoutMs?: number;
+}
+
+export async function readActivePointerOutcome(
+  options: ReadActivePointerOptions = {},
+): Promise<PointerOutcome> {
+  const controller = new AbortController();
+  let timer: NodeJS.Timeout | undefined;
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  }
   let raw: string;
   try {
-    raw = await fs.readFile(activePointerFile(), 'utf-8');
+    raw = await fs.readFile(activePointerFile(), {
+      encoding: 'utf-8',
+      signal: controller.signal,
+    });
   } catch (err) {
-    if (isMissingFileError(err)) return null;
-    throw err;
+    const e = err as NodeJS.ErrnoException;
+    if (isMissingFileError(err)) return { kind: 'missing' };
+    if (e.name === 'AbortError' || e.code === 'ABORT_ERR') return { kind: 'timeout' };
+    return { kind: 'read-error', error: err instanceof Error ? err : new Error(String(err)) };
+  } finally {
+    if (timer) clearTimeout(timer);
   }
   const trimmed = raw.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return { kind: 'missing' };
   try {
-    return validateProfileName(trimmed);
+    return { kind: 'valid', name: validateProfileName(trimmed) };
   } catch {
-    // Corrupt pointer contents — treat as absent so later resolution can
-    // fall through to the env var or default. Chunk D's `doctor` surfaces this.
-    return null;
+    return { kind: 'invalid-content', raw: trimmed };
+  }
+}
+
+export async function readActivePointer(): Promise<string | null> {
+  const outcome = await readActivePointerOutcome();
+  switch (outcome.kind) {
+    case 'valid':
+      return outcome.name;
+    case 'missing':
+    case 'invalid-content':
+      // Corrupt content is degraded to absent so callers that use this
+      // loose API (init, logout, doctor) continue to function. Strict
+      // callers should use readActivePointerOutcome directly.
+      return null;
+    case 'read-error':
+      throw outcome.error;
+    case 'timeout':
+      // The loose API has no timeout, so this branch is only reachable from
+      // callers who passed options — none today. Rethrow defensively.
+      throw Object.assign(new Error('Active pointer read timed out'), { code: 'ETIMEDOUT' });
   }
 }
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -325,6 +325,24 @@ describe('auth', () => {
         'Client credentials token request failed (403)',
       );
     });
+
+    it('tags the failed-request error with profile when non-default', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      });
+
+      await expect(
+        getTokenViaClientCredentials(mockCredentialsWithTenant, 'staging'),
+      ).rejects.toThrow(/\[profile: staging\].*Client credentials token request failed/);
+    });
+
+    it('tags the no-tenant_id error with profile when non-default', async () => {
+      await expect(getTokenViaClientCredentials(mockCredentials, 'staging')).rejects.toThrow(
+        /\[profile: staging\].*No tenant_id available/,
+      );
+    });
   });
 
   describe('refreshAccessToken', () => {
@@ -355,6 +373,33 @@ describe('auth', () => {
       await expect(refreshAccessToken(mockCredentials)).rejects.toThrow(
         'Token refresh failed (401)',
       );
+    });
+
+    it('tags the failed-refresh error with profile when non-default', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      });
+
+      await expect(refreshAccessToken(mockCredentials, 'staging')).rejects.toThrow(
+        /\[profile: staging\].*Token refresh failed/,
+      );
+    });
+
+    it('omits the profile tag for the default profile', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      });
+
+      try {
+        await refreshAccessToken(mockCredentials);
+        expect.unreachable();
+      } catch (err) {
+        expect((err as Error).message).not.toContain('[profile:');
+      }
     });
   });
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -399,6 +399,25 @@ describe('auth', () => {
       await expect(getValidToken()).rejects.toThrow('Not authenticated');
     });
 
+    it('tags the not-authenticated error with profile when non-default', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+      await expect(getValidToken('staging')).rejects.toThrow(
+        /\[profile: staging\].*noxctl init --profile staging/,
+      );
+    });
+
+    it('omits the profile tag for the default profile', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+      try {
+        await getValidToken();
+        expect.unreachable();
+      } catch (err) {
+        const message = (err as Error).message;
+        expect(message).not.toContain('[profile:');
+        expect(message).toContain('noxctl init');
+      }
+    });
+
     it('returns existing token when not expired', async () => {
       credentialStore.loadCredentialBlob.mockResolvedValueOnce(
         blobResult(JSON.stringify(mockCredentials)),

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { fortnoxRequest, FortnoxApiError } from '../src/fortnox-client.js';
+import { getResolvedProfile } from '../src/auth.js';
 
 vi.mock('../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
 }));
 
 describe('fortnox-client', () => {
@@ -200,6 +202,46 @@ describe('fortnox-client', () => {
       } catch (err) {
         const e = err as FortnoxApiError;
         expect(e.hint).toContain('server error');
+      }
+    });
+  });
+
+  describe('profile tagging', () => {
+    afterEach(() => {
+      vi.mocked(getResolvedProfile).mockReturnValue('default');
+    });
+
+    it('prefixes the error message with [profile: <name>] when non-default', async () => {
+      vi.mocked(getResolvedProfile).mockReturnValue('staging');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+      });
+
+      try {
+        await fortnoxRequest('customers');
+        expect.unreachable();
+      } catch (err) {
+        const e = err as FortnoxApiError;
+        expect(e.message.startsWith('[profile: staging]')).toBe(true);
+      }
+    });
+
+    it('omits the profile prefix for the default profile', async () => {
+      vi.mocked(getResolvedProfile).mockReturnValue('default');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+      });
+
+      try {
+        await fortnoxRequest('customers');
+        expect.unreachable();
+      } catch (err) {
+        const e = err as FortnoxApiError;
+        expect(e.message).not.toContain('[profile:');
       }
     });
   });

--- a/tests/mcp-integration-profile.test.ts
+++ b/tests/mcp-integration-profile.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+// End-to-end integration: bind a non-default profile via the same helpers
+// the MCP stdio startup path uses, connect a real MCP Client/Server pair
+// through InMemoryTransport, and verify that a tool-level failure (here:
+// unauthenticated — no credentials in tmp HOME) surfaces the profile tag
+// through the SDK's error-response path.
+
+describe('MCP profile tag reaches tool responses', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
+  let origProfileEnv: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'noxctl-mcp-integration-'));
+    origHome = process.env['HOME'];
+    origUserProfile = process.env['USERPROFILE'];
+    origProfileEnv = process.env['NOXCTL_PROFILE'];
+    process.env['HOME'] = tmpHome;
+    process.env['USERPROFILE'] = tmpHome;
+    delete process.env['NOXCTL_PROFILE'];
+
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = origHome;
+    if (origUserProfile === undefined) delete process.env['USERPROFILE'];
+    else process.env['USERPROFILE'] = origUserProfile;
+    if (origProfileEnv === undefined) delete process.env['NOXCTL_PROFILE'];
+    else process.env['NOXCTL_PROFILE'] = origProfileEnv;
+
+    await fs.rm(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces [profile: staging] in tool error via FortnoxApiError', async () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    // Mock the entire credential-load path so we do not hit the user's real
+    // macOS keychain (which is user-scoped, not $HOME-scoped) and end up
+    // making real network calls. getValidToken returns a fake token, then
+    // the mocked fetch forces a 500 so fortnoxRequest constructs a
+    // FortnoxApiError — the main chokepoint we want to cover.
+    vi.doMock('../src/auth.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/auth.js')>('../src/auth.js');
+      return {
+        ...actual,
+        getValidToken: vi.fn().mockResolvedValue('fake-token'),
+      };
+    });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+      text: () => Promise.resolve(''),
+    });
+
+    const { bindStartupProfile, createServer } = await import('../src/index.js');
+
+    await bindStartupProfile({ profile: 'staging' });
+
+    const server = createServer();
+    const client = new Client({ name: 'integration-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const result = await client.callTool({
+      name: 'fortnox_list_customers',
+      arguments: {},
+    });
+
+    const content = result.content as { type: string; text: string }[] | undefined;
+    const text = content?.[0]?.text ?? '';
+    const combined = `${text} ${JSON.stringify(result)}`;
+    expect(combined).toContain('[profile: staging]');
+  });
+
+  it('omits the profile tag for the default profile', async () => {
+    vi.doMock('../src/auth.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/auth.js')>('../src/auth.js');
+      return {
+        ...actual,
+        getValidToken: vi.fn().mockResolvedValue('fake-token'),
+      };
+    });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+      text: () => Promise.resolve(''),
+    });
+
+    const { bindStartupProfile, createServer } = await import('../src/index.js');
+
+    await bindStartupProfile({ profile: 'default' });
+
+    const server = createServer();
+    const client = new Client({ name: 'integration-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const result = await client.callTool({
+      name: 'fortnox_list_customers',
+      arguments: {},
+    });
+
+    const content = result.content as { type: string; text: string }[] | undefined;
+    const text = content?.[0]?.text ?? '';
+    expect(text).not.toContain('[profile:');
+  });
+});
+
+// Seam test: the CLI `serve` action must forward the resolved profile name
+// into startMcpServer so that a --profile flag isn't silently lost at the
+// CLI→MCP boundary. Exercising this without spawning a subprocess keeps CI
+// fast and free of stdio-framing flakiness.
+describe('CLI → MCP handoff', () => {
+  it('bindStartupProfile respects an explicit profile option and skips pointer resolution', async () => {
+    vi.resetModules();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    // Sabotage the pointer so pointer resolution would fail closed if used.
+    // If bindStartupProfile honored the explicit option, it should not even
+    // read the pointer — so this test must complete without throwing.
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'noxctl-seam-'));
+    const cfgDir = path.join(tmpHome, '.fortnox-mcp');
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(path.join(cfgDir, 'active-profile'), 'has space\n');
+    const prevHome = process.env['HOME'];
+    process.env['HOME'] = tmpHome;
+    process.env['USERPROFILE'] = tmpHome;
+
+    try {
+      const { bindStartupProfile } = await import('../src/index.js');
+      const { getResolvedProfile } = await import('../src/auth.js');
+
+      await expect(bindStartupProfile({ profile: 'from-cli' })).resolves.toBe('from-cli');
+      expect(getResolvedProfile()).toBe('from-cli');
+    } finally {
+      if (prevHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = prevHome;
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/mcp-profile.test.ts
+++ b/tests/mcp-profile.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('MCP startup profile binding', () => {
+  let tmpHome: string;
+  let cfgDir: string;
+  let activePointerFile: string;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
+  let origProfileEnv: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'noxctl-mcp-profile-'));
+    cfgDir = path.join(tmpHome, '.fortnox-mcp');
+    activePointerFile = path.join(cfgDir, 'active-profile');
+
+    origHome = process.env['HOME'];
+    origUserProfile = process.env['USERPROFILE'];
+    origProfileEnv = process.env['NOXCTL_PROFILE'];
+    process.env['HOME'] = tmpHome;
+    process.env['USERPROFILE'] = tmpHome;
+    delete process.env['NOXCTL_PROFILE'];
+  });
+
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = origHome;
+    if (origUserProfile === undefined) delete process.env['USERPROFILE'];
+    else process.env['USERPROFILE'] = origUserProfile;
+    if (origProfileEnv === undefined) delete process.env['NOXCTL_PROFILE'];
+    else process.env['NOXCTL_PROFILE'] = origProfileEnv;
+
+    await fs.rm(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveStartupProfile', () => {
+    it('returns default when no env or pointer is set', async () => {
+      const { resolveStartupProfile } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).resolves.toBe('default');
+    });
+
+    it('prefers NOXCTL_PROFILE over pointer', async () => {
+      await fs.mkdir(cfgDir, { recursive: true });
+      await fs.writeFile(activePointerFile, 'pointed\n');
+      process.env['NOXCTL_PROFILE'] = 'envwin';
+      const { resolveStartupProfile } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).resolves.toBe('envwin');
+    });
+
+    it('falls back to pointer when env is unset', async () => {
+      await fs.mkdir(cfgDir, { recursive: true });
+      await fs.writeFile(activePointerFile, 'pointed\n');
+      const { resolveStartupProfile } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).resolves.toBe('pointed');
+    });
+
+    it('falls back to default when pointer contains an invalid name', async () => {
+      await fs.mkdir(cfgDir, { recursive: true });
+      await fs.writeFile(activePointerFile, 'has space\n');
+      const { resolveStartupProfile } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).resolves.toBe('default');
+    });
+
+    it('falls back to default when NOXCTL_PROFILE is invalid', async () => {
+      process.env['NOXCTL_PROFILE'] = 'bad name!';
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { resolveStartupProfile } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).resolves.toBe('default');
+      expect(errSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('bindStartupProfile', () => {
+    it('binds the provided profile via setResolvedProfile', async () => {
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { bindStartupProfile } = await import('../src/index.js');
+      const { getResolvedProfile } = await import('../src/auth.js');
+
+      const profile = await bindStartupProfile({ profile: 'bound' });
+      expect(profile).toBe('bound');
+      expect(getResolvedProfile()).toBe('bound');
+    });
+
+    it('writes a stderr banner when profile is non-default', async () => {
+      const writes: string[] = [];
+      vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+      const { bindStartupProfile } = await import('../src/index.js');
+      await bindStartupProfile({ profile: 'staging' });
+
+      expect(writes.some((w) => w.includes('[profile: staging]'))).toBe(true);
+    });
+
+    it('does not write a banner for the default profile', async () => {
+      const writes: string[] = [];
+      vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+      const { bindStartupProfile } = await import('../src/index.js');
+      await bindStartupProfile({ profile: 'default' });
+
+      expect(writes.some((w) => w.includes('[profile:'))).toBe(false);
+    });
+
+    it('resolves from env/pointer when no profile option is given', async () => {
+      await fs.mkdir(cfgDir, { recursive: true });
+      await fs.writeFile(activePointerFile, 'pointed\n');
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      const { bindStartupProfile } = await import('../src/index.js');
+      const { getResolvedProfile } = await import('../src/auth.js');
+
+      const profile = await bindStartupProfile();
+      expect(profile).toBe('pointed');
+      expect(getResolvedProfile()).toBe('pointed');
+    });
+  });
+});

--- a/tests/mcp-profile.test.ts
+++ b/tests/mcp-profile.test.ts
@@ -22,6 +22,12 @@ describe('MCP startup profile binding', () => {
     process.env['HOME'] = tmpHome;
     process.env['USERPROFILE'] = tmpHome;
     delete process.env['NOXCTL_PROFILE'];
+
+    // Reset module cache so each test gets a fresh auth.ts with a clean
+    // `resolvedProfile` module-global. Without this, tests coincidentally
+    // pass only because of assertion narrowness, not because the binding
+    // is actually isolated.
+    vi.resetModules();
   });
 
   afterEach(async () => {
@@ -57,19 +63,35 @@ describe('MCP startup profile binding', () => {
       await expect(resolveStartupProfile()).resolves.toBe('pointed');
     });
 
-    it('falls back to default when pointer contains an invalid name', async () => {
+    it('fails closed when pointer contains an invalid name and no env override', async () => {
       await fs.mkdir(cfgDir, { recursive: true });
       await fs.writeFile(activePointerFile, 'has space\n');
-      const { resolveStartupProfile } = await import('../src/index.js');
-      await expect(resolveStartupProfile()).resolves.toBe('default');
+      const { resolveStartupProfile, StartupProfileError } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).rejects.toBeInstanceOf(StartupProfileError);
+      await expect(resolveStartupProfile()).rejects.toMatchObject({
+        code: 'invalid-pointer-content',
+      });
     });
 
-    it('falls back to default when NOXCTL_PROFILE is invalid', async () => {
-      process.env['NOXCTL_PROFILE'] = 'bad name!';
-      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    it('overrides a corrupt pointer with a valid NOXCTL_PROFILE and warns', async () => {
+      await fs.mkdir(cfgDir, { recursive: true });
+      await fs.writeFile(activePointerFile, 'has space\n');
+      process.env['NOXCTL_PROFILE'] = 'envwin';
+      const writes: string[] = [];
+      vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        writes.push(String(chunk));
+        return true;
+      });
       const { resolveStartupProfile } = await import('../src/index.js');
-      await expect(resolveStartupProfile()).resolves.toBe('default');
-      expect(errSpy).toHaveBeenCalled();
+      await expect(resolveStartupProfile()).resolves.toBe('envwin');
+      expect(writes.some((w) => w.includes('[warning:'))).toBe(true);
+    });
+
+    it('fails closed when NOXCTL_PROFILE is invalid', async () => {
+      process.env['NOXCTL_PROFILE'] = 'bad name!';
+      const { resolveStartupProfile, StartupProfileError } = await import('../src/index.js');
+      await expect(resolveStartupProfile()).rejects.toBeInstanceOf(StartupProfileError);
+      await expect(resolveStartupProfile()).rejects.toMatchObject({ code: 'invalid-env' });
     });
   });
 


### PR DESCRIPTION
## Summary

- Binds the active profile at MCP server startup so stdio clients (Claude Desktop, Web, Mobile) resolve credentials from the same `flag / env / pointer` precedence as the CLI.
- Surfaces the resolved profile in Fortnox API errors and runtime token-acquisition failures so mis-bound sessions are diagnosable from stderr / the returned tool error.
- Fails closed on ambiguous pointer state before MCP startup (invalid content, read error, timeout) rather than silently defaulting — the wrong-tenant routing risk outweighs the convenience of fallback.

## Changes

- **`src/index.ts`** — `resolveStartupProfile()` + `bindStartupProfile()` + `StartupProfileError` (codes: `invalid-pointer-content | pointer-read-error | pointer-timeout | invalid-env`). `startMcpServer({ profile? })` binds via `setResolvedProfile` and emits a `[profile: <name>]` stderr banner for non-default profiles. Fatal binding errors exit with code 2 + stderr.
- **`src/profiles.ts`** — typed `PointerOutcome` union + `readActivePointerOutcome()` with `AbortController`-based timeout that actually cancels the underlying `fs.readFile`.
- **`src/cli.ts`** — `serve` action forwards `resolvedProfileInfo.name` to `startMcpServer`. preAction fails closed only for `serve` when no flag/env override is present, so `doctor` / `profile use` can still repair corrupt state. Banner dedupe: when `name === 'serve'`, MCP owns the banner.
- **`src/fortnox-client.ts`** — `FortnoxApiError` message prefixed with `[profile: <name>]` when non-default.
- **`src/auth.ts`** — `refreshAccessToken`, `getTokenViaClientCredentials`, and `getValidToken` errors are profile-tagged (not just `FortnoxApiError`), covering runtime token-refresh failures and initial-auth misses.

## Tests

- `tests/mcp-profile.test.ts` — `resolveStartupProfile` + `bindStartupProfile` precedence, banner behaviour, fail-closed semantics, env-overrides-corrupt-pointer warning.
- `tests/mcp-integration-profile.test.ts` — new. In-process `Client` ↔ `Server` via `InMemoryTransport`; binds `staging`, forces a 500 via mocked fetch, asserts `[profile: staging]` surfaces in the tool error response. Mirror test for `default` asserts no prefix. Plus a CLI→MCP handoff seam test.
- `tests/auth.test.ts` — tagging tests for `refreshAccessToken`, `getTokenViaClientCredentials`, and `getValidToken`; default-profile omits prefix.
- `tests/fortnox-client.test.ts` — profile tag on API error, default omits prefix.

**456/456 passing**, lint clean, build clean.

## Adversarial review

This PR was reviewed by Codex (gpt-5.4, xhigh effort, 2 rounds). All actionable findings were implemented before merge. See `debate/mcp-profile-binding-summary.md` locally for the full debate record.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 456/456 passing
- [ ] Smoke test MCP startup locally via Claude Desktop against a non-default profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)