### PR TITLE
docs: multi-profile docs for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to noxctl are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-20
+
+### Added
+
+- **Multi-profile support** — run noxctl against multiple Fortnox tenants from a single installation. Each profile has its own namespaced OAuth credentials in the OS keychain.
+- **Profile resolution precedence:** `--profile <name>` flag → `NOXCTL_PROFILE` env var → `~/.fortnox-mcp/active-profile` pointer → `default`.
+- **`noxctl profile` subcommands:** `use <name>`, `current`, `list`.
+- **`--profile <name>` flag** on all commands, including `init` and `serve`.
+- **MCP server startup profile binding** — the MCP server now resolves the profile at startup (from env + active pointer, or the forwarded CLI flag) and binds it for the session. Non-default sessions print a `[profile: <name>]` stderr banner.
+- **Profile-tagged errors** — Fortnox API errors (`FortnoxApiError`) and runtime token-acquisition failures (`refreshAccessToken`, `getTokenViaClientCredentials`, `getValidToken`) are prefixed with `[profile: <name>]` when non-default, so mis-bound MCP sessions are diagnosable from a single line.
+- **`MIGRATION.md`** covering the 0.1 → 0.2 upgrade path.
+
+### Changed
+
+- **Fail-closed pointer semantics at MCP startup.** `noxctl serve` refuses to start when the active-profile pointer is corrupt, unreadable, or times out and no `--profile` flag or `NOXCTL_PROFILE` is set. Exits with code 2 and a stderr message pointing at `noxctl doctor`. The CLI's `doctor` and `profile use` commands remain usable against a broken pointer so it can be repaired.
+- **Pointer read uses `AbortController`** instead of `Promise.race`, so a timeout actually cancels the underlying `fs.readFile` rather than letting it run to completion in the background.
+- **Credential storage is now namespaced by profile.** A one-time migration on first run re-writes existing credentials under the `default` profile. The legacy entry is preserved for one release cycle to allow rollback to 0.1.x.
+
+### Security
+
+- Corrupt or ambiguous profile state no longer silently routes requests to the `default` tenant. This removes a wrong-tenant routing risk that existed implicitly in 0.1.x (where there was only one tenant, so the risk was vacuous — but the code path didn't enforce it).
+
+## [0.1.0] - 2026-03-20
+
+### Added
+
+- Initial release.
+- CLI and MCP server for Fortnox covering: customers, suppliers, articles, invoices, invoice payments, supplier invoices, supplier invoice payments, offers, orders, bookkeeping (vouchers, accounts), financial reports (income statement, balance sheet), tax (VAT summary, ROT/RUT tax reductions), projects, cost centers, price lists, prices, and company info.
+- Interactive `noxctl init` setup wizard with OAuth2 authorization-code and client-credentials (service account) flows.
+- Secure credential storage in the OS keychain (macOS Keychain, Linux Secret Service, Windows DPAPI).
+- Mutation safety: TTY confirmation prompts, `--yes` / `confirm: true` for scripting, `--dry-run` / `dryRun` for previews.
+- Table and JSON output modes (auto-detected by TTY, override with `-o`).
+- `noxctl doctor` / `fortnox_status` for setup validation.
+
+[0.2.0]: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.2.0
+[0.1.0]: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **Multi-profile support** — run noxctl against multiple Fortnox tenants from a single installation. Each profile has its own namespaced OAuth credentials in the OS keychain.
+- **Multi-profile support** — run noxctl against multiple Fortnox tenants from a single installation. Each profile has its own namespaced OAuth credentials in the OS secure store.
 - **Profile resolution precedence:** `--profile <name>` flag → `NOXCTL_PROFILE` env var → `~/.fortnox-mcp/active-profile` pointer → `default`.
 - **`noxctl profile` subcommands:** `use <name>`, `current`, `list`.
 - **`--profile <name>` flag** on all commands, including `init` and `serve`.
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Fail-closed pointer semantics at MCP startup.** `noxctl serve` refuses to start when the active-profile pointer is corrupt, unreadable, or times out and no `--profile` flag or `NOXCTL_PROFILE` is set. Exits with code 2 and a stderr message pointing at `noxctl doctor`. The CLI's `doctor` and `profile use` commands remain usable against a broken pointer so it can be repaired.
 - **Pointer read uses `AbortController`** instead of `Promise.race`, so a timeout actually cancels the underlying `fs.readFile` rather than letting it run to completion in the background.
-- **Credential storage is now namespaced by profile.** A one-time migration on first run re-writes existing credentials under the `default` profile. The legacy entry is preserved for one release cycle to allow rollback to 0.1.x.
+- **Credential storage is now namespaced by profile.** Existing 0.1.x installs are dual-read transparently (legacy entry → `default` profile) and the profile index is seeded on first observation. The new namespaced entry is written lazily on the next credential save (token refresh or `noxctl init`); the legacy entry stays dual-written for one release cycle so rollback to 0.1.x continues to work.
 
 ### Security
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,13 +6,13 @@
 
 ### What happens on upgrade
 
-On the first invocation after upgrading, noxctl performs a one-time credential migration:
+On the first invocation after upgrading, noxctl transparently dual-reads credentials:
 
-1. Reads the legacy keychain entry (the one 0.1.x wrote under fixed service names).
-2. Re-writes the same credentials under the `default` profile's namespaced keychain entry.
-3. Creates a `profiles.json` index entry for `default` under `~/.fortnox-mcp/`.
+1. **Reads the legacy credential entry** (the one 0.1.x wrote under fixed service names) and uses it as the `default` profile's credentials. No rewrite happens at read time — the legacy entry is the source of truth until something updates credentials.
+2. **Seeds the profile index** — on first observation of the legacy entry, noxctl writes a `default` row to `~/.fortnox-mcp/profiles.json` so `noxctl profile list` and `profile current` have something to show.
+3. **Migrates lazily on the next save.** The first time 0.2.0 writes credentials for the `default` profile (a token refresh, or running `noxctl init` again), it dual-writes to both the new namespaced entry and the legacy entry. From that point on the new entry exists and is preferred, while the legacy entry stays in sync so a downgrade still works.
 
-The legacy entry is left intact for one release cycle so a downgrade to 0.1.x still works. No data loss; no action required.
+No data loss; no action required.
 
 If you've never set up noxctl, there's nothing to migrate — `noxctl init` will create the `default` profile fresh.
 
@@ -63,8 +63,17 @@ noxctl profile use default              # repair the pointer
 
 ### Rollback to 0.1.x
 
+Global install:
+
 ```bash
 npm install -g noxctl@0.1.0
 ```
 
-0.1.x will read the legacy keychain entry that 0.2.0 left in place. Profiles other than `default` are invisible to 0.1.x — their credentials remain in the keychain but are not used.
+**If you registered the MCP server with Claude Desktop / claude.ai / Code**, that registration runs `npx noxctl serve`, which resolves `noxctl` dynamically and may still pick the latest published version regardless of your global pin. Re-register with an explicit version to actually pin the MCP server:
+
+```bash
+claude mcp remove fortnox
+claude mcp add fortnox -- npx noxctl@0.1.0 serve
+```
+
+0.1.x will read the legacy credential entry that 0.2.0 left in place. Profiles other than `default` are invisible to 0.1.x — their credentials remain in the secure store but are not used.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,70 @@
+# Migration guide
+
+## 0.1.x → 0.2.0
+
+0.2.0 introduces multi-profile support (run noxctl against multiple Fortnox tenants from one installation). **Upgrading is a no-op for existing single-tenant users** — your existing credentials are automatically adopted as the `default` profile on first run.
+
+### What happens on upgrade
+
+On the first invocation after upgrading, noxctl performs a one-time credential migration:
+
+1. Reads the legacy keychain entry (the one 0.1.x wrote under fixed service names).
+2. Re-writes the same credentials under the `default` profile's namespaced keychain entry.
+3. Creates a `profiles.json` index entry for `default` under `~/.fortnox-mcp/`.
+
+The legacy entry is left intact for one release cycle so a downgrade to 0.1.x still works. No data loss; no action required.
+
+If you've never set up noxctl, there's nothing to migrate — `noxctl init` will create the `default` profile fresh.
+
+### Verifying the migration
+
+```bash
+noxctl doctor               # should report credentials present and API reachable
+noxctl profile current      # should print "default (source: …)"
+noxctl profile list         # should list at least "default"
+noxctl company info         # should return your company
+```
+
+### Adding a second profile
+
+```bash
+noxctl init --profile staging      # OAuth flow for a second tenant
+noxctl --profile staging company info
+noxctl profile use staging         # make it the default for future commands
+noxctl profile use default         # switch back
+```
+
+### MCP clients (Claude Desktop / claude.ai / Web / Mobile)
+
+Existing MCP server registrations continue to work — they bind to the `default` profile on startup and behave exactly as in 0.1.x.
+
+To run multiple MCP servers (one per tenant) side by side, register them with scoped environments:
+
+```bash
+claude mcp add fortnox-prod     -- npx noxctl serve
+claude mcp add fortnox-staging  -e NOXCTL_PROFILE=staging -- npx noxctl serve
+```
+
+Non-default sessions print a `[profile: <name>]` stderr banner on startup and prefix Fortnox API / token-refresh errors with the same tag, so mis-bound sessions are easy to diagnose from a single error line.
+
+### Behavior change: fail-closed on corrupt pointer
+
+`noxctl serve` now refuses to start if the active-profile pointer (`~/.fortnox-mcp/active-profile`) is unreadable or contains an invalid profile name and no `--profile` flag or `NOXCTL_PROFILE` is set. This prevents a corrupt pointer from silently routing MCP sessions to the wrong tenant.
+
+Recovery:
+
+```bash
+noxctl profile current                  # shows what went wrong
+noxctl profile use default              # repair the pointer
+# or: NOXCTL_PROFILE=default noxctl serve   # one-off override
+```
+
+`noxctl doctor` and `noxctl profile use` deliberately still work with a corrupt pointer so you can diagnose and repair without needing to hand-edit files.
+
+### Rollback to 0.1.x
+
+```bash
+npm install -g noxctl@0.1.0
+```
+
+0.1.x will read the legacy keychain entry that 0.2.0 left in place. Profiles other than `default` are invisible to 0.1.x — their credentials remain in the keychain but are not used.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You should see your company name, organisation number, and address. If this work
 
 ## Profiles (multi-tenant)
 
-noxctl supports multiple Fortnox tenants from a single installation — useful if you bookkeep for several companies, or want to keep a sandbox tenant separate from production. Each profile has its own OAuth credentials in the OS keychain, keyed by profile name.
+noxctl supports multiple Fortnox tenants from a single installation — useful if you bookkeep for several companies, or want to keep a sandbox tenant separate from production. Each profile has its own OAuth credentials in the OS secure store (macOS Keychain / Linux Secret Service / Windows DPAPI), keyed by profile name.
 
 ### Running against a specific profile
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,46 @@ node dist/cli.js company info
 
 You should see your company name, organisation number, and address. If this works, you're all set.
 
+## Profiles (multi-tenant)
+
+noxctl supports multiple Fortnox tenants from a single installation — useful if you bookkeep for several companies, or want to keep a sandbox tenant separate from production. Each profile has its own OAuth credentials in the OS keychain, keyed by profile name.
+
+### Running against a specific profile
+
+Three ways to pick the profile, in precedence order (highest wins):
+
+1. **`--profile <name>` flag** — explicit, per-command
+2. **`NOXCTL_PROFILE` environment variable** — scoped to a shell session
+3. **Active pointer** — `~/.fortnox-mcp/active-profile`, set by `noxctl profile use`
+
+If none of these is set, noxctl uses the `default` profile (what existing users have been using all along — no opt-in required).
+
+```bash
+noxctl init --profile staging              # authorize a second tenant
+noxctl --profile staging invoices list     # one-off against staging
+NOXCTL_PROFILE=staging noxctl company info # shell-scoped
+noxctl profile use staging                 # sticky — persists to the pointer
+noxctl profile current                     # show resolved profile + source
+noxctl profile list                        # list known profiles
+```
+
+### MCP server
+
+When launched by Claude Desktop / claude.ai, the MCP server resolves the profile from `NOXCTL_PROFILE` and the active pointer at startup, and binds for the session. When launched via `noxctl --profile <name> serve`, the CLI forwards the flag.
+
+To run multiple MCP servers (one per tenant) in parallel, register them with distinct names and scoped environments:
+
+```bash
+claude mcp add fortnox-prod     -- npx noxctl serve
+claude mcp add fortnox-staging  -e NOXCTL_PROFILE=staging -- npx noxctl serve
+```
+
+Non-default sessions print a `[profile: <name>]` stderr banner on startup and prefix every Fortnox API error and token-refresh failure with the same tag so mis-bound sessions are diagnosable from a single error line.
+
+### Fail-closed pointer semantics
+
+If the active pointer becomes unreadable or corrupt and no explicit `--profile` flag or `NOXCTL_PROFILE` is set, `noxctl serve` **refuses to start** rather than silently falling back to `default`. This prevents a corrupted pointer from routing production MCP sessions to the wrong tenant. The CLI's `doctor` and `profile use` commands are exempt — they can still run against a broken pointer so you can repair it.
+
 ## Tools
 
 Every operation is available both as a CLI command and as an MCP tool. The CLI is the primary interface; the MCP server exposes the same operations to AI agents. All mutations — every row labeled `(mutation)` — prompt for confirmation on a TTY and require `--yes` (CLI) or `confirm: true` (MCP) when piped. See [Mutation safety](#mutation-safety).
@@ -281,6 +321,9 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl init` | — | Interactive setup wizard — connects to Fortnox, stores credentials, optionally registers MCP server |
 | `noxctl doctor` | `fortnox_status` | Validate setup: Node version, credentials, token status, API connectivity, and scopes |
 | `noxctl logout` | — | Remove stored credentials from the OS keychain |
+| `noxctl profile use <name>` | — | Set the active profile (writes `~/.fortnox-mcp/active-profile`) |
+| `noxctl profile current` | — | Show the currently resolved profile and where it came from |
+| `noxctl profile list` | — | List known profiles from the index |
 
 ## CLI output
 


### PR DESCRIPTION
## Summary

- Adds a **Profiles (multi-tenant)** section to README covering precedence (`--profile` flag → `NOXCTL_PROFILE` → active pointer → `default`), per-tenant MCP scoping, and the fail-closed pointer semantics introduced in PR #22.
- Adds `noxctl profile use|current|list` rows to the Utility table.
- New **MIGRATION.md** covering the 0.1 → 0.2 upgrade path (automatic credential migration, verification steps, adding a second profile, MCP client scoping, fail-closed recovery, rollback).
- New **CHANGELOG.md** with entries for 0.2.0 and 0.1.0 (Keep-a-Changelog format).

No code changes — this is the documentation counterpart to PR #22 and prerequisite to the 0.2.0 release.

## Test plan

- [ ] Render README on GitHub and sanity-check the new section
- [ ] Render MIGRATION.md on GitHub
- [ ] Render CHANGELOG.md on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)