### PR TITLE
Fix open bugs and implement backlog enhancements (11 issues)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to noxctl are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Contracts API** (#10) — recurring invoicing: `noxctl contracts list|get|create|update|finish|create-invoice|increase-invoice-count` and matching MCP tools.
+- **Financial years / locked period** (#11) — `noxctl financial-years list|get|locked-period` and MCP tools; context for period-aware operations.
+- **Analytics views** (#7) — overdue summary, unpaid totals, top customers, VAT summary with net VAT position: `noxctl analytics ...` and MCP tools.
+- **`noxctl dashboard`** (#12) — at-a-glance outstanding/overdue/recent invoices/monthly revenue.
+- **Natural date periods** (#9) — `--period Q1|2025-Q3|march|mars|last-quarter|ytd|...` on list/report commands (calendar-year based; fiscal-year awareness deferred).
+- **Shell completions** (#8) — `noxctl completion bash|zsh|fish`.
+- **Confirmation payload preview** (#6) — the y/N prompt now shows the exact JSON payload that will be sent.
+- **JSON error envelope** (#32) — in JSON mode, failures are emitted to stderr as `{"error": {status?, message, hint?, source}}`.
+- **YubiKey serial diagnostics** (#33) — `keychain init` records the enrolled key's serial; `unlock` preflights it against `ykman list --serials` and names both serials on mismatch. ykman's misleading "empty slot"/"Failed to write" errors are translated.
+
+### Changed
+
+- **Stable JSON envelopes for single-resource output** (#34) — `get`/`create`/`update`/action commands now wrap their JSON output under the singular resource key (`{"Invoice": {...}}`), matching the list convention. Scripts that consumed the bare object should unwrap one level.
+- The `-o` help text documents the default output mode (table on TTY, JSON when piped) (#34).
+
+### Fixed
+
+- `customers create`/`update` strip the server-derived read-only fields `Country`, `DeliveryCountry`, `VisitingCountry`, so a `customers get` response can be fed back into create/update unchanged (#31).
+
 ## [0.2.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -361,6 +361,36 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl prices get --pricelist <code> --article <number>` | `fortnox_get_price` | Get a specific price |
 | `noxctl prices update --pricelist <code> --article <number> --input <file>` | `fortnox_update_price` | Update a price (mutation) |
 
+### Contracts (avtal — recurring invoicing)
+
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl contracts list [--filter active\|inactive\|finished]` | `fortnox_list_contracts` | List/filter contracts |
+| `noxctl contracts get <number>` | `fortnox_get_contract` | Get a single contract |
+| `noxctl contracts create --customer <number> --input <file>` | `fortnox_create_contract` | Create a contract (mutation) |
+| `noxctl contracts update <number> --input <file>` | `fortnox_update_contract` | Update a contract (mutation) |
+| `noxctl contracts finish <number>` | `fortnox_finish_contract` | Finish a contract (mutation) |
+| `noxctl contracts create-invoice <number>` | `fortnox_create_invoice_from_contract` | Create the next invoice now (mutation) |
+| `noxctl contracts increase-invoice-count <number>` | `fortnox_increase_contract_invoice_count` | Extend by one invoice (mutation) |
+
+### Financial years and locked period
+
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl financial-years list [--date <date>]` | `fortnox_list_financialyears` | List financial years (räkenskapsår) |
+| `noxctl financial-years get <id>` | `fortnox_get_financialyear` | Get a single financial year |
+| `noxctl financial-years locked-period` | `fortnox_get_lockedperiod` | Show through which date bookkeeping is locked |
+
+### Analytics and dashboard
+
+| CLI | MCP tool | Description |
+|-----|----------|-------------|
+| `noxctl analytics overdue` | `fortnox_overdue_invoices` | Overdue invoices summary |
+| `noxctl analytics unpaid` | `fortnox_unpaid_totals` | Outstanding receivables, with overdue split |
+| `noxctl analytics top-customers [--period <period>]` | `fortnox_top_customers` | Top customers by invoiced amount |
+| `noxctl analytics vat --period <period>` | `fortnox_vat_summary` | VAT summary with net VAT position |
+| `noxctl dashboard` | — | At-a-glance: outstanding, overdue, recent invoices, monthly revenue |
+
 ### Company
 
 | CLI | MCP tool | Description |
@@ -377,6 +407,7 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl profile use <name>` | — | Set the active profile (writes `~/.fortnox-mcp/active-profile`) |
 | `noxctl profile current` | — | Show the currently resolved profile and where it came from |
 | `noxctl profile list` | — | List known profiles from the index |
+| `noxctl completion <bash\|zsh\|fish>` | — | Generate a shell completion script |
 
 ## CLI output
 
@@ -388,6 +419,14 @@ noxctl -o json invoices list      # force JSON (JavaScript Object Notation)
 noxctl -o table invoices list     # force table
 noxctl invoices list | jq .       # auto-JSON (piped)
 ```
+
+JSON output has a stable envelope: list commands wrap under the plural resource key (`{"Invoices": [...], "MetaInformation": {...}}`) and single-resource commands under the singular key (`{"Invoice": {...}}`), so scripted callers can rely on a fixed accessor. Failures in JSON mode are emitted to stderr as a structured envelope:
+
+```json
+{ "error": { "status": 400, "message": "...", "source": "fortnox-api" } }
+```
+
+Natural date periods are accepted wherever `--from`/`--to` work, via `--period`: `Q1`, `2025-Q3`, `march`/`mars`, `this-quarter`, `last-quarter`, `this-month`, `last-month`, `ytd`, `this-year`, `last-year`, or a bare year. Periods are **calendar-year** based (broken fiscal years are not yet considered).
 
 When running from a local clone instead of an installed binary, replace `noxctl` with `node dist/cli.js`.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,59 @@ Non-default sessions print a `[profile: <name>]` stderr banner on startup and pr
 
 If the active pointer becomes unreadable or corrupt and no explicit `--profile` flag or `NOXCTL_PROFILE` is set, `noxctl serve` **refuses to start** rather than silently falling back to `default`. This prevents a corrupted pointer from routing production MCP sessions to the wrong tenant. The CLI's `doctor` and `profile use` commands are exempt — they can still run against a broken pointer so you can repair it.
 
+## YubiKey-locked keychain (macOS)
+
+By default, credentials live in your macOS **login keychain**, which unlocks automatically when you log in. That's convenient, but it means an AI agent (or anything running as you) can read the tokens without a per-session gesture from you.
+
+The optional **dedicated keychain** moves credentials into a separate, lock-on-sleep keychain whose password is derived from your YubiKey via HMAC-SHA1 challenge-response. You unlock it once per session with a single tap; it re-locks when your Mac sleeps. The keychain password is never typed or stored — it only exists on the YubiKey.
+
+This is opt-in and macOS-only. It does not change how credentials are stored on Linux or Windows.
+
+### One-time YubiKey setup
+
+Program OTP slot 2 for challenge-response (requires touch). **This writes only the empty OTP slot 2** — FIDO2, PIV, OATH, OpenPGP, and slot 1 are untouched, and it is reversible with `ykman otp delete 2`.
+
+```bash
+brew install ykman                              # if not already installed
+ykman otp chalresp --generate --touch 2         # program slot 2
+```
+
+### Enable it
+
+```bash
+noxctl keychain init      # generate challenge, tap to derive the password,
+                          # create the locked keychain, copy existing creds in
+```
+
+`init` uses **copy-and-keep**: your existing login-keychain credentials are copied into the new keychain but left in place as a rollback. Once you've confirmed the new flow works, remove the originals:
+
+```bash
+noxctl keychain seal      # delete the login-keychain copies (irreversible)
+```
+
+Until you `seal`, the login copies remain readable without a tap — so the per-session protection isn't fully in effect.
+
+### Daily use
+
+```bash
+noxctl keychain unlock    # tap your YubiKey — open until the Mac next sleeps
+noxctl keychain status    # mode, lock state, ykman/YubiKey presence
+noxctl keychain lock      # lock immediately
+```
+
+When the keychain is locked, any command that needs credentials fails fast with a message telling you to run `noxctl keychain unlock` — it never pops a macOS password dialog (the challenge-response password can't be typed into one).
+
+### Recovery if you lose the YubiKey
+
+The keychain password lives only on the key, so a lost or re-programmed key means the dedicated keychain can't be unlocked. As long as you have **not** run `seal`, your credentials are still in the login keychain — delete the dedicated keychain and challenge file to fall back:
+
+```bash
+security delete-keychain ~/Library/Keychains/fortnox-mcp.keychain-db
+rm ~/.fortnox-mcp/keychain-challenge
+```
+
+If you *have* sealed, re-run `noxctl init` to re-authenticate from scratch.
+
 ## Tools
 
 Every operation is available both as a CLI command and as an MCP tool. The CLI is the primary interface; the MCP server exposes the same operations to AI agents. All mutations — every row labeled `(mutation)` — prompt for confirmation on a TTY and require `--yes` (CLI) or `confirm: true` (MCP) when piped. See [Mutation safety](#mutation-safety).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,21 +1,29 @@
 # Project Status
 
-**Last session:** 2026-05-25
-**Branch:** main (feature work uncommitted)
+**Last session:** 2026-06-10
+**Branch:** `fix/issue-batch-bugs-enhancements` — pushed, PR #35 open
 
 ## Completed This Session
 
-- **YubiKey-locked dedicated keychain (macOS) — feature complete, pending live verification + commit**
-  - `src/keychain-target.ts`: full module — challenge-response (`computeChallengeResponse`, OTP slot 2), dedicated-keychain create/unlock/lock/lock-state, prompt-free locked-read (`readDedicatedSecret` → `KeychainLockedError`, no GUI dialog), challenge file read/write, `activeKeychainPath()` precedence (env override → darwin files-exist → null), `deleteLoginSecret`/`loginKeychainPath` for seal.
-  - `src/credentials-store.ts`: reads/writes/deletes route to the dedicated keychain when active (Swift via stdin, path passed as argv).
-  - `src/auth.ts`: `loadCredentials` now re-throws `KeychainLockedError` (was swallowed) so a locked keychain surfaces instead of looking like "no creds".
-  - `src/cli.ts`: new `noxctl keychain` group — `init` (copy-and-keep migration), `unlock`, `lock`, `status`, `seal`; `doctor` reports dedicated-mode + lock state + ykman.
-  - Tests: new `tests/keychain-target.test.ts` (39 tests). Full suite 499 pass, lint clean.
-  - Swift plumbing validated end-to-end with a static password (no YubiKey) — 9/9 checks.
+Batch-fixed 11 GitHub issues (both open bugs + all tractable enhancements), one commit per issue, red/green TDD throughout. 552 unit tests (up from 499), lint clean.
+
+- **#31 (bug)** — `customers create/update` strip server-derived read-only fields (`Country`, `DeliveryCountry`, `VisitingCountry`) in the operations layer.
+- **#34 (bug)** — single-resource JSON output consistently wrapped under the singular key (`{"Invoice": {...}}`); `-o` help documents the TTY/piped default. **Breaking** for scripts consuming bare objects (CHANGELOG Unreleased → Changed).
+- **#32** — JSON-mode failures emit `{"error": {status?, message, hint?, source}}` to stderr (`errorEnvelope` in formatter.ts).
+- **#6** — confirmation prompt prints the request payload before y/N.
+- **#8** — `noxctl completion bash|zsh|fish` (src/completions.ts, generated from the Commander tree).
+- **#9** — `--period` natural dates (src/date-periods.ts): Q1/2025-Q3/month names (en+sv)/last-quarter/ytd/year. Calendar-year based; fiscal-year design still open.
+- **#33** — YubiKey serial enrollment diagnostics: init records serial to `~/.fortnox-mcp/keychain-serial`, unlock preflights `ykman list --serials`, ykman's "empty slot"/"Failed to write" errors translated.
+- **#11** — financial years + locked period (operations/tools/CLI).
+- **#10** — Contracts API: list/get/create/update/finish/create-invoice/increase-invoice-count.
+- **#7** — analytics ops (src/operations/analytics.ts): overdue summary, unpaid totals, top customers, VAT summary with netVat. Pure aggregation functions unit-tested.
+- **#12** — `noxctl dashboard` composing the analytics ops.
+
+Issue triage: closed #16 (multi-profile — shipped in 0.2.0); commented on #13 (still blocked on Fortnox API scope config).
 
 ## In Progress
 
-- **Live verification still needed (requires the user + a physical tap):** `noxctl keychain init` then `unlock` on the Mac. CI has no hardware. Then commit.
+- **PR #35 awaiting review/merge.** Merging auto-closes the 11 issues.
 
 ## Blockers
 
@@ -23,6 +31,7 @@ None.
 
 ## Next Steps
 
-- User runs `noxctl keychain init` / `unlock` to verify the tap flow, then commit the feature.
-- Consider a CHANGELOG entry + version bump when releasing.
-- See `TODO.md` for the rest of the backlog.
+- Review + merge PR #35.
+- Live-verify the new endpoints against the real API (`npm run test:live`); contracts/financial-years were only tested against mocks.
+- Consider version bump (0.3.0 given the #34 breaking envelope change) + CHANGELOG release entry.
+- Recurring `api-drift` spec-fetch failures (HTTP 429, issues #5–#30) are still unaddressed — the weekly fetch has failed since March; worth fixing the fetch script (retry/backoff or new URL) and closing the stale issues.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,20 +1,21 @@
 # Project Status
 
-**Last session:** 2026-04-21
-**Branch:** main
+**Last session:** 2026-05-25
+**Branch:** main (feature work uncommitted)
 
 ## Completed This Session
 
-- **0.2.0 release shipped**
-  - Docs PR #23 merged (README profile section, MIGRATION.md, CHANGELOG.md)
-  - Version bumped to 0.2.0 in `package.json`, `src/cli.ts`, `src/index.ts` (commit `d53585e`)
-  - Published to npm: `noxctl@0.2.0` is now `latest`
-  - Git tag `v0.2.0` pushed
-  - GitHub release created: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.2.0
+- **YubiKey-locked dedicated keychain (macOS) — feature complete, pending live verification + commit**
+  - `src/keychain-target.ts`: full module — challenge-response (`computeChallengeResponse`, OTP slot 2), dedicated-keychain create/unlock/lock/lock-state, prompt-free locked-read (`readDedicatedSecret` → `KeychainLockedError`, no GUI dialog), challenge file read/write, `activeKeychainPath()` precedence (env override → darwin files-exist → null), `deleteLoginSecret`/`loginKeychainPath` for seal.
+  - `src/credentials-store.ts`: reads/writes/deletes route to the dedicated keychain when active (Swift via stdin, path passed as argv).
+  - `src/auth.ts`: `loadCredentials` now re-throws `KeychainLockedError` (was swallowed) so a locked keychain surfaces instead of looking like "no creds".
+  - `src/cli.ts`: new `noxctl keychain` group — `init` (copy-and-keep migration), `unlock`, `lock`, `status`, `seal`; `doctor` reports dedicated-mode + lock state + ykman.
+  - Tests: new `tests/keychain-target.test.ts` (39 tests). Full suite 499 pass, lint clean.
+  - Swift plumbing validated end-to-end with a static password (no YubiKey) — 9/9 checks.
 
 ## In Progress
 
-Nothing. 0.2.0 is fully shipped.
+- **Live verification still needed (requires the user + a physical tap):** `noxctl keychain init` then `unlock` on the Mac. CI has no hardware. Then commit.
 
 ## Blockers
 
@@ -22,4 +23,6 @@ None.
 
 ## Next Steps
 
-See `TODO.md` for the prioritized backlog.
+- User runs `noxctl keychain init` / `unlock` to verify the tap flow, then commit the feature.
+- Consider a CHANGELOG entry + version bump when releasing.
+- See `TODO.md` for the rest of the backlog.

--- a/TODO.md
+++ b/TODO.md
@@ -15,23 +15,23 @@ Weekly GitHub Actions workflow (`api-drift.yml`) fetches the Fortnox OpenAPI spe
 
 ### Tier 2 — Usability
 
-1. Better confirmation preview (show payload before y/N prompt)
-2. Selective analytics MCP tools (overdue invoices, unpaid totals, top customers, VAT summary)
-3. Shell completions
-4. Natural date periods (`Q1`, `march`) — needs fiscal-year design first
+1. ~~Better confirmation preview (show payload before y/N prompt)~~ ✅ Done
+2. ~~Selective analytics MCP tools (overdue invoices, unpaid totals, top customers, VAT summary)~~ ✅ Done
+3. ~~Shell completions~~ ✅ Done
+4. ~~Natural date periods (`Q1`, `march`)~~ ✅ Done (calendar-year based; fiscal-year awareness still open)
 5. Claude Desktop auto-registration in `init`
 
 ### Tier 3 — More API Coverage
 
 6. ~~**Projects / Cost Centers**~~ ✅ Done
-7. **Contracts** — recurring invoicing automation
+7. ~~**Contracts** — recurring invoicing automation~~ ✅ Done
 8. ~~**Tax Reductions (ROT/RUT)**~~ ✅ Done
 9. ~~**Price Lists / Prices**~~ ✅ Done
-10. **Financial Years / Locked Period** — context for period-aware operations
+10. ~~**Financial Years / Locked Period**~~ ✅ Done
 
 ### Tier 4 — Backlog
 
-11. CLI `dashboard` command
+11. ~~CLI `dashboard` command~~ ✅ Done
 12. Bilingual MCP descriptions (Swedish primary + English keywords)
 13. MCP capability resource
 14. Bank transactions (requires enabling Bank API scope)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { loadCredentialBlob, saveCredentialBlob, type LoadSource } from './credentials-store.js';
+import { KeychainLockedError } from './keychain-target.js';
 import { DEFAULT_PROFILE, validateProfileName } from './profile-name.js';
 import { migrateLegacyIfNeeded, readProfileIndex, upsertProfile } from './profiles.js';
 
@@ -83,7 +84,10 @@ export async function loadCredentials(profile?: string): Promise<FortnoxCredenti
   let result: { blob: string | null; source: LoadSource; legacyBlob: string | null };
   try {
     result = await loadCredentialBlob(target);
-  } catch {
+  } catch (err) {
+    // A locked dedicated keychain must surface, not look like "no credentials" —
+    // the caller tells the user to run `noxctl keychain unlock` (tap YubiKey).
+    if (err instanceof KeychainLockedError) throw err;
     return null;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,8 @@ import {
   financialYearListColumns,
   financialYearDetailColumns,
   lockedPeriodDetailColumns,
+  contractListColumns,
+  contractDetailColumns,
 } from './views.js';
 
 const program = new Command();
@@ -2833,6 +2835,144 @@ prices
     }
     const data = await updatePrice(opts.pricelist, opts.article, fields, opts.fromQuantity);
     outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
+  });
+
+// --- contracts ---
+const contracts = program
+  .command('contracts')
+  .description('Contract operations (avtal — recurring invoicing)');
+
+contracts
+  .command('list')
+  .description('List/filter contracts')
+  .option('--filter <filter>', 'Filter: active, inactive, finished')
+  .option('--page <number>', 'Page number', parseInt)
+  .option('--limit <number>', 'Results per page', parseInt)
+  .option('-a, --all', 'Fetch all pages')
+  .action(async (opts) => {
+    const { listContracts } = await import('./operations/contracts.js');
+    const data = await listContracts({
+      filter: opts.filter,
+      page: opts.page,
+      limit: opts.limit,
+      all: opts.all,
+    });
+    outputList(data.Contracts ?? [], contractListColumns, json(), data, data.MetaInformation);
+  });
+
+contracts
+  .command('get <documentNumber>')
+  .description('Get a single contract')
+  .action(async (documentNumber: string) => {
+    const { getContract } = await import('./operations/contracts.js');
+    const data = await getContract(documentNumber);
+    outputDetail(data, contractDetailColumns, json(), 'Contract');
+  });
+
+contracts
+  .command('create')
+  .description('Create a contract (recurring invoicing)')
+  .requiredOption('--customer <number>', 'Customer number')
+  .requiredOption('--input <file>', 'Contract data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  echo '{"InvoiceRows":[{"Description":"Hosting","DeliveredQuantity":1,"Price":500,"AccountNumber":3001,"VAT":25}],"PeriodStart":"2026-07-01","PeriodEnd":"2027-06-30","InvoiceInterval":3,"ContractLength":12}' | noxctl contracts create --customer 25 --input - --dry-run`,
+  )
+  .action(async (opts) => {
+    const { createContract } = await import('./operations/contracts.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const input = JSON.parse(raw) as Record<string, unknown>;
+    const params = { CustomerNumber: opts.customer, ...input };
+    if (
+      !(await confirmMutation(`Create contract for customer ${opts.customer}`, opts, {
+        Contract: params,
+      }))
+    ) {
+      return;
+    }
+    const data = await createContract(params);
+    outputDetail(data, contractDetailColumns, json(), 'Contract');
+  });
+
+contracts
+  .command('update <documentNumber>')
+  .description('Update a contract')
+  .requiredOption('--input <file>', 'Fields to update as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (documentNumber: string, opts) => {
+    const { updateContract } = await import('./operations/contracts.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (!(await confirmMutation(`Update contract ${documentNumber}`, opts, { Contract: fields }))) {
+      return;
+    }
+    const data = await updateContract(documentNumber, fields);
+    outputDetail(data, contractDetailColumns, json(), 'Contract');
+  });
+
+contracts
+  .command('finish <documentNumber>')
+  .description('Finish a contract — no further invoices will be created')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { finishContract } = await import('./operations/contracts.js');
+    if (!(await confirmMutation(`Finish contract ${documentNumber}`, opts))) {
+      return;
+    }
+    const data = await finishContract(documentNumber);
+    outputConfirmation(
+      `Contract ${documentNumber} finished.`,
+      json(),
+      data,
+      contractDetailColumns,
+      'Contract',
+    );
+  });
+
+contracts
+  .command('create-invoice <documentNumber>')
+  .description('Create the next invoice from a contract immediately')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { createInvoiceFromContract } = await import('./operations/contracts.js');
+    if (!(await confirmMutation(`Create invoice from contract ${documentNumber}`, opts))) {
+      return;
+    }
+    const data = await createInvoiceFromContract(documentNumber);
+    outputConfirmation(
+      `Invoice created from contract ${documentNumber}.`,
+      json(),
+      data,
+      invoiceConfirmColumns,
+      'Invoice',
+    );
+  });
+
+contracts
+  .command('increase-invoice-count <documentNumber>')
+  .description('Extend a non-continuous contract by one invoice')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { increaseInvoiceCount } = await import('./operations/contracts.js');
+    if (!(await confirmMutation(`Increase invoice count for contract ${documentNumber}`, opts))) {
+      return;
+    }
+    const data = await increaseInvoiceCount(documentNumber);
+    outputConfirmation(
+      `Invoice count increased for contract ${documentNumber}.`,
+      json(),
+      data,
+      contractDetailColumns,
+      'Contract',
+    );
   });
 
 // --- financial years ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -206,6 +206,28 @@ async function confirmMutation(
   }
 }
 
+function requireDarwin(): void {
+  if (process.platform !== 'darwin') {
+    console.error('The dedicated YubiKey-locked keychain is a macOS-only feature.');
+    process.exit(2);
+  }
+}
+
+// Confirmation for local, irreversible operations (not Fortnox mutations).
+async function localConfirm(question: string, yes?: boolean): Promise<boolean> {
+  if (yes) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('Confirmation required. Re-run with --yes.');
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`${question} [y/N] `);
+    return ['y', 'yes'].includes(answer.trim().toLowerCase());
+  } finally {
+    rl.close();
+  }
+}
+
 // --- init (interactive setup wizard) ---
 program
   .command('init')
@@ -668,6 +690,23 @@ program
           : 'Linux Secret Service';
     pass('Credential store', storeBackend);
 
+    // 2a. Dedicated YubiKey-locked keychain (macOS only)
+    if (process.platform === 'darwin') {
+      const kt = await import('./keychain-target.js');
+      const activePath = kt.activeKeychainPath();
+      if (activePath) {
+        const state = kt.keychainLockState(activePath);
+        if (state === 'locked') {
+          fail('Dedicated keychain', 'locked — run `noxctl keychain unlock` (tap your YubiKey)');
+        } else {
+          pass('Dedicated keychain', `active, ${state} (${activePath})`);
+        }
+        pass('ykman', kt.ykmanAvailable() ? 'installed' : 'not installed (brew install ykman)');
+      } else {
+        pass('Dedicated keychain', 'not enabled (using login keychain)');
+      }
+    }
+
     // 2b. Profile resolution
     pass('Profile', `${resolvedProfileInfo.name} (source: ${resolvedProfileInfo.source})`);
 
@@ -703,7 +742,18 @@ program
     }
 
     // 3. Credentials exist
-    const creds = await loadCredentials();
+    let creds: Awaited<ReturnType<typeof loadCredentials>>;
+    try {
+      creds = await loadCredentials();
+    } catch (err) {
+      const { KeychainLockedError } = await import('./keychain-target.js');
+      if (err instanceof KeychainLockedError) {
+        fail('Credentials', err.message);
+        console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
+        return;
+      }
+      throw err;
+    }
     if (!creds) {
       fail(
         'Credentials',
@@ -800,6 +850,267 @@ program
     }
 
     console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
+  });
+
+// --- keychain (dedicated YubiKey-locked credential store, macOS only) ---
+const keychain = program
+  .command('keychain')
+  .description('Manage the dedicated YubiKey-locked credential keychain (macOS)');
+
+keychain
+  .command('status')
+  .description('Show dedicated-keychain mode, lock state, and YubiKey availability')
+  .action(async () => {
+    const kt = await import('./keychain-target.js');
+    const onDarwin = process.platform === 'darwin';
+
+    console.log('Keychain status\n');
+    console.log(
+      `  Platform          ${process.platform}${onDarwin ? '' : ' (dedicated keychain is macOS-only)'}`,
+    );
+    if (!onDarwin) return;
+
+    const activePath = kt.activeKeychainPath();
+    const kcPath = activePath ?? kt.dedicatedKeychainPath();
+    const lockState = kt.keychainLockState(kcPath);
+
+    console.log(`  Dedicated mode    ${activePath ? 'active' : 'inactive (using login keychain)'}`);
+    console.log(`  Keychain file     ${kcPath} (${lockState})`);
+    console.log(
+      `  Challenge file    ${kt.readChallenge() ? kt.challengeFilePath() : 'not present'}`,
+    );
+    console.log(`  ykman installed   ${kt.ykmanAvailable() ? 'yes' : 'no (brew install ykman)'}`);
+    console.log(`  YubiKey present   ${kt.yubikeyPresent() ? 'yes' : 'no'}`);
+
+    if (activePath && lockState === 'locked') {
+      console.log('\n  Locked — run `noxctl keychain unlock` (tap your YubiKey).');
+    }
+  });
+
+keychain
+  .command('unlock')
+  .description('Unlock the dedicated keychain for this session (tap your YubiKey)')
+  .action(async () => {
+    requireDarwin();
+    const kt = await import('./keychain-target.js');
+    const kcPath = kt.activeKeychainPath() ?? kt.dedicatedKeychainPath();
+
+    const state = kt.keychainLockState(kcPath);
+    if (state === 'missing') {
+      console.error('No dedicated keychain found. Run `noxctl keychain init` first.');
+      process.exit(1);
+    }
+    if (state === 'unlocked') {
+      console.log('Keychain is already unlocked.');
+      return;
+    }
+    const challenge = kt.readChallenge();
+    if (!challenge) {
+      console.error(
+        'Challenge file missing — cannot derive the unlock password. Re-run `noxctl keychain init`.',
+      );
+      process.exit(1);
+    }
+    console.log('Tap your YubiKey when it blinks...');
+    let password: string;
+    try {
+      password = kt.computeChallengeResponse(challenge);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    try {
+      kt.unlockDedicatedKeychain(kcPath, password);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    console.log('Keychain unlocked — open until your Mac sleeps.');
+  });
+
+keychain
+  .command('lock')
+  .description('Lock the dedicated keychain now')
+  .action(async () => {
+    requireDarwin();
+    const kt = await import('./keychain-target.js');
+    const kcPath = kt.activeKeychainPath() ?? kt.dedicatedKeychainPath();
+    if (kt.keychainLockState(kcPath) === 'missing') {
+      console.error('No dedicated keychain found.');
+      process.exit(1);
+    }
+    kt.lockKeychain(kcPath);
+    console.log('Keychain locked.');
+  });
+
+keychain
+  .command('init')
+  .description('Create the YubiKey-locked keychain and copy in existing credentials')
+  .action(async () => {
+    requireDarwin();
+    const kt = await import('./keychain-target.js');
+
+    if (!kt.ykmanAvailable()) {
+      console.error('ykman not found — install it with `brew install ykman`, then re-run.');
+      process.exit(1);
+    }
+    if (!kt.yubikeyPresent()) {
+      console.error('No YubiKey detected — insert it and re-run.');
+      process.exit(1);
+    }
+
+    const kcPath = kt.dedicatedKeychainPath();
+    if (kt.readChallenge()) {
+      console.error(
+        'Already initialized. Use `noxctl keychain unlock` or `noxctl keychain status`.',
+      );
+      process.exit(1);
+    }
+    if (kt.keychainLockState(kcPath) !== 'missing') {
+      console.error(
+        `A keychain already exists at ${kcPath} but no challenge file is present.\n` +
+          `Remove the stale keychain (\`security delete-keychain "${kcPath}"\`) and re-run.`,
+      );
+      process.exit(1);
+    }
+
+    console.log('This creates a dedicated, lock-on-sleep keychain whose password is derived');
+    console.log('from your YubiKey (OTP slot 2 challenge-response). You unlock it once per');
+    console.log('session with a tap. Existing credentials are copied in; the login-keychain');
+    console.log('originals are left in place (run `noxctl keychain seal` to remove them later).');
+    console.log('');
+    console.log('Slot 2 must already be programmed: `ykman otp chalresp --generate --touch 2`.');
+    console.log('');
+
+    // Collect existing credentials from the LOGIN keychain BEFORE activating
+    // dedicated mode (challenge file absent -> activeKeychainPath() is null).
+    const { readProfileIndex } = await import('./profiles.js');
+    const { loadCredentialBlob, saveCredentialBlob } = await import('./credentials-store.js');
+
+    const idx = await readProfileIndex();
+    const names = new Set<string>([DEFAULT_PROFILE, ...idx.profiles.map((p) => p.name)]);
+    const blobs: { profile: string; blob: string }[] = [];
+    for (const name of names) {
+      const { blob } = await loadCredentialBlob(name);
+      if (blob) blobs.push({ profile: name, blob });
+    }
+    console.log(
+      `Found ${blobs.length} credential set(s) to copy: ${
+        blobs.map((b) => b.profile).join(', ') || '(none)'
+      }`,
+    );
+    console.log('');
+
+    // Derive the keychain password from the YubiKey (requires a tap). Done
+    // before creating the keychain so a missed tap leaves nothing behind.
+    const challenge = kt.generateChallenge();
+    console.log('Tap your YubiKey when it blinks...');
+    let password: string;
+    try {
+      password = kt.computeChallengeResponse(challenge);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const created = kt.createDedicatedKeychain(kcPath, password);
+    if (created === 'exists') {
+      console.error(`Unexpected: keychain already exists at ${kcPath}. Aborting.`);
+      process.exit(1);
+    }
+    kt.setLockOnSleep(kcPath);
+
+    // Activate dedicated mode: now activeKeychainPath() resolves to kcPath and
+    // saveCredentialBlob targets the new (still-unlocked) keychain.
+    kt.writeChallenge(challenge);
+
+    let copied = 0;
+    for (const { profile, blob } of blobs) {
+      try {
+        await saveCredentialBlob(blob, profile);
+        copied++;
+      } catch (err) {
+        console.error(
+          `  ! failed to copy "${profile}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    console.log('');
+    console.log(`Done. Created ${kcPath}, copied ${copied}/${blobs.length} credential set(s).`);
+    console.log('The keychain is unlocked now and will lock when your Mac sleeps.');
+    console.log('Next session: `noxctl keychain unlock` (one tap).');
+    console.log('When you trust it: `noxctl keychain seal` to delete the login-keychain copies.');
+  });
+
+keychain
+  .command('seal')
+  .description('Delete the login-keychain credential copies left by `init` (irreversible)')
+  .option('--yes', 'Skip the confirmation prompt')
+  .action(async (opts: { yes?: boolean }) => {
+    requireDarwin();
+    const kt = await import('./keychain-target.js');
+
+    const activePath = kt.activeKeychainPath();
+    if (!activePath) {
+      console.error(
+        'Dedicated keychain mode is not active — nothing to seal. Run `noxctl keychain init` first.',
+      );
+      process.exit(1);
+    }
+    if (kt.keychainLockState(activePath) === 'locked') {
+      console.error(
+        'Dedicated keychain is locked — run `noxctl keychain unlock` first so the copies can be verified before the originals are deleted.',
+      );
+      process.exit(1);
+    }
+
+    const { readProfileIndex } = await import('./profiles.js');
+    const { LEGACY_KEYCHAIN_ACCOUNT, keychainAccount } = await import('./profile-name.js');
+    const { loadCredentialBlob } = await import('./credentials-store.js');
+
+    const idx = await readProfileIndex();
+    const uniqueNames = [
+      ...new Set([DEFAULT_PROFILE, ...idx.profiles.map((p) => p.name)].map((n) => n.toLowerCase())),
+    ];
+
+    // Verify the dedicated keychain actually holds each profile's creds before
+    // deleting the login originals — never strand the user with no copy.
+    const verified: string[] = [];
+    for (const name of uniqueNames) {
+      const { blob } = await loadCredentialBlob(name);
+      if (blob) verified.push(name);
+    }
+    if (verified.length === 0) {
+      console.error(
+        'The dedicated keychain holds no credentials — refusing to delete the login copies.',
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      `Verified ${verified.length} credential set(s) in the dedicated keychain: ${verified.join(', ')}`,
+    );
+    const confirmed = await localConfirm(
+      'Delete the login-keychain copies now? This cannot be undone.',
+      opts.yes,
+    );
+    if (!confirmed) {
+      console.log('Aborted. Login-keychain copies left in place.');
+      return;
+    }
+
+    // Accounts init may have written to the login keychain: the legacy
+    // "default" account plus profile:<name> for every known profile.
+    const accounts = new Set<string>([LEGACY_KEYCHAIN_ACCOUNT]);
+    for (const name of uniqueNames) accounts.add(keychainAccount(name));
+
+    let deleted = 0;
+    for (const account of accounts) {
+      if (kt.deleteLoginSecret(account)) deleted++;
+    }
+    console.log(`Deleted ${deleted} login-keychain entr${deleted === 1 ? 'y' : 'ies'}.`);
+    console.log('Credentials now live only in the YubiKey-locked keychain.');
   });
 
 // --- serve (default command) ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   outputConfirmation,
   formatTaxReport,
   formatFinancialReport,
+  errorEnvelope,
 } from './formatter.js';
 import {
   readActivePointer,
@@ -2779,6 +2780,12 @@ try {
       process.exit(1);
     }
   }
-  console.error(err instanceof Error ? err.message : err);
+  if (json()) {
+    // Structured mode fails structured: scripted callers branch on .error
+    // instead of string-scraping stderr.
+    console.error(JSON.stringify(errorEnvelope(err), null, 2));
+  } else {
+    console.error(err instanceof Error ? err.message : err);
+  }
   process.exit(1);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,9 @@ import {
   priceListDetailColumns,
   priceListColumns,
   priceDetailColumns,
+  financialYearListColumns,
+  financialYearDetailColumns,
+  lockedPeriodDetailColumns,
 } from './views.js';
 
 const program = new Command();
@@ -2830,6 +2833,53 @@ prices
     }
     const data = await updatePrice(opts.pricelist, opts.article, fields, opts.fromQuantity);
     outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
+  });
+
+// --- financial years ---
+const financialYears = program
+  .command('financial-years')
+  .description('Financial year and locked period operations');
+
+financialYears
+  .command('list')
+  .description('List financial years (räkenskapsår)')
+  .option('--date <date>', 'Find the financial year containing this date (YYYY-MM-DD)')
+  .action(async (opts: { date?: string }) => {
+    const { listFinancialYears } = await import('./operations/financial-years.js');
+    const data = await listFinancialYears({ date: opts.date });
+    outputList(
+      data.FinancialYears ?? [],
+      financialYearListColumns,
+      json(),
+      data,
+      data.MetaInformation,
+    );
+  });
+
+financialYears
+  .command('get <id>')
+  .description('Get a single financial year')
+  .action(async (id: string) => {
+    const { getFinancialYear } = await import('./operations/financial-years.js');
+    const data = await getFinancialYear(parseInt(id, 10));
+    outputDetail(data, financialYearDetailColumns, json(), 'FinancialYear');
+  });
+
+financialYears
+  .command('locked-period')
+  .description('Show the locked period (bokföring låst t.o.m.)')
+  .action(async () => {
+    const { getLockedPeriod } = await import('./operations/financial-years.js');
+    const data = await getLockedPeriod();
+    if (json()) {
+      console.log(JSON.stringify({ LockedPeriod: data }, null, 2));
+      return;
+    }
+    if (!data.EndDate) {
+      console.log('No period is locked.');
+      return;
+    }
+    outputDetail(data, lockedPeriodDetailColumns, false);
   });
 
 // --- completion ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,13 @@ async function confirmMutation(
   const company = await fetchCompanyHint();
   const suffix = company ? ` (${company})` : '';
 
+  // Show what will actually be sent so the user can verify before confirming.
+  if (payload !== undefined) {
+    console.log('Request payload:');
+    console.log(JSON.stringify(payload, null, 2));
+    console.log();
+  }
+
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -898,6 +898,12 @@ keychain
     );
     console.log(`  ykman installed   ${kt.ykmanAvailable() ? 'yes' : 'no (brew install ykman)'}`);
     console.log(`  YubiKey present   ${kt.yubikeyPresent() ? 'yes' : 'no'}`);
+    const enrolledSerial = kt.readEnrolledSerial();
+    console.log(`  Enrolled serial   ${enrolledSerial ?? 'not recorded'}`);
+    if (enrolledSerial) {
+      const mismatch = kt.diagnoseSerialMismatch(enrolledSerial, kt.listYubikeySerials());
+      if (mismatch) console.log(`\n  ${mismatch}`);
+    }
 
     if (activePath && lockState === 'locked') {
       console.log('\n  Locked — run `noxctl keychain unlock` (tap your YubiKey).');
@@ -926,6 +932,13 @@ keychain
       console.error(
         'Challenge file missing — cannot derive the unlock password. Re-run `noxctl keychain init`.',
       );
+      process.exit(1);
+    }
+    // Preflight: a wrong/absent key is diagnosable from serials alone, before
+    // burning a tap on a challenge that can only fail.
+    const mismatch = kt.diagnoseSerialMismatch(kt.readEnrolledSerial(), kt.listYubikeySerials());
+    if (mismatch) {
+      console.error(mismatch);
       process.exit(1);
     }
     console.log('Tap your YubiKey when it blinks...');
@@ -1040,6 +1053,18 @@ keychain
     // Activate dedicated mode: now activeKeychainPath() resolves to kcPath and
     // saveCredentialBlob targets the new (still-unlocked) keychain.
     kt.writeChallenge(challenge);
+
+    // Remember which physical key answered the enrollment challenge so unlock
+    // can distinguish "wrong key inserted" from "missed tap" later.
+    const serials = kt.listYubikeySerials();
+    if (serials.length === 1) {
+      kt.writeEnrolledSerial(serials[0]);
+      console.log(`Enrolled against YubiKey serial ${serials[0]}.`);
+    } else if (serials.length > 1) {
+      console.log(
+        `Multiple YubiKeys present (${serials.join(', ')}) — not recording an enrolled serial.`,
+      );
+    }
 
     let copied = 0;
     for (const { profile, blob } of blobs) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
   type ResolvedProfile,
 } from './profiles.js';
 import { setResolvedProfile } from './auth.js';
+import { applyPeriod } from './date-periods.js';
 import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
 import {
   invoiceListColumns,
@@ -79,6 +80,14 @@ program
 
 function json(): boolean {
   return isJsonMode(program.opts());
+}
+
+function fromToParams(opts: { period?: string; from?: string; to?: string }): {
+  fromDate?: string;
+  toDate?: string;
+} {
+  const { from, to } = applyPeriod(opts);
+  return { fromDate: from, toDate: to };
 }
 
 let resolvedProfileInfo: ResolvedProfile = { name: DEFAULT_PROFILE, source: 'default' };
@@ -1140,6 +1149,10 @@ invoices
   .option('--customer <number>', 'Filter by customer number')
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
   .option('-a, --all', 'Fetch all pages')
@@ -1148,8 +1161,7 @@ invoices
     const data = await listInvoices({
       filter: opts.filter,
       customerNumber: opts.customer,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
       page: opts.page,
       limit: opts.limit,
       all: opts.all,
@@ -1322,14 +1334,23 @@ const tax = program.command('tax').description('Tax operations');
 tax
   .command('report')
   .description('Generate VAT tax report for a period')
-  .requiredOption('--from <date>', 'From date (YYYY-MM-DD)')
-  .requiredOption('--to <date>', 'To date (YYYY-MM-DD)')
+  .option('--from <date>', 'From date (YYYY-MM-DD)')
+  .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--year <number>', 'Financial year', parseInt)
   .action(async (opts) => {
     const { generateTaxReport } = await import('./operations/tax.js');
+    const range = fromToParams(opts);
+    if (!range.fromDate || !range.toDate) {
+      console.error('tax report requires a period: --from/--to or --period.');
+      process.exit(2);
+    }
     const data = await generateTaxReport({
-      fromDate: opts.from,
-      toDate: opts.to,
+      fromDate: range.fromDate,
+      toDate: range.toDate,
       financialYear: opts.year,
     });
     if (json()) {
@@ -1351,12 +1372,15 @@ reports
   .option('--year <number>', 'Financial year', parseInt)
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .action(async (opts) => {
     const { getIncomeStatement } = await import('./operations/financial-reports.js');
     const data = await getIncomeStatement({
       financialYear: opts.year,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
     });
     if (json()) {
       console.log(JSON.stringify(data, null, 2));
@@ -1704,6 +1728,10 @@ supplierInvoices
   .option('--supplier <number>', 'Filter by supplier number')
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
   .option('-a, --all', 'Fetch all pages')
@@ -1712,8 +1740,7 @@ supplierInvoices
     const data = await listSupplierInvoices({
       filter: opts.filter,
       supplierNumber: opts.supplier,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
       page: opts.page,
       limit: opts.limit,
       all: opts.all,
@@ -1825,6 +1852,10 @@ vouchers
   .option('--series <series>', 'Voucher series (e.g. "A")')
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--year <number>', 'Financial year', parseInt)
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
@@ -1833,8 +1864,7 @@ vouchers
     const { listVouchers } = await import('./operations/vouchers.js');
     const data = await listVouchers({
       series: opts.series,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
       financialYear: opts.year,
       page: opts.page,
       limit: opts.limit,
@@ -2132,6 +2162,10 @@ offers
   .option('--customer <number>', 'Filter by customer number')
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
   .option('-a, --all', 'Fetch all pages')
@@ -2140,8 +2174,7 @@ offers
     const data = await listOffers({
       filter: opts.filter,
       customerNumber: opts.customer,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
       page: opts.page,
       limit: opts.limit,
       all: opts.all,
@@ -2260,6 +2293,10 @@ orders
   .option('--customer <number>', 'Filter by customer number')
   .option('--from <date>', 'From date (YYYY-MM-DD)')
   .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, this-quarter, last-quarter, this-month, last-month, ytd, this-year, last-year, or a bare year. Mutually exclusive with --from/--to.',
+  )
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
   .option('-a, --all', 'Fetch all pages')
@@ -2268,8 +2305,7 @@ orders
     const data = await listOrders({
       filter: opts.filter,
       customerNumber: opts.customer,
-      fromDate: opts.from,
-      toDate: opts.to,
+      ...fromToParams(opts),
       page: opts.page,
       limit: opts.limit,
       all: opts.all,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,20 @@ function json(): boolean {
   return isJsonMode(program.opts());
 }
 
+// Emit a fatal error honoring -o json mode (structured envelope to stderr) vs
+// plain text, then exit. Validation failures inside command actions must go
+// through this so they don't bypass the JSON error contract the way a bare
+// console.error would. The top-level catch handles thrown errors the same way;
+// this is for the cases where we want a specific non-1 exit code.
+function fail(message: string, exitCode = 1): never {
+  if (json()) {
+    console.error(JSON.stringify(errorEnvelope(new Error(message)), null, 2));
+  } else {
+    console.error(message);
+  }
+  process.exit(exitCode);
+}
+
 function fromToParams(opts: { period?: string; from?: string; to?: string }): {
   fromDate?: string;
   toDate?: string;
@@ -1377,8 +1391,7 @@ tax
     const { generateTaxReport } = await import('./operations/tax.js');
     const range = fromToParams(opts);
     if (!range.fromDate || !range.toDate) {
-      console.error('tax report requires a period: --from/--to or --period.');
-      process.exit(2);
+      fail('tax report requires a period: --from/--to or --period.', 2);
     }
     const data = await generateTaxReport({
       fromDate: range.fromDate,
@@ -2056,7 +2069,13 @@ invoicePayments
       return;
     }
     await deleteInvoicePayment(paymentNumber);
-    outputConfirmation(`Invoice payment ${paymentNumber} deleted.`, json(), {});
+    outputConfirmation(
+      `Invoice payment ${paymentNumber} deleted.`,
+      json(),
+      { Number: paymentNumber, deleted: true },
+      undefined,
+      'InvoicePayment',
+    );
   });
 
 invoicePayments
@@ -2181,7 +2200,13 @@ supplierInvoicePayments
       return;
     }
     await deleteSupplierInvoicePayment(paymentNumber);
-    outputConfirmation(`Supplier invoice payment ${paymentNumber} deleted.`, json(), {});
+    outputConfirmation(
+      `Supplier invoice payment ${paymentNumber} deleted.`,
+      json(),
+      { Number: paymentNumber, deleted: true },
+      undefined,
+      'SupplierInvoicePayment',
+    );
   });
 
 // --- offers ---
@@ -2600,7 +2625,13 @@ costcenters
       return;
     }
     await deleteCostCenter(code);
-    console.log(`Cost center ${code} deleted.`);
+    outputConfirmation(
+      `Cost center ${code} deleted.`,
+      json(),
+      { Code: code, deleted: true },
+      undefined,
+      'CostCenter',
+    );
   });
 
 // --- tax reductions (ROT/RUT) ---
@@ -3107,8 +3138,7 @@ analytics
     const { getVatSummary } = await import('./operations/analytics.js');
     const range = fromToParams(opts);
     if (!range.fromDate || !range.toDate) {
-      console.error('analytics vat requires a period: --from/--to or --period.');
-      process.exit(2);
+      fail('analytics vat requires a period: --from/--to or --period.', 2);
     }
     const summary = await getVatSummary({
       fromDate: range.fromDate,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,8 @@ import {
   lockedPeriodDetailColumns,
   contractListColumns,
   contractDetailColumns,
+  topCustomerColumns,
+  monthlyRevenueColumns,
 } from './views.js';
 
 const program = new Command();
@@ -3020,6 +3022,146 @@ financialYears
       return;
     }
     outputDetail(data, lockedPeriodDetailColumns, false);
+  });
+
+// --- analytics ---
+const analytics = program
+  .command('analytics')
+  .description('Precomputed analytics views (overdue, unpaid, top customers, VAT)');
+
+analytics
+  .command('overdue')
+  .description('Overdue invoices summary')
+  .action(async () => {
+    const { getOverdueSummary } = await import('./operations/analytics.js');
+    const summary = await getOverdueSummary();
+    if (json()) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+    if (summary.count === 0) {
+      console.log('No overdue invoices.');
+      return;
+    }
+    console.log(
+      `Overdue: ${summary.count} invoice(s), ${summary.totalBalance.toFixed(2)} outstanding. Oldest due ${summary.oldestDueDate}.\n`,
+    );
+    outputList(summary.invoices, invoiceListColumns, false, summary.invoices);
+  });
+
+analytics
+  .command('unpaid')
+  .description('Unpaid totals (outstanding receivables)')
+  .action(async () => {
+    const { getUnpaidTotals } = await import('./operations/analytics.js');
+    const s = await getUnpaidTotals();
+    if (json()) {
+      console.log(JSON.stringify(s, null, 2));
+      return;
+    }
+    console.log(`Unpaid:  ${s.count} invoice(s), ${s.totalBalance.toFixed(2)} outstanding.`);
+    console.log(`Overdue: ${s.overdueCount} invoice(s), ${s.overdueBalance.toFixed(2)}.`);
+  });
+
+analytics
+  .command('top-customers')
+  .description('Top customers by invoiced amount')
+  .option('--from <date>', 'From date (YYYY-MM-DD)')
+  .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, last-quarter, ytd, ... Mutually exclusive with --from/--to.',
+  )
+  .option('--limit <number>', 'Number of customers (default 10)', parseInt)
+  .action(async (opts) => {
+    const { getTopCustomers } = await import('./operations/analytics.js');
+    const range = fromToParams(opts);
+    const result = await getTopCustomers({
+      fromDate: range.fromDate,
+      toDate: range.toDate,
+      limit: opts.limit,
+    });
+    if (json()) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    outputList(
+      result.customers.map((c) => ({ ...c })),
+      topCustomerColumns,
+      false,
+      result.customers,
+    );
+  });
+
+analytics
+  .command('vat')
+  .description('VAT summary for a period (net VAT position)')
+  .option('--from <date>', 'From date (YYYY-MM-DD)')
+  .option('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--period <period>',
+    'Natural period (calendar-year): Q1, 2025-Q3, march/mars, last-quarter, ytd, ... Mutually exclusive with --from/--to.',
+  )
+  .option('--year <number>', 'Financial year', parseInt)
+  .action(async (opts) => {
+    const { getVatSummary } = await import('./operations/analytics.js');
+    const range = fromToParams(opts);
+    if (!range.fromDate || !range.toDate) {
+      console.error('analytics vat requires a period: --from/--to or --period.');
+      process.exit(2);
+    }
+    const summary = await getVatSummary({
+      fromDate: range.fromDate,
+      toDate: range.toDate,
+      financialYear: opts.year,
+    });
+    if (json()) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+    console.log(formatTaxReport(summary));
+    console.log(
+      `\nNet VAT: ${(summary.netVat as number).toFixed(2)} (negative = owed to Skatteverket)`,
+    );
+  });
+
+// --- dashboard ---
+program
+  .command('dashboard')
+  .description('At-a-glance summary: recent invoices, outstanding, overdue, monthly revenue')
+  .option('--months <number>', 'Months of revenue history (default 6)', parseInt)
+  .action(async (opts: { months?: number }) => {
+    const { getDashboard } = await import('./operations/analytics.js');
+    const dash = await getDashboard({ months: opts.months });
+    if (json()) {
+      console.log(JSON.stringify(dash, null, 2));
+      return;
+    }
+
+    console.log('OUTSTANDING');
+    console.log(
+      `  Unpaid:  ${dash.unpaid.count} invoice(s), ${dash.unpaid.totalBalance.toFixed(2)}`,
+    );
+    console.log(
+      `  Overdue: ${dash.overdue.count} invoice(s), ${dash.overdue.totalBalance.toFixed(2)}` +
+        (dash.overdue.oldestDueDate ? ` (oldest due ${dash.overdue.oldestDueDate})` : ''),
+    );
+
+    if (dash.overdue.count > 0) {
+      console.log('\nOVERDUE INVOICES');
+      outputList(dash.overdue.invoices, invoiceListColumns, false, dash.overdue.invoices);
+    }
+
+    console.log('\nRECENT INVOICES');
+    outputList(dash.recentInvoices, invoiceListColumns, false, dash.recentInvoices);
+
+    console.log('\nMONTHLY INVOICED');
+    outputList(
+      dash.monthlyRevenue.map((m) => ({ ...m })),
+      monthlyRevenueColumns,
+      false,
+      dash.monthlyRevenue,
+    );
   });
 
 // --- completion ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,10 +159,10 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     // loudly but continue so `doctor` / `profile use` can repair the state.
     const wouldRelyOnPointer = !flag && !env;
     if (wouldRelyOnPointer && name === 'serve') {
-      console.error(
+      fail(
         `Active profile pointer ${desc}. Refusing to start MCP server with ambiguous profile. Run \`noxctl doctor\` or set NOXCTL_PROFILE explicitly.`,
+        2,
       );
-      process.exit(2);
     }
     process.stderr.write(`[warning: active-profile pointer ${desc}; ignoring]\n`);
   }
@@ -171,8 +171,7 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     resolvedProfileInfo = resolveProfile({ flag, env, pointer });
   } catch (err) {
     if (err instanceof InvalidProfileNameError) {
-      console.error(err.message);
-      process.exit(2);
+      fail(err.message, 2);
     }
     throw err;
   }
@@ -263,8 +262,7 @@ async function confirmMutation(
 
 function requireDarwin(): void {
   if (process.platform !== 'darwin') {
-    console.error('The dedicated YubiKey-locked keychain is a macOS-only feature.');
-    process.exit(2);
+    fail('The dedicated YubiKey-locked keychain is a macOS-only feature.', 2);
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ program
   .description('CLI and MCP server for Fortnox accounting')
   .version('0.2.0')
   .addOption(
-    new Option('-o, --output <format>', 'Output format')
+    new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])
       .default(undefined),
   )
@@ -1159,7 +1159,7 @@ invoices
   .action(async (documentNumber: string) => {
     const { getInvoice } = await import('./operations/invoices.js');
     const data = await getInvoice(documentNumber);
-    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json(), 'Invoice');
   });
 
 invoices
@@ -1191,7 +1191,7 @@ Examples:
       return;
     }
     const data = await createInvoice(params);
-    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json(), 'Invoice');
   });
 
 invoices
@@ -1216,7 +1216,7 @@ Examples:
         return;
       }
       const data = await updateInvoice(documentNumber, fields);
-      outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, invoiceDetailColumns, json(), 'Invoice');
     },
   );
 
@@ -1263,6 +1263,7 @@ invoices
         json(),
         data,
         invoiceConfirmColumns,
+        'Invoice',
       );
     },
   );
@@ -1278,7 +1279,13 @@ invoices
       return;
     }
     const data = await bookkeepInvoice(documentNumber);
-    outputConfirmation(`Invoice ${documentNumber} bookkeept.`, json(), data, invoiceConfirmColumns);
+    outputConfirmation(
+      `Invoice ${documentNumber} bookkeept.`,
+      json(),
+      data,
+      invoiceConfirmColumns,
+      'Invoice',
+    );
   });
 
 invoices
@@ -1292,7 +1299,13 @@ invoices
       return;
     }
     const data = await creditInvoice(documentNumber);
-    outputConfirmation(`Invoice ${documentNumber} credited.`, json(), data, invoiceConfirmColumns);
+    outputConfirmation(
+      `Invoice ${documentNumber} credited.`,
+      json(),
+      data,
+      invoiceConfirmColumns,
+      'Invoice',
+    );
   });
 
 // --- tax ---
@@ -1420,7 +1433,7 @@ customers
   .action(async (customerNumber: string) => {
     const { getCustomer } = await import('./operations/customers.js');
     const data = await getCustomer(customerNumber);
-    outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, customerDetailColumns, json(), 'Customer');
   });
 
 customers
@@ -1449,7 +1462,7 @@ Examples:
       return;
     }
     const data = await createCustomer(params);
-    outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, customerDetailColumns, json(), 'Customer');
   });
 
 customers
@@ -1475,7 +1488,7 @@ Examples:
         return;
       }
       const data = await updateCustomer(customerNumber, fields);
-      outputDetail(data as Record<string, unknown>, customerDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, customerDetailColumns, json(), 'Customer');
     },
   );
 
@@ -1510,7 +1523,7 @@ articles
   .action(async (articleNumber: string) => {
     const { getArticle } = await import('./operations/articles.js');
     const data = await getArticle(articleNumber);
-    outputDetail(data as Record<string, unknown>, articleDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, articleDetailColumns, json(), 'Article');
   });
 
 articles
@@ -1543,7 +1556,7 @@ Examples:
       return;
     }
     const data = await createArticle(params);
-    outputDetail(data as Record<string, unknown>, articleDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, articleDetailColumns, json(), 'Article');
   });
 
 articles
@@ -1567,7 +1580,7 @@ Examples:
         return;
       }
       const data = await updateArticle(articleNumber, fields);
-      outputDetail(data as Record<string, unknown>, articleDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, articleDetailColumns, json(), 'Article');
     },
   );
 
@@ -1608,7 +1621,7 @@ suppliers
   .action(async (supplierNumber: string) => {
     const { getSupplier } = await import('./operations/suppliers.js');
     const data = await getSupplier(supplierNumber);
-    outputDetail(data as Record<string, unknown>, supplierDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, supplierDetailColumns, json(), 'Supplier');
   });
 
 suppliers
@@ -1637,7 +1650,7 @@ Examples:
       return;
     }
     const data = await createSupplier(params);
-    outputDetail(data as Record<string, unknown>, supplierDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, supplierDetailColumns, json(), 'Supplier');
   });
 
 suppliers
@@ -1663,7 +1676,7 @@ Examples:
         return;
       }
       const data = await updateSupplier(supplierNumber, fields);
-      outputDetail(data as Record<string, unknown>, supplierDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, supplierDetailColumns, json(), 'Supplier');
     },
   );
 
@@ -1716,7 +1729,12 @@ supplierInvoices
   .action(async (givenNumber: string) => {
     const { getSupplierInvoice } = await import('./operations/supplier-invoices.js');
     const data = await getSupplierInvoice(givenNumber);
-    outputDetail(data as Record<string, unknown>, supplierInvoiceDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      supplierInvoiceDetailColumns,
+      json(),
+      'SupplierInvoice',
+    );
   });
 
 supplierInvoices
@@ -1745,7 +1763,12 @@ Examples:
       return;
     }
     const data = await createSupplierInvoice(params);
-    outputDetail(data as Record<string, unknown>, supplierInvoiceDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      supplierInvoiceDetailColumns,
+      json(),
+      'SupplierInvoice',
+    );
   });
 
 supplierInvoices
@@ -1764,6 +1787,7 @@ supplierInvoices
       json(),
       data,
       supplierInvoiceConfirmColumns,
+      'SupplierInvoice',
     );
   });
 
@@ -1776,7 +1800,12 @@ company
   .action(async () => {
     const { getCompanyInfo } = await import('./operations/company.js');
     const data = await getCompanyInfo();
-    outputDetail(data as Record<string, unknown>, companyDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      companyDetailColumns,
+      json(),
+      'CompanyInformation',
+    );
   });
 
 // --- vouchers ---
@@ -1818,7 +1847,7 @@ vouchers
     const { getVoucher } = await import('./operations/vouchers.js');
     const data = await getVoucher(series, voucherNumber, opts.year);
     if (json()) {
-      console.log(JSON.stringify(data, null, 2));
+      console.log(JSON.stringify({ Voucher: data }, null, 2));
     } else {
       outputDetail(data as Record<string, unknown>, voucherDetailColumns, false);
       const rows = (data as Record<string, unknown>).VoucherRows as Record<string, unknown>[];
@@ -1853,7 +1882,7 @@ Examples:
       return;
     }
     const data = await createVoucher(params);
-    outputDetail(data as Record<string, unknown>, voucherDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, voucherDetailColumns, json(), 'Voucher');
   });
 
 // --- invoice-payments ---
@@ -1896,7 +1925,12 @@ invoicePayments
   .action(async (paymentNumber: string) => {
     const { getInvoicePayment } = await import('./operations/invoice-payments.js');
     const data = await getInvoicePayment(paymentNumber);
-    outputDetail(data as Record<string, unknown>, invoicePaymentDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      invoicePaymentDetailColumns,
+      json(),
+      'InvoicePayment',
+    );
   });
 
 invoicePayments
@@ -1933,7 +1967,12 @@ Examples:
       return;
     }
     const data = await createInvoicePayment(params);
-    outputDetail(data as Record<string, unknown>, invoicePaymentDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      invoicePaymentDetailColumns,
+      json(),
+      'InvoicePayment',
+    );
   });
 
 invoicePayments
@@ -1961,7 +2000,13 @@ invoicePayments
       return;
     }
     const result = await bookkeepInvoicePayment(paymentNumber);
-    outputConfirmation(`Invoice payment ${paymentNumber} bookkeept.`, json(), result);
+    outputConfirmation(
+      `Invoice payment ${paymentNumber} bookkeept.`,
+      json(),
+      result,
+      undefined,
+      'InvoicePayment',
+    );
   });
 
 // --- supplier-invoice-payments ---
@@ -2005,7 +2050,12 @@ supplierInvoicePayments
   .action(async (paymentNumber: string) => {
     const { getSupplierInvoicePayment } = await import('./operations/supplier-invoice-payments.js');
     const data = await getSupplierInvoicePayment(paymentNumber);
-    outputDetail(data as Record<string, unknown>, supplierInvoicePaymentDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      supplierInvoicePaymentDetailColumns,
+      json(),
+      'SupplierInvoicePayment',
+    );
   });
 
 supplierInvoicePayments
@@ -2041,7 +2091,12 @@ Examples:
       return;
     }
     const data = await createSupplierInvoicePayment(params);
-    outputDetail(data as Record<string, unknown>, supplierInvoicePaymentDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      supplierInvoicePaymentDetailColumns,
+      json(),
+      'SupplierInvoicePayment',
+    );
   });
 
 supplierInvoicePayments
@@ -2096,7 +2151,7 @@ offers
   .action(async (documentNumber: string) => {
     const { getOffer } = await import('./operations/offers.js');
     const data = await getOffer(documentNumber);
-    outputDetail(data as Record<string, unknown>, offerDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, offerDetailColumns, json(), 'Offer');
   });
 
 offers
@@ -2125,7 +2180,7 @@ Examples:
       return;
     }
     const data = await createOffer(params);
-    outputDetail(data as Record<string, unknown>, offerDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, offerDetailColumns, json(), 'Offer');
   });
 
 offers
@@ -2143,7 +2198,7 @@ offers
         return;
       }
       const data = await updateOffer(documentNumber, fields);
-      outputDetail(data as Record<string, unknown>, offerDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, offerDetailColumns, json(), 'Offer');
     },
   );
 
@@ -2163,6 +2218,7 @@ offers
       json(),
       data,
       invoiceConfirmColumns,
+      'Invoice',
     );
   });
 
@@ -2177,7 +2233,13 @@ offers
       return;
     }
     const data = await createOrderFromOffer(documentNumber);
-    outputConfirmation(`Order created from offer ${documentNumber}.`, json(), data);
+    outputConfirmation(
+      `Order created from offer ${documentNumber}.`,
+      json(),
+      data,
+      undefined,
+      'Order',
+    );
   });
 
 // --- orders ---
@@ -2217,7 +2279,7 @@ orders
   .action(async (documentNumber: string) => {
     const { getOrder } = await import('./operations/orders.js');
     const data = await getOrder(documentNumber);
-    outputDetail(data as Record<string, unknown>, orderDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, orderDetailColumns, json(), 'Order');
   });
 
 orders
@@ -2246,7 +2308,7 @@ Examples:
       return;
     }
     const data = await createOrder(params);
-    outputDetail(data as Record<string, unknown>, orderDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, orderDetailColumns, json(), 'Order');
   });
 
 orders
@@ -2264,7 +2326,7 @@ orders
         return;
       }
       const data = await updateOrder(documentNumber, fields);
-      outputDetail(data as Record<string, unknown>, orderDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, orderDetailColumns, json(), 'Order');
     },
   );
 
@@ -2284,6 +2346,7 @@ orders
       json(),
       data,
       invoiceConfirmColumns,
+      'Invoice',
     );
   });
 
@@ -2316,7 +2379,7 @@ projects
   .action(async (projectNumber: string) => {
     const { getProject } = await import('./operations/projects.js');
     const data = await getProject(projectNumber);
-    outputDetail(data as Record<string, unknown>, projectDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, projectDetailColumns, json(), 'Project');
   });
 
 projects
@@ -2344,7 +2407,7 @@ projects
       return;
     }
     const data = await createProject(params);
-    outputDetail(data as Record<string, unknown>, projectDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, projectDetailColumns, json(), 'Project');
   });
 
 projects
@@ -2362,7 +2425,7 @@ projects
         return;
       }
       const data = await updateProject(projectNumber, fields);
-      outputDetail(data as Record<string, unknown>, projectDetailColumns, json());
+      outputDetail(data as Record<string, unknown>, projectDetailColumns, json(), 'Project');
     },
   );
 
@@ -2401,7 +2464,7 @@ costcenters
   .action(async (code: string) => {
     const { getCostCenter } = await import('./operations/costcenters.js');
     const data = await getCostCenter(code);
-    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json(), 'CostCenter');
   });
 
 costcenters
@@ -2430,7 +2493,7 @@ costcenters
       return;
     }
     const data = await createCostCenter(params);
-    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json(), 'CostCenter');
   });
 
 costcenters
@@ -2447,7 +2510,7 @@ costcenters
       return;
     }
     const data = await updateCostCenter(code, fields);
-    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, costCenterDetailColumns, json(), 'CostCenter');
   });
 
 costcenters
@@ -2503,7 +2566,12 @@ taxreductions
   .action(async (id: string) => {
     const { getTaxReduction } = await import('./operations/taxreductions.js');
     const data = await getTaxReduction(parseInt(id, 10));
-    outputDetail(data as Record<string, unknown>, taxReductionDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      taxReductionDetailColumns,
+      json(),
+      'TaxReduction',
+    );
   });
 
 taxreductions
@@ -2544,7 +2612,12 @@ taxreductions
       return;
     }
     const data = await createTaxReduction(params);
-    outputDetail(data as Record<string, unknown>, taxReductionDetailColumns, json());
+    outputDetail(
+      data as Record<string, unknown>,
+      taxReductionDetailColumns,
+      json(),
+      'TaxReduction',
+    );
   });
 
 // --- price lists ---
@@ -2582,7 +2655,7 @@ pricelists
   .action(async (code: string) => {
     const { getPriceList } = await import('./operations/pricelists.js');
     const data = await getPriceList(code);
-    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json(), 'PriceList');
   });
 
 pricelists
@@ -2609,7 +2682,7 @@ pricelists
       return;
     }
     const data = await createPriceList(params);
-    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json(), 'PriceList');
   });
 
 pricelists
@@ -2626,7 +2699,7 @@ pricelists
       return;
     }
     const data = await updatePriceList(code, fields);
-    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, priceListDetailColumns, json(), 'PriceList');
   });
 
 // --- prices ---
@@ -2663,7 +2736,7 @@ prices
   .action(async (opts) => {
     const { getPrice } = await import('./operations/pricelists.js');
     const data = await getPrice(opts.pricelist, opts.article, opts.fromQuantity);
-    outputDetail(data as Record<string, unknown>, priceDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
   });
 
 prices
@@ -2687,7 +2760,7 @@ prices
       return;
     }
     const data = await updatePrice(opts.pricelist, opts.article, fields, opts.fromQuantity);
-    outputDetail(data as Record<string, unknown>, priceDetailColumns, json());
+    outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
   });
 
 // Error handling

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,7 @@ export function getResolvedProfileInfo(): ResolvedProfile {
 }
 
 // Commands that don't need (and shouldn't require) a resolved profile.
-const PROFILE_RESOLUTION_SKIP = new Set(['help']);
+const PROFILE_RESOLUTION_SKIP = new Set(['help', 'completion']);
 
 program.hook('preAction', async (thisCommand, actionCommand) => {
   const name = actionCommand.name();
@@ -2769,6 +2769,23 @@ prices
     }
     const data = await updatePrice(opts.pricelist, opts.article, fields, opts.fromQuantity);
     outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
+  });
+
+// --- completion ---
+program
+  .command('completion <shell>')
+  .description('Generate shell completion script (bash, zsh, fish)')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  noxctl completion bash > /usr/local/etc/bash_completion.d/noxctl
+  noxctl completion zsh > "\${fpath[1]}/_noxctl"
+  noxctl completion fish > ~/.config/fish/completions/noxctl.fish`,
+  )
+  .action(async (shell: string) => {
+    const { extractCommandTree, renderCompletion } = await import('./completions.js');
+    console.log(renderCompletion(shell, extractCommandTree(program)));
   });
 
 // Error handling

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,23 @@ function json(): boolean {
   return isJsonMode(program.opts());
 }
 
+// Suppress Commander's own plain-text usage errors (unknown command, missing
+// required option, ...) when in JSON mode, so the top-level catch can emit a
+// structured error envelope instead of leaving non-JSON on stderr. In table
+// mode, keep Commander's friendly usage message.
+//
+// Both configureOutput and exitOverride must be set HERE, before the command
+// tree is built: Commander only copies these settings into subcommands created
+// *after* they're configured on the parent. Set at the bottom, a subcommand's
+// parse error would call process.exit() directly and bypass the catch below
+// (leaving JSON-mode failures with no envelope).
+program.configureOutput({
+  outputError: (str, write) => {
+    if (!json()) write(str);
+  },
+});
+program.exitOverride();
+
 // Emit a fatal error honoring -o json mode (structured envelope to stderr) vs
 // plain text, then exit. Validation failures inside command actions must go
 // through this so they don't bypass the JSON error contract the way a bare
@@ -3211,27 +3228,27 @@ Examples:
     console.log(renderCompletion(shell, extractCommandTree(program)));
   });
 
-// Error handling
-program.exitOverride();
-
+// Error handling (configureOutput + exitOverride set above, before the command
+// tree, so subcommands inherit them).
 try {
   await program.parseAsync(process.argv);
 } catch (err) {
-  if (err instanceof Error && 'code' in err) {
-    const code = (err as { code: string }).code;
-    // Commander throws for --help and --version with exitCode 0
-    if (code === 'commander.helpDisplayed' || code === 'commander.version') {
-      process.exit(0);
-    }
-    if (code === 'commander.unknownCommand' || code === 'commander.missingMandatoryOptionValue') {
-      process.exit(1);
-    }
+  const code = err instanceof Error && 'code' in err ? (err as { code: string }).code : undefined;
+  // Commander throws these for --help and --version after writing output; exit 0.
+  if (code === 'commander.helpDisplayed' || code === 'commander.version') {
+    process.exit(0);
   }
+  // Commander parse errors (unknownCommand, missingMandatoryOptionValue,
+  // excessArguments, ...) carry a `commander.*` code. configureOutput above
+  // already wrote their plain-text usage message in table mode, so we must not
+  // print it again here; in JSON mode that output was suppressed, so we emit
+  // the structured envelope below instead.
+  const isCommanderParseError = typeof code === 'string' && code.startsWith('commander.');
   if (json()) {
     // Structured mode fails structured: scripted callers branch on .error
     // instead of string-scraping stderr.
     console.error(JSON.stringify(errorEnvelope(err), null, 2));
-  } else {
+  } else if (!isCommanderParseError) {
     console.error(err instanceof Error ? err.message : err);
   }
   process.exit(1);

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,185 @@
+import type { Command } from 'commander';
+
+export interface CommandNode {
+  name: string;
+  description: string;
+  options: string[];
+  subcommands: CommandNode[];
+}
+
+export function extractCommandTree(cmd: Command): CommandNode {
+  return {
+    name: cmd.name(),
+    description: cmd.description(),
+    options: cmd.options.map((o) => o.long).filter((l): l is string => Boolean(l)),
+    subcommands: cmd.commands
+      .filter((sub) => sub.name() !== 'help')
+      .map((sub) => extractCommandTree(sub as Command)),
+  };
+}
+
+function shellEscapeSingle(str: string): string {
+  return str.replace(/'/g, "'\\''");
+}
+
+export function renderBashCompletion(tree: CommandNode): string {
+  const lines: string[] = [
+    '# bash completion for noxctl',
+    '# Install: noxctl completion bash > /usr/local/etc/bash_completion.d/noxctl',
+    '#      or: eval "$(noxctl completion bash)"',
+    '_noxctl_completions() {',
+    '  local cur prev words',
+    '  cur="${COMP_WORDS[COMP_CWORD]}"',
+    '  local cmd="" sub=""',
+    '  local i',
+    '  for ((i=1; i < COMP_CWORD; i++)); do',
+    '    case "${COMP_WORDS[i]}" in',
+    '      -*) continue ;;',
+    '      *) if [[ -z "$cmd" ]]; then cmd="${COMP_WORDS[i]}"; elif [[ -z "$sub" ]]; then sub="${COMP_WORDS[i]}"; fi ;;',
+    '    esac',
+    '  done',
+    '  local opts=""',
+    '  if [[ -z "$cmd" ]]; then',
+    `    opts="${tree.subcommands.map((c) => c.name).join(' ')} ${tree.options.join(' ')}"`,
+    '  else',
+    '    case "$cmd" in',
+  ];
+
+  for (const cmd of tree.subcommands) {
+    lines.push(`      ${cmd.name})`);
+    if (cmd.subcommands.length > 0) {
+      lines.push('        if [[ -z "$sub" ]]; then');
+      lines.push(
+        `          opts="${cmd.subcommands.map((c) => c.name).join(' ')} ${cmd.options.join(' ')}"`,
+      );
+      lines.push('        else');
+      lines.push('          case "$sub" in');
+      for (const sub of cmd.subcommands) {
+        lines.push(`            ${sub.name}) opts="${sub.options.join(' ')}" ;;`);
+      }
+      lines.push('          esac');
+      lines.push('        fi');
+    } else {
+      lines.push(`        opts="${cmd.options.join(' ')}"`);
+    }
+    lines.push('        ;;');
+  }
+
+  lines.push(
+    '    esac',
+    '  fi',
+    '  COMPREPLY=( $(compgen -W "$opts" -- "$cur") )',
+    '}',
+    'complete -F _noxctl_completions noxctl',
+    '',
+  );
+  return lines.join('\n');
+}
+
+export function renderZshCompletion(tree: CommandNode): string {
+  const lines: string[] = [
+    '#compdef noxctl',
+    '# zsh completion for noxctl',
+    '# Install: noxctl completion zsh > "${fpath[1]}/_noxctl" && compinit',
+    '',
+    '_noxctl() {',
+    '  local -a commands',
+    '  local curcontext="$curcontext" state line',
+    '  _arguments -C \\',
+    ...tree.options.map((o) => `    '${o}[option]' \\`),
+    "    '1: :->command' \\",
+    "    '*: :->args'",
+    '',
+    '  case $state in',
+    '    command)',
+    '      commands=(',
+    ...tree.subcommands.map(
+      (c) => `        '${c.name}:${shellEscapeSingle(c.description || c.name)}'`,
+    ),
+    '      )',
+    "      _describe 'command' commands",
+    '      ;;',
+    '    args)',
+    '      case $words[2] in',
+  ];
+
+  for (const cmd of tree.subcommands) {
+    if (cmd.subcommands.length === 0 && cmd.options.length === 0) continue;
+    lines.push(`        ${cmd.name})`);
+    if (cmd.subcommands.length > 0) {
+      lines.push('          local -a subcommands');
+      lines.push('          subcommands=(');
+      for (const sub of cmd.subcommands) {
+        lines.push(`            '${sub.name}:${shellEscapeSingle(sub.description || sub.name)}'`);
+      }
+      lines.push('          )');
+      lines.push('          if (( CURRENT == 3 )); then');
+      lines.push("            _describe 'subcommand' subcommands");
+      lines.push('          else');
+      lines.push('            case $words[3] in');
+      for (const sub of cmd.subcommands) {
+        if (sub.options.length === 0) continue;
+        lines.push(
+          `              ${sub.name}) _arguments ${sub.options.map((o) => `'${o}[option]'`).join(' ')} ;;`,
+        );
+      }
+      lines.push('            esac');
+      lines.push('          fi');
+    } else {
+      lines.push(`          _arguments ${cmd.options.map((o) => `'${o}[option]'`).join(' ')}`);
+    }
+    lines.push('          ;;');
+  }
+
+  lines.push('      esac', '      ;;', '  esac', '}', '', '_noxctl "$@"', '');
+  return lines.join('\n');
+}
+
+export function renderFishCompletion(tree: CommandNode): string {
+  const lines: string[] = [
+    '# fish completion for noxctl',
+    '# Install: noxctl completion fish > ~/.config/fish/completions/noxctl.fish',
+    '',
+  ];
+
+  const topNames = tree.subcommands.map((c) => c.name).join(' ');
+  for (const cmd of tree.subcommands) {
+    lines.push(
+      `complete -c noxctl -f -n "not __fish_seen_subcommand_from ${topNames}" -a ${cmd.name} -d '${shellEscapeSingle(cmd.description || '')}'`,
+    );
+    const subNames = cmd.subcommands.map((c) => c.name).join(' ');
+    for (const sub of cmd.subcommands) {
+      lines.push(
+        `complete -c noxctl -f -n "__fish_seen_subcommand_from ${cmd.name}; and not __fish_seen_subcommand_from ${subNames}" -a ${sub.name} -d '${shellEscapeSingle(sub.description || '')}'`,
+      );
+      for (const opt of sub.options) {
+        lines.push(
+          `complete -c noxctl -f -n "__fish_seen_subcommand_from ${sub.name}" -l ${opt.replace(/^--/, '')}`,
+        );
+      }
+    }
+    for (const opt of cmd.options) {
+      lines.push(
+        `complete -c noxctl -f -n "__fish_seen_subcommand_from ${cmd.name}" -l ${opt.replace(/^--/, '')}`,
+      );
+    }
+  }
+  for (const opt of tree.options) {
+    lines.push(`complete -c noxctl -l ${opt.replace(/^--/, '')}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function renderCompletion(shell: string, tree: CommandNode): string {
+  switch (shell) {
+    case 'bash':
+      return renderBashCompletion(tree);
+    case 'zsh':
+      return renderZshCompletion(tree);
+    case 'fish':
+      return renderFishCompletion(tree);
+    default:
+      throw new Error(`Unsupported shell "${shell}". Supported: bash, zsh, fish.`);
+  }
+}

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -11,6 +11,7 @@ import {
   validateProfileName,
 } from './profile-name.js';
 import { configDir } from './config-paths.js';
+import { activeKeychainPath, readDedicatedSecret } from './keychain-target.js';
 
 function legacyCredentialsFile(): string {
   return path.join(configDir(), 'credentials.json');
@@ -114,6 +115,12 @@ function decodeHexIfNeeded(value: string): string {
 }
 
 function loadMacSecret(account: string): string | null {
+  // Dedicated-keychain mode: read prompt-free from the YubiKey-locked keychain.
+  // A locked keychain throws KeychainLockedError (propagated so the caller can
+  // tell the user to run `noxctl keychain unlock`), not a silent null.
+  const dedicated = activeKeychainPath();
+  if (dedicated) return readDedicatedSecret(account, dedicated);
+
   try {
     const raw = execFileSync(
       'security',
@@ -133,6 +140,11 @@ function saveMacSecret(account: string, secret: string): void {
   // the Security framework — the secret never appears in process arguments.
   const scriptPath = path.join(os.tmpdir(), `noxctl-keychain-${process.pid}.swift`);
 
+  // In dedicated-keychain mode, target that keychain file; otherwise the
+  // default (login) keychain. The path is passed as argv (not interpolated) so
+  // an odd path can't break or inject into the Swift source.
+  const keychainPath = activeKeychainPath() ?? '';
+
   // account is either LEGACY_KEYCHAIN_ACCOUNT ("default") or `profile:<validated>`.
   // Validation in profile-name.ts restricts the character set so embedding is safe.
   const swiftScript = `
@@ -145,20 +157,30 @@ guard let password = String(data: data, encoding: .utf8) else { exit(1) }
 let service = "${SERVICE_NAME}"
 let account = "${account}"
 
-let deleteQuery: [String: Any] = [
+let kcPath = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : ""
+var useKeychain: SecKeychain? = nil
+if !kcPath.isEmpty {
+  var kc: SecKeychain?
+  if SecKeychainOpen(kcPath, &kc) == errSecSuccess { useKeychain = kc }
+  else { exit(1) }
+}
+
+var deleteQuery: [String: Any] = [
   kSecClass as String: kSecClassGenericPassword,
   kSecAttrService as String: service,
   kSecAttrAccount as String: account
 ]
+if let kc = useKeychain { deleteQuery[kSecMatchSearchList as String] = [kc] }
 SecItemDelete(deleteQuery as CFDictionary)
 
 let pwData = password.data(using: String.Encoding.utf8)!
-let addQuery: [String: Any] = [
+var addQuery: [String: Any] = [
   kSecClass as String: kSecClassGenericPassword,
   kSecAttrService as String: service,
   kSecAttrAccount as String: account,
   kSecValueData as String: pwData
 ]
+if let kc = useKeychain { addQuery[kSecUseKeychain as String] = kc }
 let status = SecItemAdd(addQuery as CFDictionary, nil)
 if status != errSecSuccess { exit(1) }
 `;
@@ -166,7 +188,7 @@ if status != errSecSuccess { exit(1) }
   try {
     fsSync.writeFileSync(scriptPath, swiftScript, { mode: 0o600 });
 
-    const result = spawnSync('swift', [scriptPath], {
+    const result = spawnSync('swift', [scriptPath, keychainPath], {
       input: secret,
       encoding: 'utf-8',
     });
@@ -175,7 +197,8 @@ if status != errSecSuccess { exit(1) }
       throw new Error(result.stderr || 'Swift keychain helper failed');
     }
   } catch {
-    // Fallback to security CLI if Swift is unavailable or fails
+    // Fallback to security CLI if Swift is unavailable or fails. The optional
+    // trailing keychain positional targets the dedicated keychain when set.
     execFileSync('security', [
       'add-generic-password',
       '-a',
@@ -185,6 +208,7 @@ if status != errSecSuccess { exit(1) }
       '-w',
       secret,
       '-U',
+      ...(keychainPath ? [keychainPath] : []),
     ]);
   } finally {
     try {
@@ -354,8 +378,16 @@ export async function saveCredentialBlob(
 }
 
 function deleteMacSecret(account: string): boolean {
+  const keychainPath = activeKeychainPath();
   try {
-    execFileSync('security', ['delete-generic-password', '-a', account, '-s', SERVICE_NAME]);
+    execFileSync('security', [
+      'delete-generic-password',
+      '-a',
+      account,
+      '-s',
+      SERVICE_NAME,
+      ...(keychainPath ? [keychainPath] : []),
+    ]);
     return true;
   } catch {
     return false;

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -196,20 +196,20 @@ if status != errSecSuccess { exit(1) }
     if (result.status !== 0) {
       throw new Error(result.stderr || 'Swift keychain helper failed');
     }
-  } catch {
-    // Fallback to security CLI if Swift is unavailable or fails. The optional
-    // trailing keychain positional targets the dedicated keychain when set.
-    execFileSync('security', [
-      'add-generic-password',
-      '-a',
-      account,
-      '-s',
-      SERVICE_NAME,
-      '-w',
-      secret,
-      '-U',
-      ...(keychainPath ? [keychainPath] : []),
-    ]);
+  } catch (err) {
+    // Fail closed rather than fall back to `security add-generic-password -w
+    // <secret>`: that CLI only accepts the password via the argv `-w` slot
+    // (briefly visible to other processes via `ps`) or an interactive prompt,
+    // so a fallback would leak the credential into process arguments — exactly
+    // what the stdin-based Swift writer above exists to avoid. `swift` ships
+    // with the Xcode Command Line Tools, so guide the user to install them.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not store credentials securely: the Swift Keychain helper failed (${detail}). ` +
+        `The 'swift' toolchain is required to write credentials without exposing them in ` +
+        `process arguments — install the Xcode Command Line Tools with 'xcode-select --install' ` +
+        `and try again.`,
+    );
   } finally {
     try {
       fsSync.unlinkSync(scriptPath);

--- a/src/date-periods.ts
+++ b/src/date-periods.ts
@@ -1,0 +1,125 @@
+// Natural date-period parsing for CLI --period arguments.
+//
+// Periods are CALENDAR-year based. Fortnox supports broken fiscal years;
+// a fiscal-year-aware design is tracked separately — until then "Q1" always
+// means January–March of the named (or current) calendar year.
+
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+const EN_MONTHS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+];
+
+const SV_MONTHS = [
+  'januari',
+  'februari',
+  'mars',
+  'april',
+  'maj',
+  'juni',
+  'juli',
+  'augusti',
+  'september',
+  'oktober',
+  'november',
+  'december',
+];
+
+function iso(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function lastDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+function monthRange(year: number, month: number): DateRange {
+  return { from: iso(year, month, 1), to: iso(year, month, lastDayOfMonth(year, month)) };
+}
+
+function quarterRange(year: number, quarter: number): DateRange {
+  const startMonth = (quarter - 1) * 3 + 1;
+  const endMonth = startMonth + 2;
+  return {
+    from: iso(year, startMonth, 1),
+    to: iso(year, endMonth, lastDayOfMonth(year, endMonth)),
+  };
+}
+
+function yearRange(year: number): DateRange {
+  return { from: iso(year, 1, 1), to: iso(year, 12, 31) };
+}
+
+export function resolvePeriod(period: string, today: Date = new Date()): DateRange {
+  const input = period.trim().toLowerCase();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1; // 1-based
+  const quarter = Math.ceil(month / 3);
+
+  // Q1..Q4, optionally year-qualified (2025-Q3 or 2025Q3)
+  const quarterMatch = /^(?:(\d{4})-?)?q([1-4])$/.exec(input);
+  if (quarterMatch) {
+    return quarterRange(
+      quarterMatch[1] ? parseInt(quarterMatch[1], 10) : year,
+      parseInt(quarterMatch[2], 10),
+    );
+  }
+
+  // Bare year
+  if (/^\d{4}$/.test(input)) return yearRange(parseInt(input, 10));
+
+  // Month names (English and Swedish), current calendar year
+  const enIdx = EN_MONTHS.indexOf(input);
+  if (enIdx !== -1) return monthRange(year, enIdx + 1);
+  const svIdx = SV_MONTHS.indexOf(input);
+  if (svIdx !== -1) return monthRange(year, svIdx + 1);
+
+  switch (input) {
+    case 'this-quarter':
+      return quarterRange(year, quarter);
+    case 'last-quarter':
+      return quarter === 1 ? quarterRange(year - 1, 4) : quarterRange(year, quarter - 1);
+    case 'this-month':
+      return monthRange(year, month);
+    case 'last-month':
+      return month === 1 ? monthRange(year - 1, 12) : monthRange(year, month - 1);
+    case 'this-year':
+      return yearRange(year);
+    case 'last-year':
+      return yearRange(year - 1);
+    case 'ytd':
+      return { from: iso(year, 1, 1), to: iso(year, month, today.getDate()) };
+  }
+
+  throw new Error(
+    `Unrecognized period "${period}". Supported: Q1–Q4, 2025-Q3, month names (march/mars), ` +
+      'this-quarter, last-quarter, this-month, last-month, this-year, last-year, ytd, or a bare year. ' +
+      'Periods are calendar-year based.',
+  );
+}
+
+// Shared by CLI actions: merge --period into from/to, rejecting ambiguous mixes.
+export function applyPeriod(opts: { period?: string; from?: string; to?: string }): {
+  from?: string;
+  to?: string;
+} {
+  if (!opts.period) return { from: opts.from, to: opts.to };
+  if (opts.from || opts.to) {
+    throw new Error('--period cannot be combined with --from/--to.');
+  }
+  return resolvePeriod(opts.period);
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -260,9 +260,11 @@ export function outputDetail(
   record: Record<string, unknown>,
   columns: Column[],
   json: boolean,
+  jsonEnvelopeKey?: string,
 ): void {
   if (json) {
-    console.log(JSON.stringify(record, null, 2));
+    const payload = jsonEnvelopeKey ? { [jsonEnvelopeKey]: record } : record;
+    console.log(JSON.stringify(payload, null, 2));
     return;
   }
   console.log(formatDetail(record, columns));
@@ -273,9 +275,11 @@ export function outputConfirmation(
   json: boolean,
   rawData: unknown,
   columns?: Column[],
+  jsonEnvelopeKey?: string,
 ): void {
   if (json) {
-    console.log(JSON.stringify(rawData, null, 2));
+    const payload = jsonEnvelopeKey ? { [jsonEnvelopeKey]: rawData } : rawData;
+    console.log(JSON.stringify(payload, null, 2));
     return;
   }
   console.log(message);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -270,6 +270,39 @@ export function outputDetail(
   console.log(formatDetail(record, columns));
 }
 
+export interface ErrorEnvelope {
+  error: {
+    status?: number;
+    message: string;
+    hint?: string;
+    source: 'fortnox-api' | 'noxctl';
+  };
+}
+
+// Duck-typed rather than instanceof so the formatter stays decoupled from
+// fortnox-client (and survives errors crossing module-instance boundaries).
+export function errorEnvelope(err: unknown): ErrorEnvelope {
+  if (
+    err instanceof Error &&
+    err.name === 'FortnoxApiError' &&
+    'statusCode' in err &&
+    'fortnoxMessage' in err
+  ) {
+    const apiErr = err as Error & { statusCode: number; fortnoxMessage: string; hint?: string };
+    return {
+      error: {
+        status: apiErr.statusCode,
+        message: apiErr.fortnoxMessage,
+        ...(apiErr.hint ? { hint: apiErr.hint } : {}),
+        source: 'fortnox-api',
+      },
+    };
+  }
+  return {
+    error: { message: err instanceof Error ? err.message : String(err), source: 'noxctl' },
+  };
+}
+
 export function outputConfirmation(
   message: string,
   json: boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { registerCostCenterTools } from './tools/costcenters.js';
 import { registerTaxReductionTools } from './tools/taxreductions.js';
 import { registerPriceListTools } from './tools/pricelists.js';
 import { registerFinancialYearTools } from './tools/financial-years.js';
+import { registerContractTools } from './tools/contracts.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -48,6 +49,7 @@ export function createServer(): McpServer {
   registerTaxReductionTools(server);
   registerPriceListTools(server);
   registerFinancialYearTools(server);
+  registerContractTools(server);
 
   return server;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { registerTaxReductionTools } from './tools/taxreductions.js';
 import { registerPriceListTools } from './tools/pricelists.js';
 import { registerFinancialYearTools } from './tools/financial-years.js';
 import { registerContractTools } from './tools/contracts.js';
+import { registerAnalyticsTools } from './tools/analytics.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -50,6 +51,7 @@ export function createServer(): McpServer {
   registerPriceListTools(server);
   registerFinancialYearTools(server);
   registerContractTools(server);
+  registerAnalyticsTools(server);
 
   return server;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { registerProjectTools } from './tools/projects.js';
 import { registerCostCenterTools } from './tools/costcenters.js';
 import { registerTaxReductionTools } from './tools/taxreductions.js';
 import { registerPriceListTools } from './tools/pricelists.js';
+import { registerFinancialYearTools } from './tools/financial-years.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -46,6 +47,7 @@ export function createServer(): McpServer {
   registerCostCenterTools(server);
   registerTaxReductionTools(server);
   registerPriceListTools(server);
+  registerFinancialYearTools(server);
 
   return server;
 }

--- a/src/keychain-target.ts
+++ b/src/keychain-target.ts
@@ -1,0 +1,311 @@
+import os from 'node:os';
+import path from 'node:path';
+import fsSync from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { configDir } from './config-paths.js';
+
+const SERVICE_NAME = 'fortnox-mcp';
+
+// OTP slot programmed for HMAC-SHA1 challenge-response. Slot 2 is the
+// conventional "long-press / second" slot and is what `noxctl keychain init`
+// expects the user to have programmed with `ykman otp chalresp --generate --touch 2`.
+export const CR_SLOT = '2';
+
+// Thrown when the dedicated keychain exists but is locked. Distinct from
+// "no credentials" so callers can tell the user to run `noxctl keychain unlock`
+// (tap the YubiKey) rather than `noxctl init`.
+export class KeychainLockedError extends Error {
+  constructor(
+    message = 'Fortnox keychain is locked — run `noxctl keychain unlock` (tap your YubiKey)',
+  ) {
+    super(message);
+    this.name = 'KeychainLockedError';
+  }
+}
+
+// Thrown when a challenge-response operation fails — most often a missed touch
+// (ykman reports "Failed to write to the YubiKey" when the tap window lapses).
+export class ChallengeResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChallengeResponseError';
+  }
+}
+
+export function dedicatedKeychainPath(): string {
+  const home = process.env.HOME || os.homedir() || '~';
+  return path.join(home, 'Library', 'Keychains', 'fortnox-mcp.keychain-db');
+}
+
+export function loginKeychainPath(): string {
+  const home = process.env.HOME || os.homedir() || '~';
+  return path.join(home, 'Library', 'Keychains', 'login.keychain-db');
+}
+
+export function challengeFilePath(): string {
+  return path.join(configDir(), 'keychain-challenge');
+}
+
+// Resolve which keychain credential operations should target.
+//   1. NOXCTL_KEYCHAIN_PATH env override (used by tests and power users).
+//   2. darwin only: the dedicated keychain + its challenge file both exist.
+//   3. otherwise null — caller falls back to the login keychain (legacy behavior).
+// The challenge file gates files-exist detection so a half-created keychain
+// (file present, never `init`-ed) doesn't silently divert reads.
+export function activeKeychainPath(): string | null {
+  const override = process.env.NOXCTL_KEYCHAIN_PATH;
+  if (override && override.trim()) return override;
+  if (process.platform !== 'darwin') return null;
+  if (fsSync.existsSync(dedicatedKeychainPath()) && fsSync.existsSync(challengeFilePath())) {
+    return dedicatedKeychainPath();
+  }
+  return null;
+}
+
+export function isDedicatedModeActive(): boolean {
+  return activeKeychainPath() !== null;
+}
+
+function decodeBase64(value: string): string {
+  return Buffer.from(value.trim(), 'base64').toString('utf-8');
+}
+
+// Read a generic-password secret from a specific keychain WITHOUT triggering
+// the macOS GUI unlock dialog. With challenge-response we cannot type the
+// keychain password into that dialog, so on a locked keychain we must fail
+// fast (KeychainLockedError) instead of popping an un-fillable prompt.
+//
+// SecKeychainSetUserInteractionAllowed(false) makes a locked keychain return
+// errSecInteractionNotAllowed rather than prompting. Account and keychain path
+// are passed as argv (not string-interpolated) so an odd path can't break or
+// inject into the Swift source. Returns null when the item is absent.
+export function readDedicatedSecret(account: string, keychainPath: string): string | null {
+  const swiftScript = `
+import Foundation
+import Security
+
+let service = "${SERVICE_NAME}"
+let account = CommandLine.arguments[1]
+let kcPath = CommandLine.arguments[2]
+
+var kc: SecKeychain?
+let openStatus = SecKeychainOpen(kcPath, &kc)
+if openStatus != errSecSuccess || kc == nil { exit(3) }
+
+SecKeychainSetUserInteractionAllowed(false)
+
+let query: [String: Any] = [
+  kSecClass as String: kSecClassGenericPassword,
+  kSecAttrService as String: service,
+  kSecAttrAccount as String: account,
+  kSecMatchSearchList as String: [kc!],
+  kSecReturnData as String: true,
+  kSecMatchLimit as String: kSecMatchLimitOne
+]
+var item: CFTypeRef?
+let status = SecItemCopyMatching(query as CFDictionary, &item)
+if status == errSecSuccess, let data = item as? Data {
+  FileHandle.standardOutput.write(data.base64EncodedData())
+  exit(0)
+}
+if status == errSecInteractionNotAllowed || status == errSecAuthFailed { exit(2) }
+exit(3)
+`;
+  const scriptPath = path.join(os.tmpdir(), `noxctl-kcread-${process.pid}.swift`);
+  try {
+    fsSync.writeFileSync(scriptPath, swiftScript, { mode: 0o600 });
+    const result = spawnSync('swift', [scriptPath, account, keychainPath], { encoding: 'utf-8' });
+    if (result.status === 0) return decodeBase64(result.stdout);
+    if (result.status === 2) throw new KeychainLockedError();
+    return null;
+  } finally {
+    try {
+      fsSync.unlinkSync(scriptPath);
+    } catch {
+      // ignore cleanup failure
+    }
+  }
+}
+
+// The fixed challenge is NOT a secret — the secret lives inside the YubiKey.
+// It's a stable random value so the same key always derives the same keychain
+// password. 32 bytes -> 64 hex chars; `ykman otp calculate` wants hex.
+export function generateChallenge(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function readChallenge(): string | null {
+  try {
+    const raw = fsSync.readFileSync(challengeFilePath(), 'utf-8').trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeChallenge(challengeHex: string): void {
+  fsSync.mkdirSync(configDir(), { recursive: true, mode: 0o700 });
+  fsSync.writeFileSync(challengeFilePath(), `${challengeHex}\n`, { mode: 0o600 });
+}
+
+export function ykmanAvailable(): boolean {
+  const r = spawnSync('ykman', ['--version'], { encoding: 'utf-8' });
+  return r.status === 0;
+}
+
+export function yubikeyPresent(): boolean {
+  const r = spawnSync('ykman', ['list'], { encoding: 'utf-8' });
+  return r.status === 0 && r.stdout.trim().length > 0;
+}
+
+// Ask the YubiKey (OTP slot CR_SLOT) to HMAC the fixed challenge. Touch is
+// required, so ykman's "Touch your YubiKey..." prompt is inherited to the
+// terminal. A missed tap exits non-zero ("Failed to write to the YubiKey").
+// The 40-hex response is the keychain password — returned, never logged.
+export function computeChallengeResponse(challengeHex: string): string {
+  const r = spawnSync('ykman', ['otp', 'calculate', CR_SLOT, challengeHex], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  if (r.error && (r.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    throw new ChallengeResponseError('ykman not found — install it with `brew install ykman`');
+  }
+  if (r.status !== 0) {
+    throw new ChallengeResponseError(
+      'Challenge-response failed. This is usually a missed touch — re-run and tap the key firmly when it blinks.',
+    );
+  }
+  const response = (r.stdout || '').trim();
+  if (!/^[0-9a-fA-F]{40}$/.test(response)) {
+    throw new ChallengeResponseError(
+      `Unexpected challenge-response output (expected 40 hex chars)`,
+    );
+  }
+  return response;
+}
+
+function runSwift(script: string, args: string[], input?: string): number {
+  const scriptPath = path.join(os.tmpdir(), `noxctl-kc-${process.pid}-${Date.now()}.swift`);
+  try {
+    fsSync.writeFileSync(scriptPath, script, { mode: 0o600 });
+    const r = spawnSync('swift', [scriptPath, ...args], {
+      input,
+      encoding: 'utf-8',
+      stdio: input === undefined ? 'pipe' : ['pipe', 'pipe', 'pipe'],
+    });
+    if (r.error) throw r.error;
+    return r.status ?? 1;
+  } finally {
+    try {
+      fsSync.unlinkSync(scriptPath);
+    } catch {
+      // ignore cleanup failure
+    }
+  }
+}
+
+// Create a file-based keychain at keychainPath with the given password (fed via
+// stdin, never argv). Returns 'created', or 'exists' if one is already there.
+export function createDedicatedKeychain(
+  keychainPath: string,
+  password: string,
+): 'created' | 'exists' {
+  const script = `
+import Foundation
+import Security
+
+let data = FileHandle.standardInput.readDataToEndOfFile()
+guard let password = String(data: data, encoding: .utf8) else { exit(1) }
+let kcPath = CommandLine.arguments[1]
+let pwBytes = Array(password.utf8)
+var kc: SecKeychain?
+let status = SecKeychainCreate(kcPath, UInt32(pwBytes.count), pwBytes, false, nil, &kc)
+if status == errSecDuplicateKeychain { exit(4) }
+if status != errSecSuccess { exit(1) }
+`;
+  const code = runSwift(script, [keychainPath], password);
+  if (code === 4) return 'exists';
+  if (code !== 0) throw new Error('Failed to create keychain');
+  return 'created';
+}
+
+// Unlock the keychain with the given password (fed via stdin). Throws on a
+// wrong password (e.g. a different YubiKey or re-programmed slot).
+export function unlockDedicatedKeychain(keychainPath: string, password: string): void {
+  const script = `
+import Foundation
+import Security
+
+let data = FileHandle.standardInput.readDataToEndOfFile()
+guard let password = String(data: data, encoding: .utf8) else { exit(1) }
+let kcPath = CommandLine.arguments[1]
+var kc: SecKeychain?
+if SecKeychainOpen(kcPath, &kc) != errSecSuccess || kc == nil { exit(3) }
+let pwBytes = Array(password.utf8)
+let status = SecKeychainUnlock(kc!, UInt32(pwBytes.count), pwBytes, true)
+if status != errSecSuccess { exit(2) }
+`;
+  const code = runSwift(script, [keychainPath], password);
+  if (code === 3)
+    throw new Error(`Keychain not found at ${keychainPath} — run \`noxctl keychain init\``);
+  if (code !== 0) {
+    throw new Error(
+      'Unlock failed — wrong response. Is this the YubiKey you set up, with slot 2 intact?',
+    );
+  }
+}
+
+export type LockState = 'locked' | 'unlocked' | 'missing';
+
+export function keychainLockState(keychainPath: string): LockState {
+  const script = `
+import Foundation
+import Security
+
+let kcPath = CommandLine.arguments[1]
+var kc: SecKeychain?
+if SecKeychainOpen(kcPath, &kc) != errSecSuccess || kc == nil { print("missing"); exit(0) }
+var st: SecKeychainStatus = 0
+if SecKeychainGetStatus(kc!, &st) != errSecSuccess { print("missing"); exit(0) }
+if (st & SecKeychainStatus(kSecUnlockStateStatus)) != 0 { print("unlocked") } else { print("locked") }
+`;
+  const scriptPath = path.join(os.tmpdir(), `noxctl-kcstat-${process.pid}.swift`);
+  try {
+    fsSync.writeFileSync(scriptPath, script, { mode: 0o600 });
+    const r = spawnSync('swift', [scriptPath, keychainPath], { encoding: 'utf-8' });
+    const out = (r.stdout || '').trim();
+    if (out === 'unlocked' || out === 'locked' || out === 'missing') return out;
+    return 'missing';
+  } finally {
+    try {
+      fsSync.unlinkSync(scriptPath);
+    } catch {
+      // ignore cleanup failure
+    }
+  }
+}
+
+// Lock when the system sleeps, no idle timeout. This is the per-session secret:
+// one tap on wake, open until next sleep.
+export function setLockOnSleep(keychainPath: string): void {
+  spawnSync('security', ['set-keychain-settings', '-l', keychainPath], { encoding: 'utf-8' });
+}
+
+export function lockKeychain(keychainPath: string): void {
+  spawnSync('security', ['lock-keychain', keychainPath], { encoding: 'utf-8' });
+}
+
+// Delete a generic-password from the LOGIN keychain specifically. The login
+// keychain path is passed explicitly so this never touches the dedicated
+// keychain even if SecKeychainCreate added it to the session search list.
+// Used by `noxctl keychain seal` to remove the pre-migration login copies.
+// Returns true if an item was deleted (exit 0), false if none matched.
+export function deleteLoginSecret(account: string): boolean {
+  const r = spawnSync(
+    'security',
+    ['delete-generic-password', '-a', account, '-s', SERVICE_NAME, loginKeychainPath()],
+    { encoding: 'utf-8' },
+  );
+  return r.status === 0;
+}

--- a/src/keychain-target.ts
+++ b/src/keychain-target.ts
@@ -348,11 +348,25 @@ if (st & SecKeychainStatus(kSecUnlockStateStatus)) != 0 { print("unlocked") } el
 // Lock when the system sleeps, no idle timeout. This is the per-session secret:
 // one tap on wake, open until next sleep.
 export function setLockOnSleep(keychainPath: string): void {
-  spawnSync('security', ['set-keychain-settings', '-l', keychainPath], { encoding: 'utf-8' });
+  const r = spawnSync('security', ['set-keychain-settings', '-l', keychainPath], {
+    encoding: 'utf-8',
+  });
+  if (r.error) throw r.error;
+  if (r.status !== 0) {
+    throw new Error(
+      `security set-keychain-settings failed: ${(r.stderr || '').trim() || `exit ${r.status}`}`,
+    );
+  }
 }
 
 export function lockKeychain(keychainPath: string): void {
-  spawnSync('security', ['lock-keychain', keychainPath], { encoding: 'utf-8' });
+  const r = spawnSync('security', ['lock-keychain', keychainPath], { encoding: 'utf-8' });
+  if (r.error) throw r.error;
+  if (r.status !== 0) {
+    throw new Error(
+      `security lock-keychain failed: ${(r.stderr || '').trim() || `exit ${r.status}`}`,
+    );
+  }
 }
 
 // Delete a generic-password from the LOGIN keychain specifically. The login

--- a/src/keychain-target.ts
+++ b/src/keychain-target.ts
@@ -149,6 +149,53 @@ export function writeChallenge(challengeHex: string): void {
   fsSync.writeFileSync(challengeFilePath(), `${challengeHex}\n`, { mode: 0o600 });
 }
 
+export function enrolledSerialFilePath(): string {
+  return path.join(configDir(), 'keychain-serial');
+}
+
+// Serial of the YubiKey the keychain was enrolled against. Persisted at init
+// so unlock can tell "wrong/unenrolled key present" apart from "missed tap" —
+// the two failure modes produce indistinguishable ykman errors otherwise.
+export function readEnrolledSerial(): string | null {
+  try {
+    const raw = fsSync.readFileSync(enrolledSerialFilePath(), 'utf-8').trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeEnrolledSerial(serial: string): void {
+  fsSync.mkdirSync(configDir(), { recursive: true, mode: 0o700 });
+  fsSync.writeFileSync(enrolledSerialFilePath(), `${serial}\n`, { mode: 0o600 });
+}
+
+export function listYubikeySerials(): string[] {
+  const r = spawnSync('ykman', ['list', '--serials'], { encoding: 'utf-8' });
+  if (r.status !== 0) return [];
+  return (r.stdout || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function diagnoseSerialMismatch(
+  enrolledSerial: string | null,
+  presentSerials: string[],
+): string | null {
+  if (!enrolledSerial) return null;
+  if (presentSerials.includes(enrolledSerial)) return null;
+  if (presentSerials.length === 0) {
+    return `No YubiKey detected. The keychain was enrolled against YubiKey serial ${enrolledSerial} — insert that key and re-run.`;
+  }
+  return (
+    `Keychain was enrolled against YubiKey serial ${enrolledSerial}, but serial ` +
+    `${presentSerials.join(', ')} is currently present — this is a different key. ` +
+    `Insert the enrolled key, or re-enroll this one (program slot 2 with ` +
+    '`ykman otp chalresp --generate --touch 2`, then re-run `noxctl keychain init`).'
+  );
+}
+
 export function ykmanAvailable(): boolean {
   const r = spawnSync('ykman', ['--version'], { encoding: 'utf-8' });
   return r.status === 0;
@@ -166,14 +213,26 @@ export function yubikeyPresent(): boolean {
 export function computeChallengeResponse(challengeHex: string): string {
   const r = spawnSync('ykman', ['otp', 'calculate', CR_SLOT, challengeHex], {
     encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'inherit'],
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (r.error && (r.error as NodeJS.ErrnoException).code === 'ENOENT') {
     throw new ChallengeResponseError('ykman not found — install it with `brew install ykman`');
   }
   if (r.status !== 0) {
+    // ykman's own wording is misleading here: "Failed to write to the
+    // YubiKey... restricted access" is what a touch timeout produces, and
+    // "empty slot" means this key was never enrolled. Translate both.
+    const stderr = (r.stderr || '').toString();
+    if (/empty slot/i.test(stderr)) {
+      throw new ChallengeResponseError(
+        `Slot ${CR_SLOT} is not programmed on this YubiKey — it is not the enrolled key ` +
+          '(or its slot was wiped). Program it with `ykman otp chalresp --generate --touch 2` ' +
+          'or insert the enrolled key.',
+      );
+    }
     throw new ChallengeResponseError(
-      'Challenge-response failed. This is usually a missed touch — re-run and tap the key firmly when it blinks.',
+      'Challenge-response failed. This is usually a missed touch — re-run and tap the key firmly when it blinks.' +
+        (stderr.trim() ? `\n(ykman said: ${stderr.trim()})` : ''),
     );
   }
   const response = (r.stdout || '').trim();

--- a/src/operations/analytics.ts
+++ b/src/operations/analytics.ts
@@ -124,6 +124,16 @@ function todayIso(): string {
   return localIsoDate(new Date());
 }
 
+// Start of the dashboard revenue window: the 1st of the month (months - 1)
+// months before `today`, in local time. Built via the Date(year, monthIndex, 1)
+// overload so a negative/overflowing month index rolls the year correctly, and
+// pinning the day to 1 avoids end-of-month overflow — e.g. mutating a Jul-31
+// Date with setMonth(1) would land on "Feb 31" → March, silently dropping a
+// whole month from the window.
+export function dashboardWindowStart(today: Date, months: number): string {
+  return localIsoDate(new Date(today.getFullYear(), today.getMonth() - (months - 1), 1));
+}
+
 export async function getOverdueSummary(): Promise<OverdueSummary> {
   const data = await listInvoices({ filter: 'unpaidoverdue', all: true });
   return summarizeOverdue(data.Invoices ?? [], todayIso());
@@ -187,12 +197,9 @@ export interface Dashboard {
 // filtered fetch would be redundant — overdue/unpaid are derived locally).
 export async function getDashboard(options: { months?: number } = {}): Promise<Dashboard> {
   const months = options.months ?? 6;
-  const today = todayIso();
-
-  const fromDate = new Date();
-  fromDate.setMonth(fromDate.getMonth() - (months - 1));
-  fromDate.setDate(1);
-  const from = localIsoDate(fromDate);
+  const now = new Date();
+  const today = localIsoDate(now);
+  const from = dashboardWindowStart(now, months);
 
   // Two fetches: the windowed one for revenue/recent, and the unpaid filter
   // (which is date-independent — an old unpaid invoice may predate the window).

--- a/src/operations/analytics.ts
+++ b/src/operations/analytics.ts
@@ -1,0 +1,199 @@
+// Precomputed analytics views over invoice data. The aggregation functions are
+// pure (invoice rows in, summary out) so they can be unit-tested without the
+// API; the exported get* functions fetch via listInvoices and delegate.
+//
+// Amounts are summed in the invoice currency as returned by Fortnox (no FX
+// conversion) — for single-currency (SEK) tenants the totals are exact.
+
+import { listInvoices } from './invoices.js';
+import { generateTaxReport } from './tax.js';
+
+type InvoiceRow = Record<string, unknown>;
+
+function num(value: unknown): number {
+  const n = typeof value === 'number' ? value : parseFloat(String(value ?? ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function isCancelled(inv: InvoiceRow): boolean {
+  return inv.Cancelled === true;
+}
+
+function isOpen(inv: InvoiceRow): boolean {
+  return !isCancelled(inv) && num(inv.Balance) > 0;
+}
+
+function isOverdue(inv: InvoiceRow, today: string): boolean {
+  return isOpen(inv) && String(inv.DueDate ?? '') < today;
+}
+
+export interface OverdueSummary {
+  count: number;
+  totalBalance: number;
+  oldestDueDate: string | null;
+  invoices: InvoiceRow[];
+}
+
+export function summarizeOverdue(invoices: InvoiceRow[], today: string): OverdueSummary {
+  const overdue = invoices
+    .filter((inv) => isOverdue(inv, today))
+    .sort((a, b) => String(a.DueDate ?? '').localeCompare(String(b.DueDate ?? '')));
+  return {
+    count: overdue.length,
+    totalBalance: overdue.reduce((sum, inv) => sum + num(inv.Balance), 0),
+    oldestDueDate: overdue.length > 0 ? String(overdue[0].DueDate) : null,
+    invoices: overdue,
+  };
+}
+
+export interface UnpaidSummary {
+  count: number;
+  totalBalance: number;
+  overdueCount: number;
+  overdueBalance: number;
+}
+
+export function summarizeUnpaid(invoices: InvoiceRow[], today: string): UnpaidSummary {
+  const open = invoices.filter(isOpen);
+  const overdue = open.filter((inv) => isOverdue(inv, today));
+  return {
+    count: open.length,
+    totalBalance: open.reduce((sum, inv) => sum + num(inv.Balance), 0),
+    overdueCount: overdue.length,
+    overdueBalance: overdue.reduce((sum, inv) => sum + num(inv.Balance), 0),
+  };
+}
+
+export interface CustomerRevenue {
+  CustomerNumber: string;
+  CustomerName: string;
+  total: number;
+  invoiceCount: number;
+}
+
+export function topCustomersFrom(invoices: InvoiceRow[], limit: number): CustomerRevenue[] {
+  const byCustomer = new Map<string, CustomerRevenue>();
+  for (const inv of invoices) {
+    if (isCancelled(inv)) continue;
+    const key = String(inv.CustomerNumber ?? '');
+    const entry = byCustomer.get(key) ?? {
+      CustomerNumber: key,
+      CustomerName: String(inv.CustomerName ?? ''),
+      total: 0,
+      invoiceCount: 0,
+    };
+    entry.total += num(inv.Total);
+    entry.invoiceCount += 1;
+    byCustomer.set(key, entry);
+  }
+  return [...byCustomer.values()].sort((a, b) => b.total - a.total).slice(0, limit);
+}
+
+export interface MonthlyRevenue {
+  month: string; // YYYY-MM
+  total: number;
+  invoiceCount: number;
+}
+
+export function monthlyRevenueFrom(invoices: InvoiceRow[]): MonthlyRevenue[] {
+  const byMonth = new Map<string, MonthlyRevenue>();
+  for (const inv of invoices) {
+    if (isCancelled(inv)) continue;
+    const month = String(inv.InvoiceDate ?? '').slice(0, 7);
+    if (!/^\d{4}-\d{2}$/.test(month)) continue;
+    const entry = byMonth.get(month) ?? { month, total: 0, invoiceCount: 0 };
+    entry.total += num(inv.Total);
+    entry.invoiceCount += 1;
+    byMonth.set(month, entry);
+  }
+  return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month));
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function getOverdueSummary(): Promise<OverdueSummary> {
+  const data = await listInvoices({ filter: 'unpaidoverdue', all: true });
+  return summarizeOverdue(data.Invoices ?? [], todayIso());
+}
+
+export async function getUnpaidTotals(): Promise<UnpaidSummary> {
+  const data = await listInvoices({ filter: 'unpaid', all: true });
+  return summarizeUnpaid(data.Invoices ?? [], todayIso());
+}
+
+export interface TopCustomersParams {
+  fromDate?: string;
+  toDate?: string;
+  limit?: number;
+}
+
+export async function getTopCustomers(params: TopCustomersParams = {}): Promise<{
+  period: { from?: string; to?: string };
+  customers: CustomerRevenue[];
+}> {
+  const data = await listInvoices({ fromDate: params.fromDate, toDate: params.toDate, all: true });
+  return {
+    period: { from: params.fromDate, to: params.toDate },
+    customers: topCustomersFrom(data.Invoices ?? [], params.limit ?? 10),
+  };
+}
+
+export interface VatSummaryParams {
+  fromDate: string;
+  toDate: string;
+  financialYear?: number;
+}
+
+// Thin wrapper over the tax report adding the bottom line scripted callers
+// usually want: net VAT position (negative = owed to Skatteverket).
+export async function getVatSummary(params: VatSummaryParams) {
+  const report = await generateTaxReport(params);
+  let netVat = 0;
+  for (const acct of Object.values(report.vatAccounts ?? {})) {
+    netVat += (acct.debit ?? 0) - (acct.credit ?? 0);
+  }
+  return { ...report, netVat };
+}
+
+export interface Dashboard {
+  unpaid: UnpaidSummary;
+  overdue: OverdueSummary;
+  recentInvoices: InvoiceRow[];
+  monthlyRevenue: MonthlyRevenue[];
+}
+
+// At-a-glance summary composed from a single full invoice fetch (plus one
+// filtered fetch would be redundant — overdue/unpaid are derived locally).
+export async function getDashboard(options: { months?: number } = {}): Promise<Dashboard> {
+  const months = options.months ?? 6;
+  const today = todayIso();
+
+  const fromDate = new Date();
+  fromDate.setMonth(fromDate.getMonth() - (months - 1));
+  fromDate.setDate(1);
+  const from = fromDate.toISOString().slice(0, 10);
+
+  // Two fetches: the windowed one for revenue/recent, and the unpaid filter
+  // (which is date-independent — an old unpaid invoice may predate the window).
+  const [windowed, unpaidData] = await Promise.all([
+    listInvoices({ fromDate: from, toDate: today, all: true }),
+    listInvoices({ filter: 'unpaid', all: true }),
+  ]);
+
+  const windowedRows = windowed.Invoices ?? [];
+  const unpaidRows = unpaidData.Invoices ?? [];
+
+  const recentInvoices = [...windowedRows]
+    .filter((inv) => !isCancelled(inv))
+    .sort((a, b) => String(b.InvoiceDate ?? '').localeCompare(String(a.InvoiceDate ?? '')))
+    .slice(0, 5);
+
+  return {
+    unpaid: summarizeUnpaid(unpaidRows, today),
+    overdue: summarizeOverdue(unpaidRows, today),
+    recentInvoices,
+    monthlyRevenue: monthlyRevenueFrom(windowedRows),
+  };
+}

--- a/src/operations/analytics.ts
+++ b/src/operations/analytics.ts
@@ -109,8 +109,19 @@ export function monthlyRevenueFrom(invoices: InvoiceRow[]): MonthlyRevenue[] {
   return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month));
 }
 
+// Format a Date as YYYY-MM-DD using LOCAL calendar fields. Using toISOString()
+// here would format in UTC, so between local midnight and the UTC offset (e.g.
+// 00:00–02:00 in Sweden, UTC+1/+2) "today" would resolve to yesterday — skewing
+// overdue classification and the dashboard window by a day.
+export function localIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localIsoDate(new Date());
 }
 
 export async function getOverdueSummary(): Promise<OverdueSummary> {
@@ -146,15 +157,23 @@ export interface VatSummaryParams {
   financialYear?: number;
 }
 
+// Net VAT position across the report's VAT accounts: sum of (debit - credit).
+// Negative = net VAT owed to Skatteverket; positive = a refund is due.
+export function netVatFromVatAccounts(
+  vatAccounts: Record<number, { debit?: number; credit?: number }> | undefined,
+): number {
+  let netVat = 0;
+  for (const acct of Object.values(vatAccounts ?? {})) {
+    netVat += (acct.debit ?? 0) - (acct.credit ?? 0);
+  }
+  return netVat;
+}
+
 // Thin wrapper over the tax report adding the bottom line scripted callers
 // usually want: net VAT position (negative = owed to Skatteverket).
 export async function getVatSummary(params: VatSummaryParams) {
   const report = await generateTaxReport(params);
-  let netVat = 0;
-  for (const acct of Object.values(report.vatAccounts ?? {})) {
-    netVat += (acct.debit ?? 0) - (acct.credit ?? 0);
-  }
-  return { ...report, netVat };
+  return { ...report, netVat: netVatFromVatAccounts(report.vatAccounts) };
 }
 
 export interface Dashboard {
@@ -173,7 +192,7 @@ export async function getDashboard(options: { months?: number } = {}): Promise<D
   const fromDate = new Date();
   fromDate.setMonth(fromDate.getMonth() - (months - 1));
   fromDate.setDate(1);
-  const from = fromDate.toISOString().slice(0, 10);
+  const from = localIsoDate(fromDate);
 
   // Two fetches: the windowed one for revenue/recent, and the unpaid filter
   // (which is date-independent — an old unpaid invoice may predate the window).

--- a/src/operations/contracts.ts
+++ b/src/operations/contracts.ts
@@ -1,0 +1,107 @@
+import { fortnoxRequest, fetchAllPages } from '../fortnox-client.js';
+import { documentSegment } from '../identifiers.js';
+
+interface ContractResponse {
+  Contract: Record<string, unknown>;
+}
+
+interface InvoiceResponse {
+  Invoice: Record<string, unknown>;
+}
+
+interface ContractsResponse {
+  Contracts: Record<string, unknown>[];
+  MetaInformation?: { '@TotalResources': number; '@TotalPages': number; '@CurrentPage': number };
+}
+
+export interface ListContractsParams {
+  filter?: string; // active, inactive, finished
+  page?: number;
+  limit?: number;
+  all?: boolean;
+}
+
+export async function listContracts(params: ListContractsParams = {}): Promise<ContractsResponse> {
+  const queryParams: Record<string, string | number | undefined> = {
+    filter: params.filter,
+  };
+
+  if (params.all) {
+    const { items, totalResources } = await fetchAllPages<Record<string, unknown>>(
+      'contracts',
+      'Contracts',
+      queryParams,
+    );
+    return {
+      Contracts: items,
+      MetaInformation: { '@TotalResources': totalResources, '@TotalPages': 1, '@CurrentPage': 1 },
+    };
+  }
+
+  return fortnoxRequest<ContractsResponse>('contracts', {
+    params: { ...queryParams, page: params.page || 1, limit: params.limit || 100 },
+  });
+}
+
+export async function getContract(documentNumber: string): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<ContractResponse>(
+    `contracts/${documentSegment(documentNumber)}`,
+  );
+  return data.Contract;
+}
+
+export async function createContract(
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<ContractResponse>('contracts', {
+    method: 'POST',
+    body: { Contract: params },
+  });
+  return data.Contract;
+}
+
+export async function updateContract(
+  documentNumber: string,
+  fields: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const { documentNumber: _, ...body } = fields;
+  const data = await fortnoxRequest<ContractResponse>(
+    `contracts/${documentSegment(documentNumber)}`,
+    {
+      method: 'PUT',
+      body: { Contract: body },
+    },
+  );
+  return data.Contract;
+}
+
+// Mark the contract as finished — no further invoices will be created.
+export async function finishContract(documentNumber: string): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<ContractResponse>(
+    `contracts/${documentSegment(documentNumber)}/finish`,
+    { method: 'PUT' },
+  );
+  return data?.Contract || {};
+}
+
+// Create the next invoice from the contract immediately. Returns the Invoice.
+export async function createInvoiceFromContract(
+  documentNumber: string,
+): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<InvoiceResponse>(
+    `contracts/${documentSegment(documentNumber)}/createinvoice`,
+    { method: 'PUT' },
+  );
+  return data?.Invoice || {};
+}
+
+// Extend a non-continuous contract by one invoice.
+export async function increaseInvoiceCount(
+  documentNumber: string,
+): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<ContractResponse>(
+    `contracts/${documentSegment(documentNumber)}/increaseinvoicecount`,
+    { method: 'PUT' },
+  );
+  return data?.Contract || {};
+}

--- a/src/operations/customers.ts
+++ b/src/operations/customers.ts
@@ -46,12 +46,23 @@ export async function getCustomer(customerNumber: string): Promise<Record<string
   return data.Customer;
 }
 
+// Server-derived display fields Fortnox rejects on write ("Fältet Country är
+// endast läsbart"). Stripping them lets a `get` response be fed back into
+// create/update unchanged; the *CountryCode fields remain the writable source.
+const READ_ONLY_CUSTOMER_FIELDS = ['Country', 'DeliveryCountry', 'VisitingCountry'] as const;
+
+function stripReadOnlyFields(params: Record<string, unknown>): Record<string, unknown> {
+  const writable = { ...params };
+  for (const field of READ_ONLY_CUSTOMER_FIELDS) delete writable[field];
+  return writable;
+}
+
 export async function createCustomer(
   params: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const data = await fortnoxRequest<CustomerResponse>('customers', {
     method: 'POST',
-    body: { Customer: params },
+    body: { Customer: stripReadOnlyFields(params) },
   });
   return data.Customer;
 }
@@ -65,7 +76,7 @@ export async function updateCustomer(
     `customers/${customerSegment(customerNumber)}`,
     {
       method: 'PUT',
-      body: { Customer: body },
+      body: { Customer: stripReadOnlyFields(body) },
     },
   );
   return data.Customer;

--- a/src/operations/financial-years.ts
+++ b/src/operations/financial-years.ts
@@ -1,0 +1,43 @@
+import { fortnoxRequest } from '../fortnox-client.js';
+
+interface FinancialYearResponse {
+  FinancialYear: Record<string, unknown>;
+}
+
+interface FinancialYearsResponse {
+  FinancialYears: Record<string, unknown>[];
+  MetaInformation?: { '@TotalResources': number; '@TotalPages': number; '@CurrentPage': number };
+}
+
+interface LockedPeriodResponse {
+  LockedPeriod: Record<string, unknown>;
+}
+
+export interface ListFinancialYearsParams {
+  // Filter to the financial year containing this date (YYYY-MM-DD).
+  date?: string;
+}
+
+export async function listFinancialYears(
+  params: ListFinancialYearsParams = {},
+): Promise<FinancialYearsResponse> {
+  return fortnoxRequest<FinancialYearsResponse>('financialyears', {
+    params: { Date: params.date },
+  });
+}
+
+export async function getFinancialYear(id: number): Promise<Record<string, unknown>> {
+  if (!Number.isInteger(id) || id < 0) {
+    throw new Error(`Invalid financial year id: ${id}`);
+  }
+  const data = await fortnoxRequest<FinancialYearResponse>(`financialyears/${id}`);
+  return data.FinancialYear;
+}
+
+// The locked period (bokföring låst t.o.m.). An empty object means no period
+// is locked. Useful as context before voucher/invoice writes to avoid
+// "period is locked" API errors.
+export async function getLockedPeriod(): Promise<Record<string, unknown>> {
+  const data = await fortnoxRequest<LockedPeriodResponse>('settings/lockedperiod');
+  return data.LockedPeriod ?? {};
+}

--- a/src/tools/analytics.ts
+++ b/src/tools/analytics.ts
@@ -1,0 +1,91 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  getOverdueSummary,
+  getUnpaidTotals,
+  getTopCustomers,
+  getVatSummary,
+} from '../operations/analytics.js';
+import { invoiceListColumns, topCustomerColumns } from '../views.js';
+import { formatTable, formatTaxReport } from '../formatter.js';
+import { textResponse } from '../tool-output.js';
+
+export function registerAnalyticsTools(server: McpServer): void {
+  server.tool(
+    'fortnox_overdue_invoices',
+    'Sammanfattning av förfallna obetalda fakturor: antal, totalt utestående belopp, äldsta förfallodatum och listan (äldst först). Användbart för snabb ekonomisk överblick.',
+    {},
+    async () => {
+      const summary = await getOverdueSummary();
+      if (summary.count === 0) {
+        return textResponse('Inga förfallna fakturor.');
+      }
+      const lines = [
+        `Förfallna fakturor: ${summary.count} st, ${summary.totalBalance.toFixed(2)} utestående.`,
+        `Äldsta förfallodatum: ${summary.oldestDueDate}.`,
+        '',
+        formatTable(summary.invoices, invoiceListColumns),
+      ];
+      return textResponse(lines.join('\n'));
+    },
+  );
+
+  server.tool(
+    'fortnox_unpaid_totals',
+    'Totalt utestående kundfordringar: antal obetalda fakturor och summa, med förfallen andel separat.',
+    {},
+    async () => {
+      const s = await getUnpaidTotals();
+      return textResponse(
+        [
+          `Obetalda fakturor: ${s.count} st, ${s.totalBalance.toFixed(2)} utestående.`,
+          `Varav förfallna: ${s.overdueCount} st, ${s.overdueBalance.toFixed(2)}.`,
+        ].join('\n'),
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_top_customers',
+    'Största kunder efter fakturerat belopp under en period. Returnerar kund, totalbelopp och antal fakturor.',
+    {
+      fromDate: z.string().optional().describe('Från datum (YYYY-MM-DD)'),
+      toDate: z.string().optional().describe('Till datum (YYYY-MM-DD)'),
+      limit: z.number().optional().describe('Antal kunder (default 10)'),
+    },
+    async ({ fromDate, toDate, limit }) => {
+      const result = await getTopCustomers({ fromDate, toDate, limit });
+      if (result.customers.length === 0) {
+        return textResponse('Inga fakturor i perioden.');
+      }
+      const period =
+        result.period.from || result.period.to
+          ? `Period: ${result.period.from ?? '…'} — ${result.period.to ?? '…'}\n\n`
+          : '';
+      return textResponse(
+        period +
+          formatTable(
+            result.customers.map((c) => ({ ...c })),
+            topCustomerColumns,
+          ),
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_vat_summary',
+    'Momssammanfattning för en period: momskonton med debet/kredit samt netto momsposition (negativt = att betala till Skatteverket).',
+    {
+      fromDate: z.string().describe('Från datum (YYYY-MM-DD)'),
+      toDate: z.string().describe('Till datum (YYYY-MM-DD)'),
+      financialYear: z.number().optional().describe('Räkenskapsår (Id)'),
+    },
+    async ({ fromDate, toDate, financialYear }) => {
+      const summary = await getVatSummary({ fromDate, toDate, financialYear });
+      const netVat = summary.netVat as number;
+      return textResponse(
+        formatTaxReport(summary) + `\n\nNetto moms: ${netVat.toFixed(2)} (negativt = att betala)`,
+      );
+    },
+  );
+}

--- a/src/tools/contracts.ts
+++ b/src/tools/contracts.ts
@@ -1,0 +1,198 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  listContracts,
+  getContract,
+  createContract,
+  updateContract,
+  finishContract,
+  createInvoiceFromContract,
+  increaseInvoiceCount,
+} from '../operations/contracts.js';
+import { contractListColumns, contractDetailColumns, invoiceDetailColumns } from '../views.js';
+import {
+  detailResponse,
+  dryRunResponse,
+  listResponse,
+  requireConfirmation,
+} from '../tool-output.js';
+
+const invoiceRowSchema = z
+  .object({
+    ArticleNumber: z.string().optional().describe('Artikelnummer'),
+    Description: z.string().optional().describe('Beskrivning av raden'),
+    DeliveredQuantity: z.number().optional().describe('Antal'),
+    Price: z.number().optional().describe('Pris per enhet'),
+    AccountNumber: z.number().optional().describe('Bokföringskonto'),
+    VAT: z.number().optional().describe('Momssats (%)'),
+    Discount: z.number().optional().describe('Rabatt'),
+  })
+  .passthrough();
+
+export function registerContractTools(server: McpServer): void {
+  server.tool(
+    'fortnox_list_contracts',
+    'Lista avtal (återkommande fakturering) i Fortnox. Returnerar: DocumentNumber, CustomerName, PeriodStart, PeriodEnd, InvoiceInterval, Continuous, Total.',
+    {
+      filter: z
+        .enum(['active', 'inactive', 'finished'])
+        .optional()
+        .describe('Filtrera på avtalsstatus'),
+      page: z.number().optional().describe('Sidnummer (default 1)'),
+      limit: z.number().optional().describe('Antal per sida (default 100, max 500)'),
+      all: z.boolean().optional().describe('Hämta alla sidor (ignorerar page/limit)'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ filter, page, limit, all, includeRaw }) => {
+      const data = await listContracts({ filter, page, limit, all });
+      return listResponse(
+        data.Contracts ?? [],
+        contractListColumns,
+        data,
+        data.MetaInformation,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_contract',
+    'Hämta ett enskilt avtal från Fortnox, inklusive fakturarader.',
+    {
+      documentNumber: z.string().describe('Avtalets dokumentnummer'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, includeRaw }) => {
+      const data = await getContract(documentNumber);
+      return detailResponse(data, contractDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_contract',
+    'Skapa ett nytt avtal i Fortnox för återkommande fakturering. Fakturor skapas automatiskt enligt InvoiceInterval.',
+    {
+      CustomerNumber: z.string().describe('Kundnummer'),
+      InvoiceRows: z.array(invoiceRowSchema).describe('Fakturarader'),
+      PeriodStart: z.string().optional().describe('Avtalsperiodens start (YYYY-MM-DD)'),
+      PeriodEnd: z.string().optional().describe('Avtalsperiodens slut (YYYY-MM-DD)'),
+      InvoiceInterval: z
+        .number()
+        .optional()
+        .describe('Faktureringsintervall i månader (1, 3, 6, 12)'),
+      ContractLength: z.number().optional().describe('Avtalslängd i månader'),
+      Continuous: z.boolean().optional().describe('Löpande avtal (utan slutdatum)'),
+      Comments: z.string().optional().describe('Kommentar'),
+      confirm: z.boolean().optional().describe('Bekräfta att avtalet ska skapas'),
+      dryRun: z.boolean().optional().describe('Visa vad som skulle skickas utan att skapa avtalet'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ confirm, dryRun, includeRaw, ...params }) => {
+      if (dryRun) {
+        return dryRunResponse(`create contract for customer ${params.CustomerNumber}`, {
+          Contract: params,
+        });
+      }
+      if (!confirm) requireConfirmation(`create contract for customer ${params.CustomerNumber}`);
+
+      const data = await createContract(params);
+      return detailResponse(data, contractDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_contract',
+    'Uppdatera ett befintligt avtal i Fortnox.',
+    {
+      documentNumber: z.string().describe('Avtalets dokumentnummer'),
+      InvoiceRows: z
+        .array(invoiceRowSchema)
+        .optional()
+        .describe('Fakturarader (ersätter alla befintliga rader)'),
+      PeriodStart: z.string().optional().describe('Avtalsperiodens start (YYYY-MM-DD)'),
+      PeriodEnd: z.string().optional().describe('Avtalsperiodens slut (YYYY-MM-DD)'),
+      InvoiceInterval: z
+        .number()
+        .optional()
+        .describe('Faktureringsintervall i månader (1, 3, 6, 12)'),
+      ContractLength: z.number().optional().describe('Avtalslängd i månader'),
+      Continuous: z.boolean().optional().describe('Löpande avtal (utan slutdatum)'),
+      Comments: z.string().optional().describe('Kommentar'),
+      confirm: z.boolean().optional().describe('Bekräfta att avtalet ska uppdateras'),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe('Visa vad som skulle skickas utan att uppdatera avtalet'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) {
+        return dryRunResponse(`update contract ${documentNumber}`, { Contract: fields });
+      }
+      if (!confirm) requireConfirmation(`update contract ${documentNumber}`);
+
+      const data = await updateContract(documentNumber, fields);
+      return detailResponse(data, contractDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_finish_contract',
+    'Avsluta ett avtal i Fortnox — inga fler fakturor skapas.',
+    {
+      documentNumber: z.string().describe('Avtalets dokumentnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta att avtalet ska avslutas'),
+      dryRun: z.boolean().optional().describe('Visa vad som skulle göras utan att avsluta avtalet'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+      if (dryRun) {
+        return dryRunResponse(`finish contract ${documentNumber}`);
+      }
+      if (!confirm) requireConfirmation(`finish contract ${documentNumber}`);
+
+      const data = await finishContract(documentNumber);
+      return detailResponse(data, contractDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_invoice_from_contract',
+    'Skapa nästa faktura från ett avtal direkt. Returnerar den skapade fakturan.',
+    {
+      documentNumber: z.string().describe('Avtalets dokumentnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta att fakturan ska skapas'),
+      dryRun: z.boolean().optional().describe('Visa vad som skulle göras utan att skapa fakturan'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+      if (dryRun) {
+        return dryRunResponse(`create invoice from contract ${documentNumber}`);
+      }
+      if (!confirm) requireConfirmation(`create invoice from contract ${documentNumber}`);
+
+      const data = await createInvoiceFromContract(documentNumber);
+      return detailResponse(data, invoiceDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_increase_contract_invoice_count',
+    'Utöka ett tidsbegränsat avtal med en faktura (ökar InvoicesRemaining).',
+    {
+      documentNumber: z.string().describe('Avtalets dokumentnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta utökningen'),
+      dryRun: z.boolean().optional().describe('Visa vad som skulle göras utan att utöka avtalet'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+      if (dryRun) {
+        return dryRunResponse(`increase invoice count for contract ${documentNumber}`);
+      }
+      if (!confirm) requireConfirmation(`increase invoice count for contract ${documentNumber}`);
+
+      const data = await increaseInvoiceCount(documentNumber);
+      return detailResponse(data, contractDetailColumns, data, includeRaw);
+    },
+  );
+}

--- a/src/tools/financial-years.ts
+++ b/src/tools/financial-years.ts
@@ -1,0 +1,65 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  listFinancialYears,
+  getFinancialYear,
+  getLockedPeriod,
+} from '../operations/financial-years.js';
+import {
+  financialYearListColumns,
+  financialYearDetailColumns,
+  lockedPeriodDetailColumns,
+} from '../views.js';
+import { detailResponse, listResponse, textResponse } from '../tool-output.js';
+
+export function registerFinancialYearTools(server: McpServer): void {
+  server.tool(
+    'fortnox_list_financialyears',
+    'Lista räkenskapsår i Fortnox. Returnerar: Id, FromDate, ToDate, AccountingMethod, AccountChartType. Kan filtreras till det räkenskapsår som innehåller ett visst datum.',
+    {
+      date: z
+        .string()
+        .optional()
+        .describe('Hitta räkenskapsåret som innehåller detta datum (YYYY-MM-DD)'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ date, includeRaw }) => {
+      const data = await listFinancialYears({ date });
+      return listResponse(
+        data.FinancialYears ?? [],
+        financialYearListColumns,
+        data,
+        data.MetaInformation,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_financialyear',
+    'Hämta ett enskilt räkenskapsår från Fortnox.',
+    {
+      id: z.number().describe('Räkenskapsårets Id'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ id, includeRaw }) => {
+      const data = await getFinancialYear(id);
+      return detailResponse(data, financialYearDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_get_lockedperiod',
+    'Hämta låst period från Fortnox (bokföringen är låst t.o.m. detta datum). Tomt svar betyder att ingen period är låst. Användbart innan verifikat/fakturor bokförs för att undvika fel om låst period.',
+    {
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ includeRaw }) => {
+      const data = await getLockedPeriod();
+      if (!data.EndDate) {
+        return textResponse('Ingen period är låst.');
+      }
+      return detailResponse(data, lockedPeriodDetailColumns, data, includeRaw);
+    },
+  );
+}

--- a/src/views.ts
+++ b/src/views.ts
@@ -395,3 +395,19 @@ export const companyDetailColumns: Column[] = [
   { key: 'Email', header: 'Email', width: 40 },
   { key: 'DatabaseNumber', header: 'Database #', width: 10 },
 ];
+
+// --- Financial year views ---
+
+export const financialYearListColumns: Column[] = [
+  { key: 'Id', header: 'Id', width: 4, align: 'right' },
+  { key: 'FromDate', header: 'From', width: 10 },
+  { key: 'ToDate', header: 'To', width: 10 },
+  { key: 'AccountingMethod', header: 'Method', width: 8 },
+  { key: 'AccountChartType', header: 'Account Chart', width: 30 },
+];
+
+export const financialYearDetailColumns: Column[] = financialYearListColumns;
+
+export const lockedPeriodDetailColumns: Column[] = [
+  { key: 'EndDate', header: 'Locked Through', width: 10 },
+];

--- a/src/views.ts
+++ b/src/views.ts
@@ -411,3 +411,33 @@ export const financialYearDetailColumns: Column[] = financialYearListColumns;
 export const lockedPeriodDetailColumns: Column[] = [
   { key: 'EndDate', header: 'Locked Through', width: 10 },
 ];
+
+// --- Contract views ---
+
+export const contractListColumns: Column[] = [
+  { key: 'DocumentNumber', header: 'Doc #', width: 7, align: 'right' },
+  { key: 'CustomerName', header: 'Customer', width: 20 },
+  { key: 'PeriodStart', header: 'Start', width: 10 },
+  { key: 'PeriodEnd', header: 'End', width: 10 },
+  { key: 'InvoiceInterval', header: 'Interval', width: 8, align: 'right' },
+  { key: 'Continuous', header: 'Cont.', width: 5 },
+  { key: 'Total', header: 'Total', width: 10, align: 'right', format: currency },
+];
+
+export const contractDetailColumns: Column[] = [
+  { key: 'DocumentNumber', header: 'Document #', width: 10 },
+  { key: 'CustomerNumber', header: 'Customer #', width: 10 },
+  { key: 'CustomerName', header: 'Customer', width: 30 },
+  { key: 'Active', header: 'Active', width: 5 },
+  { key: 'Continuous', header: 'Continuous', width: 5 },
+  { key: 'ContractDate', header: 'Contract Date', width: 10 },
+  { key: 'ContractLength', header: 'Length (months)', width: 6, align: 'right' },
+  { key: 'PeriodStart', header: 'Period Start', width: 10 },
+  { key: 'PeriodEnd', header: 'Period End', width: 10 },
+  { key: 'InvoiceInterval', header: 'Invoice Interval', width: 6, align: 'right' },
+  { key: 'InvoicesRemaining', header: 'Invoices Remaining', width: 6, align: 'right' },
+  { key: 'LastInvoiceDate', header: 'Last Invoice', width: 10 },
+  { key: 'Total', header: 'Total', width: 12, align: 'right', format: currency },
+  { key: 'TotalVAT', header: 'VAT', width: 12, align: 'right', format: currency },
+  { key: 'Comments', header: 'Comments', width: 40 },
+];

--- a/src/views.ts
+++ b/src/views.ts
@@ -441,3 +441,18 @@ export const contractDetailColumns: Column[] = [
   { key: 'TotalVAT', header: 'VAT', width: 12, align: 'right', format: currency },
   { key: 'Comments', header: 'Comments', width: 40 },
 ];
+
+// --- Analytics views ---
+
+export const topCustomerColumns: Column[] = [
+  { key: 'CustomerNumber', header: 'Cust #', width: 8, align: 'right' },
+  { key: 'CustomerName', header: 'Customer', width: 30 },
+  { key: 'total', header: 'Invoiced', width: 14, align: 'right', format: currency },
+  { key: 'invoiceCount', header: 'Invoices', width: 8, align: 'right' },
+];
+
+export const monthlyRevenueColumns: Column[] = [
+  { key: 'month', header: 'Month', width: 7 },
+  { key: 'total', header: 'Invoiced', width: 14, align: 'right', format: currency },
+  { key: 'invoiceCount', header: 'Invoices', width: 8, align: 'right' },
+];

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -150,3 +150,22 @@ describe('Commander parse errors honor -o json', () => {
     expect(res.stderr.split('required option').length - 1).toBe(1);
   });
 });
+
+describe('global --profile validation honors -o json', () => {
+  // The preAction hook validates --profile before any data command runs, so a
+  // scripted `-o json` caller must still get a structured envelope.
+  it('rejects an invalid profile with a JSON envelope in json mode', () => {
+    const res = run(['-o', 'json', '--profile', '../evil', 'customers', 'list']);
+    expect(res.status).toBe(2);
+    const parsed = JSON.parse(res.stderr.trim()) as { error: { message: string; source: string } };
+    expect(parsed.error.source).toBe('noxctl');
+    expect(parsed.error.message).toMatch(/invalid profile name/i);
+  });
+
+  it('rejects an invalid profile with plain text in table mode', () => {
+    const res = run(['-o', 'table', '--profile', '../evil', 'customers', 'list']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/invalid profile name/i);
+    expect(() => JSON.parse(res.stderr.trim())).toThrow();
+  });
+});

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -103,3 +103,30 @@ describe('CLI -o json error envelope', () => {
     expect(() => JSON.parse(res.stderr.trim())).toThrow();
   });
 });
+
+describe('CLI usage validation honors -o json (no period given)', () => {
+  // These fire before any API call, so they exercise the JSON error contract
+  // for direct-exit validation paths without needing credentials.
+  it('tax report emits a JSON envelope (exit 2) in json mode', () => {
+    const res = run(['tax', 'report', '-o', 'json']);
+    expect(res.status).toBe(2);
+    const parsed = JSON.parse(res.stderr.trim()) as { error: { message: string; source: string } };
+    expect(parsed.error.source).toBe('noxctl');
+    expect(parsed.error.message).toMatch(/requires a period/i);
+  });
+
+  it('tax report stays plain text (exit 2) in table mode', () => {
+    const res = run(['tax', 'report', '-o', 'table']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/requires a period/i);
+    expect(() => JSON.parse(res.stderr.trim())).toThrow();
+  });
+
+  it('analytics vat emits a JSON envelope (exit 2) in json mode', () => {
+    const res = run(['analytics', 'vat', '-o', 'json']);
+    expect(res.status).toBe(2);
+    const parsed = JSON.parse(res.stderr.trim()) as { error: { message: string; source: string } };
+    expect(parsed.error.source).toBe('noxctl');
+    expect(parsed.error.message).toMatch(/requires a period/i);
+  });
+});

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -130,3 +130,23 @@ describe('CLI usage validation honors -o json (no period given)', () => {
     expect(parsed.error.message).toMatch(/requires a period/i);
   });
 });
+
+describe('Commander parse errors honor -o json', () => {
+  it('a missing required option emits a JSON envelope in json mode', () => {
+    const res = run(['-o', 'json', 'customers', 'create']);
+    expect(res.status).toBe(1);
+    const parsed = JSON.parse(res.stderr.trim()) as { error: { message: string; source: string } };
+    expect(parsed.error.source).toBe('noxctl');
+    expect(parsed.error.message).toMatch(/required option/i);
+  });
+
+  it('a missing required option stays plain text in table mode, printed once', () => {
+    const res = run(['-o', 'table', 'customers', 'create']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/required option '--name/);
+    expect(() => JSON.parse(res.stderr.trim())).toThrow();
+    // Commander prints its usage error exactly once (no double-print from the
+    // top-level handler).
+    expect(res.stderr.split('required option').length - 1).toBe(1);
+  });
+});

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { errorEnvelope } from '../src/formatter.js';
+
+const CLI_PATH = path.resolve('dist/cli.js');
+
+let tmpHome: string;
+
+function run(args: string[]): { stdout: string; stderr: string; status: number } {
+  const mergedEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: tmpHome,
+    USERPROFILE: tmpHome,
+  };
+  delete mergedEnv.NOXCTL_PROFILE;
+
+  const opts: ExecFileSyncOptions = {
+    encoding: 'utf-8',
+    timeout: 10000,
+    env: mergedEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], opts) as string;
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number };
+    return {
+      stdout: (e.stdout?.toString() ?? '') as string,
+      stderr: (e.stderr?.toString() ?? '') as string,
+      status: e.status ?? 1,
+    };
+  }
+}
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'noxctl-cli-errors-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+describe('errorEnvelope', () => {
+  it('maps FortnoxApiError-shaped errors to a fortnox-api envelope', () => {
+    const err = Object.assign(
+      new Error('Fortnox API error (400): Fältet Country är endast läsbart.'),
+      {
+        name: 'FortnoxApiError',
+        statusCode: 400,
+        fortnoxMessage: 'Fältet Country är endast läsbart.',
+        hint: undefined,
+      },
+    );
+    expect(errorEnvelope(err)).toEqual({
+      error: {
+        status: 400,
+        message: 'Fältet Country är endast läsbart.',
+        source: 'fortnox-api',
+      },
+    });
+  });
+
+  it('includes the hint when present', () => {
+    const err = Object.assign(new Error('x'), {
+      name: 'FortnoxApiError',
+      statusCode: 403,
+      fortnoxMessage: 'No access',
+      hint: 'Check API scopes.',
+    });
+    expect(errorEnvelope(err).error.hint).toBe('Check API scopes.');
+  });
+
+  it('maps plain errors to a noxctl envelope', () => {
+    expect(errorEnvelope(new Error('Invalid customer number'))).toEqual({
+      error: { message: 'Invalid customer number', source: 'noxctl' },
+    });
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(errorEnvelope('boom').error.message).toBe('boom');
+  });
+});
+
+describe('CLI -o json error envelope', () => {
+  it('emits a parseable JSON envelope on failure in json mode', () => {
+    const res = run(['customers', 'get', '../evil', '-o', 'json']);
+    expect(res.status).toBe(1);
+    const parsed = JSON.parse(res.stderr.trim()) as {
+      error: { message: string; source: string };
+    };
+    expect(parsed.error.source).toBe('noxctl');
+    expect(parsed.error.message).toContain('Invalid customer number');
+  });
+
+  it('keeps plain-text errors in table mode', () => {
+    const res = run(['customers', 'get', '../evil', '-o', 'table']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('Invalid customer number');
+    expect(() => JSON.parse(res.stderr.trim())).toThrow();
+  });
+});

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import {
+  extractCommandTree,
+  renderBashCompletion,
+  renderZshCompletion,
+  renderFishCompletion,
+} from '../src/completions.js';
+
+function sampleProgram(): Command {
+  const program = new Command();
+  program.name('noxctl').option('-o, --output <format>', 'Output format');
+  const invoices = program.command('invoices').description('Invoice operations');
+  invoices.command('list').option('--filter <filter>', 'Filter').option('-a, --all', 'All pages');
+  invoices.command('get <documentNumber>');
+  program.command('doctor').description('Diagnose');
+  return program;
+}
+
+describe('extractCommandTree', () => {
+  it('captures nested subcommands and long options', () => {
+    const tree = extractCommandTree(sampleProgram());
+    expect(tree.name).toBe('noxctl');
+    expect(tree.options).toContain('--output');
+    const invoices = tree.subcommands.find((c) => c.name === 'invoices');
+    expect(invoices).toBeDefined();
+    const list = invoices!.subcommands.find((c) => c.name === 'list');
+    expect(list!.options).toEqual(expect.arrayContaining(['--filter', '--all']));
+    expect(tree.subcommands.map((c) => c.name)).toContain('doctor');
+  });
+});
+
+describe('renderers', () => {
+  const tree = extractCommandTree(sampleProgram());
+
+  it('bash script completes subcommands', () => {
+    const script = renderBashCompletion(tree);
+    expect(script).toContain('complete -F _noxctl_completions noxctl');
+    expect(script).toContain('invoices');
+    expect(script).toContain('doctor');
+    expect(script).toContain('--filter');
+  });
+
+  it('zsh script is a compdef for noxctl', () => {
+    const script = renderZshCompletion(tree);
+    expect(script).toContain('#compdef noxctl');
+    expect(script).toContain('invoices');
+    expect(script).toContain('--filter');
+  });
+
+  it('fish script registers completions', () => {
+    const script = renderFishCompletion(tree);
+    expect(script).toContain('complete -c noxctl');
+    expect(script).toContain('invoices');
+    expect(script).toContain('filter');
+  });
+});

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -16,6 +16,9 @@ const fsSync = vi.hoisted(() => ({
   default: {
     writeFileSync: vi.fn(),
     unlinkSync: vi.fn(),
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
   },
 }));
 
@@ -34,6 +37,7 @@ import {
   keychainAccount,
   InvalidProfileNameError,
 } from '../src/profile-name.js';
+import { KeychainLockedError } from '../src/keychain-target.js';
 
 const SERVICE_NAME = 'fortnox-mcp';
 const ORIGINAL_PLATFORM = process.platform;
@@ -46,6 +50,8 @@ function restorePlatform(): void {
   Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true });
 }
 
+const ORIGINAL_KEYCHAIN_ENV = process.env.NOXCTL_KEYCHAIN_PATH;
+
 beforeEach(() => {
   childProcess.execFileSync.mockReset();
   childProcess.spawnSync.mockReset();
@@ -53,10 +59,18 @@ beforeEach(() => {
   fsPromises.default.rm.mockReset();
   fsSync.default.writeFileSync.mockReset();
   fsSync.default.unlinkSync.mockReset();
+  fsSync.default.existsSync.mockReset();
+  fsSync.default.existsSync.mockReturnValue(false);
+  fsSync.default.readFileSync.mockReset();
+  fsSync.default.mkdirSync.mockReset();
+  // Default: dedicated-keychain mode OFF so the legacy login-keychain paths run.
+  delete process.env.NOXCTL_KEYCHAIN_PATH;
 });
 
 afterEach(() => {
   restorePlatform();
+  if (ORIGINAL_KEYCHAIN_ENV === undefined) delete process.env.NOXCTL_KEYCHAIN_PATH;
+  else process.env.NOXCTL_KEYCHAIN_PATH = ORIGINAL_KEYCHAIN_ENV;
 });
 
 describe('validateProfileName', () => {
@@ -558,6 +572,70 @@ describe('Windows DPAPI backend', () => {
     expect(call).toBeDefined();
     const script = (call![1] as string[]).join(' ');
     expect(script).toContain('credentials.demo.dpapi');
+  });
+});
+
+describe('dedicated-keychain mode (darwin)', () => {
+  const KC = '/tmp/fortnox-mcp.keychain-db';
+
+  beforeEach(() => {
+    setPlatform('darwin');
+    // Env override activates dedicated mode without needing existsSync.
+    process.env.NOXCTL_KEYCHAIN_PATH = KC;
+  });
+
+  it('routes reads through the dedicated Swift reader, not the security CLI', async () => {
+    const newBlob = JSON.stringify({ client_id: 'dedicated' });
+    childProcess.spawnSync.mockImplementation((cmd: string, args: readonly string[]) => {
+      if (cmd === 'swift') {
+        const account = args[1];
+        return account === 'profile:default'
+          ? { status: 0, stdout: Buffer.from(newBlob).toString('base64'), stderr: '' }
+          : { status: 3, stdout: '', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await loadCredentialBlob('default');
+    expect(result.blob).toBe(newBlob);
+
+    const findCalls = childProcess.execFileSync.mock.calls.filter(
+      ([cmd, a]) => cmd === 'security' && (a as string[]).includes('find-generic-password'),
+    );
+    expect(findCalls).toHaveLength(0);
+
+    const swiftCall = childProcess.spawnSync.mock.calls.find(([cmd]) => cmd === 'swift');
+    expect((swiftCall![1] as string[])[2]).toBe(KC);
+  });
+
+  it('throws KeychainLockedError when the dedicated keychain is locked', async () => {
+    childProcess.spawnSync.mockReturnValue({ status: 2, stdout: '', stderr: '' });
+    await expect(loadCredentialBlob('default')).rejects.toThrow(KeychainLockedError);
+  });
+
+  it('save targets the dedicated keychain via Swift argv and kSecUseKeychain', async () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    await saveCredentialBlob('{"x":1}', 'default');
+
+    const swiftCall = childProcess.spawnSync.mock.calls.find(([cmd]) => cmd === 'swift');
+    expect(swiftCall).toBeDefined();
+    expect((swiftCall![1] as string[])[1]).toBe(KC);
+
+    const scriptBody = fsSync.default.writeFileSync.mock.calls
+      .map((c) => c[1] as string)
+      .join('\n');
+    expect(scriptBody).toContain('kSecUseKeychain');
+  });
+
+  it('delete appends the dedicated keychain as the trailing positional', async () => {
+    childProcess.execFileSync.mockReturnValue('');
+    await deleteCredentialBlob('demo');
+
+    const delArgs = childProcess.execFileSync.mock.calls
+      .map((c) => c[1] as string[])
+      .find((a) => a.includes('delete-generic-password'));
+    expect(delArgs).toBeDefined();
+    expect(delArgs![delArgs!.length - 1]).toBe(KC);
   });
 });
 

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -431,6 +431,27 @@ describe('saveCredentialBlob (darwin)', () => {
     await saveCredentialBlob('{"x":1}', 'default');
     expect(fsPromises.default.rm).toHaveBeenCalled();
   });
+
+  it('fails closed when the Swift helper fails — never leaks the secret to `security` argv', async () => {
+    // Swift helper fails for every invocation.
+    childProcess.spawnSync.mockReturnValue({ status: 1, stderr: 'swift exploded', stdout: '' });
+    // If a fallback ran it would call execFileSync; make that observable.
+    childProcess.execFileSync.mockReturnValue('');
+
+    await expect(saveCredentialBlob('{"secret":"super-token"}', 'default')).rejects.toThrow(
+      /swift/i,
+    );
+
+    // The credential must never reach `security add-generic-password -w <secret>`,
+    // where it would be visible to other processes via `ps`.
+    const leaked = childProcess.execFileSync.mock.calls.some(
+      ([cmd, args]) =>
+        cmd === 'security' &&
+        Array.isArray(args) &&
+        (args as string[]).includes('add-generic-password'),
+    );
+    expect(leaked).toBe(false);
+  });
 });
 
 describe('deleteCredentialBlob (darwin)', () => {

--- a/tests/date-periods.test.ts
+++ b/tests/date-periods.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePeriod } from '../src/date-periods.js';
+
+// Fixed "today" for determinism: 2026-06-10 (Q2).
+const TODAY = new Date(2026, 5, 10);
+
+describe('resolvePeriod', () => {
+  it('resolves quarters of the current calendar year', () => {
+    expect(resolvePeriod('Q1', TODAY)).toEqual({ from: '2026-01-01', to: '2026-03-31' });
+    expect(resolvePeriod('q2', TODAY)).toEqual({ from: '2026-04-01', to: '2026-06-30' });
+    expect(resolvePeriod('Q4', TODAY)).toEqual({ from: '2026-10-01', to: '2026-12-31' });
+  });
+
+  it('resolves year-qualified quarters', () => {
+    expect(resolvePeriod('2025-Q3', TODAY)).toEqual({ from: '2025-07-01', to: '2025-09-30' });
+  });
+
+  it('resolves English month names in the current year', () => {
+    expect(resolvePeriod('march', TODAY)).toEqual({ from: '2026-03-01', to: '2026-03-31' });
+    expect(resolvePeriod('February', TODAY)).toEqual({ from: '2026-02-01', to: '2026-02-28' });
+  });
+
+  it('resolves Swedish month names', () => {
+    expect(resolvePeriod('mars', TODAY)).toEqual({ from: '2026-03-01', to: '2026-03-31' });
+    expect(resolvePeriod('maj', TODAY)).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+  });
+
+  it('handles leap-year February', () => {
+    expect(resolvePeriod('february', new Date(2028, 0, 15))).toEqual({
+      from: '2028-02-01',
+      to: '2028-02-29',
+    });
+  });
+
+  it('resolves relative periods', () => {
+    expect(resolvePeriod('this-quarter', TODAY)).toEqual({ from: '2026-04-01', to: '2026-06-30' });
+    expect(resolvePeriod('last-quarter', TODAY)).toEqual({ from: '2026-01-01', to: '2026-03-31' });
+    expect(resolvePeriod('this-month', TODAY)).toEqual({ from: '2026-06-01', to: '2026-06-30' });
+    expect(resolvePeriod('last-month', TODAY)).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+    expect(resolvePeriod('ytd', TODAY)).toEqual({ from: '2026-01-01', to: '2026-06-10' });
+    expect(resolvePeriod('last-year', TODAY)).toEqual({ from: '2025-01-01', to: '2025-12-31' });
+    expect(resolvePeriod('this-year', TODAY)).toEqual({ from: '2026-01-01', to: '2026-12-31' });
+  });
+
+  it('last-quarter crosses the year boundary from Q1', () => {
+    expect(resolvePeriod('last-quarter', new Date(2026, 1, 1))).toEqual({
+      from: '2025-10-01',
+      to: '2025-12-31',
+    });
+  });
+
+  it('resolves a bare year', () => {
+    expect(resolvePeriod('2025', TODAY)).toEqual({ from: '2025-01-01', to: '2025-12-31' });
+  });
+
+  it('throws a helpful error on unknown input', () => {
+    expect(() => resolvePeriod('banana', TODAY)).toThrow(/Unrecognized period/);
+  });
+});

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -338,3 +338,42 @@ describe('outputDetail JSON envelope', () => {
     expect(JSON.parse(logs.join(''))).toEqual({ DocumentNumber: '28' });
   });
 });
+
+describe('outputConfirmation JSON envelope', () => {
+  it('wraps action results under the singular resource key in JSON mode', async () => {
+    const { outputConfirmation } = await import('../src/formatter.js');
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+    // Shape emitted by `invoice-payments delete -o json` after the fix: a
+    // singular-key envelope, not a bare {}.
+    outputConfirmation(
+      'deleted',
+      true,
+      { Number: '5', deleted: true },
+      undefined,
+      'InvoicePayment',
+    );
+    spy.mockRestore();
+    expect(JSON.parse(logs.join(''))).toEqual({ InvoicePayment: { Number: '5', deleted: true } });
+  });
+
+  it('prints the human message (not JSON) in table mode', async () => {
+    const { outputConfirmation } = await import('../src/formatter.js');
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+    outputConfirmation(
+      'Cost center X deleted.',
+      false,
+      { Code: 'X', deleted: true },
+      undefined,
+      'CostCenter',
+    );
+    spy.mockRestore();
+    expect(logs.join('\n')).toContain('Cost center X deleted.');
+    expect(() => JSON.parse(logs.join(''))).toThrow();
+  });
+});

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   formatTable,
   formatDetail,
@@ -312,5 +312,29 @@ describe('isJsonMode', () => {
   it('explicit flag overrides TTY detection', () => {
     const fakeStdout = { isTTY: true } as NodeJS.WriteStream;
     expect(isJsonMode({ output: 'json' }, fakeStdout)).toBe(true);
+  });
+});
+
+describe('outputDetail JSON envelope', () => {
+  it('wraps the record under the envelope key in JSON mode', async () => {
+    const { outputDetail } = await import('../src/formatter.js');
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+    outputDetail({ DocumentNumber: '28' }, [], true, 'Invoice');
+    spy.mockRestore();
+    expect(JSON.parse(logs.join(''))).toEqual({ Invoice: { DocumentNumber: '28' } });
+  });
+
+  it('prints the bare record when no envelope key is given', async () => {
+    const { outputDetail } = await import('../src/formatter.js');
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+    outputDetail({ DocumentNumber: '28' }, [], true);
+    spy.mockRestore();
+    expect(JSON.parse(logs.join(''))).toEqual({ DocumentNumber: '28' });
   });
 });

--- a/tests/keychain-target.test.ts
+++ b/tests/keychain-target.test.ts
@@ -294,6 +294,16 @@ describe('security CLI wrappers', () => {
     );
   });
 
+  it('setLockOnSleep throws when `security` exits non-zero (no silent success)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 1, stderr: 'SecKeychainSetSettings failed' });
+    expect(() => setLockOnSleep('/tmp/k.keychain-db')).toThrow(/set-keychain-settings failed/i);
+  });
+
+  it('setLockOnSleep throws when `security` cannot be spawned', () => {
+    childProcess.spawnSync.mockReturnValue({ error: new Error('ENOENT'), status: null });
+    expect(() => setLockOnSleep('/tmp/k.keychain-db')).toThrow(/ENOENT/);
+  });
+
   it('lockKeychain calls `security lock-keychain <path>`', () => {
     childProcess.spawnSync.mockReturnValue({ status: 0 });
     lockKeychain('/tmp/k.keychain-db');
@@ -302,6 +312,11 @@ describe('security CLI wrappers', () => {
       ['lock-keychain', '/tmp/k.keychain-db'],
       expect.anything(),
     );
+  });
+
+  it('lockKeychain throws when `security` exits non-zero (no false "locked" report)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 1, stderr: 'could not lock' });
+    expect(() => lockKeychain('/tmp/k.keychain-db')).toThrow(/lock-keychain failed/i);
   });
 
   it('deleteLoginSecret targets the login keychain explicitly and reports success via exit 0', () => {

--- a/tests/keychain-target.test.ts
+++ b/tests/keychain-target.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const childProcess = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+const fsSync = vi.hoisted(() => ({
+  default: {
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('node:child_process', () => childProcess);
+vi.mock('node:fs', () => fsSync);
+
+import {
+  KeychainLockedError,
+  ChallengeResponseError,
+  dedicatedKeychainPath,
+  loginKeychainPath,
+  challengeFilePath,
+  activeKeychainPath,
+  isDedicatedModeActive,
+  readDedicatedSecret,
+  generateChallenge,
+  readChallenge,
+  writeChallenge,
+  ykmanAvailable,
+  yubikeyPresent,
+  computeChallengeResponse,
+  createDedicatedKeychain,
+  unlockDedicatedKeychain,
+  keychainLockState,
+  setLockOnSleep,
+  lockKeychain,
+  deleteLoginSecret,
+} from '../src/keychain-target.js';
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_KEYCHAIN_ENV = process.env.NOXCTL_KEYCHAIN_PATH;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  childProcess.spawnSync.mockReset();
+  childProcess.execFileSync.mockReset();
+  fsSync.default.writeFileSync.mockReset();
+  fsSync.default.unlinkSync.mockReset();
+  fsSync.default.existsSync.mockReset();
+  fsSync.default.existsSync.mockReturnValue(false);
+  fsSync.default.readFileSync.mockReset();
+  fsSync.default.mkdirSync.mockReset();
+  delete process.env.NOXCTL_KEYCHAIN_PATH;
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true });
+  if (ORIGINAL_KEYCHAIN_ENV === undefined) delete process.env.NOXCTL_KEYCHAIN_PATH;
+  else process.env.NOXCTL_KEYCHAIN_PATH = ORIGINAL_KEYCHAIN_ENV;
+});
+
+describe('paths', () => {
+  it('dedicatedKeychainPath ends with fortnox-mcp.keychain-db under Library/Keychains', () => {
+    expect(dedicatedKeychainPath()).toMatch(/Library\/Keychains\/fortnox-mcp\.keychain-db$/);
+  });
+
+  it('loginKeychainPath ends with login.keychain-db under Library/Keychains', () => {
+    expect(loginKeychainPath()).toMatch(/Library\/Keychains\/login\.keychain-db$/);
+  });
+
+  it('challengeFilePath ends with keychain-challenge', () => {
+    expect(challengeFilePath()).toMatch(/keychain-challenge$/);
+  });
+});
+
+describe('activeKeychainPath precedence', () => {
+  it('honors the NOXCTL_KEYCHAIN_PATH env override above everything', () => {
+    process.env.NOXCTL_KEYCHAIN_PATH = '/tmp/override.keychain-db';
+    setPlatform('linux');
+    expect(activeKeychainPath()).toBe('/tmp/override.keychain-db');
+    expect(isDedicatedModeActive()).toBe(true);
+  });
+
+  it('ignores a blank/whitespace override', () => {
+    process.env.NOXCTL_KEYCHAIN_PATH = '   ';
+    setPlatform('darwin');
+    fsSync.default.existsSync.mockReturnValue(false);
+    expect(activeKeychainPath()).toBeNull();
+  });
+
+  it('returns null on non-darwin without an override', () => {
+    setPlatform('linux');
+    expect(activeKeychainPath()).toBeNull();
+    expect(isDedicatedModeActive()).toBe(false);
+  });
+
+  it('returns the dedicated path on darwin only when both keychain and challenge files exist', () => {
+    setPlatform('darwin');
+    fsSync.default.existsSync.mockReturnValue(true);
+    expect(activeKeychainPath()).toBe(dedicatedKeychainPath());
+  });
+
+  it('returns null on darwin when the challenge file is missing (half-created keychain)', () => {
+    setPlatform('darwin');
+    fsSync.default.existsSync.mockImplementation((p: string) => p === dedicatedKeychainPath());
+    expect(activeKeychainPath()).toBeNull();
+  });
+});
+
+describe('challenge file helpers', () => {
+  it('generateChallenge returns 64 hex chars (32 bytes)', () => {
+    const c = generateChallenge();
+    expect(c).toMatch(/^[0-9a-f]{64}$/);
+    expect(generateChallenge()).not.toBe(c);
+  });
+
+  it('readChallenge trims and returns the stored value', () => {
+    fsSync.default.readFileSync.mockReturnValue('  abc123\n');
+    expect(readChallenge()).toBe('abc123');
+  });
+
+  it('readChallenge returns null for an empty file', () => {
+    fsSync.default.readFileSync.mockReturnValue('   \n');
+    expect(readChallenge()).toBeNull();
+  });
+
+  it('readChallenge returns null when the file is missing', () => {
+    fsSync.default.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(readChallenge()).toBeNull();
+  });
+
+  it('writeChallenge creates the config dir and writes with a trailing newline at mode 0600', () => {
+    writeChallenge('deadbeef');
+    expect(fsSync.default.mkdirSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ recursive: true, mode: 0o700 }),
+    );
+    expect(fsSync.default.writeFileSync).toHaveBeenCalledWith(
+      challengeFilePath(),
+      'deadbeef\n',
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+});
+
+describe('ykman availability probes', () => {
+  it('ykmanAvailable is true when `ykman --version` exits 0', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: 'YubiKey Manager 5.9.1' });
+    expect(ykmanAvailable()).toBe(true);
+  });
+
+  it('ykmanAvailable is false when ykman is missing', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 127, stdout: '' });
+    expect(ykmanAvailable()).toBe(false);
+  });
+
+  it('yubikeyPresent is true when `ykman list` exits 0 with output', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: 'YubiKey 5 NFC [OTP+FIDO+CCID]' });
+    expect(yubikeyPresent()).toBe(true);
+  });
+
+  it('yubikeyPresent is false when no key is listed', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: '   ' });
+    expect(yubikeyPresent()).toBe(false);
+  });
+});
+
+describe('computeChallengeResponse', () => {
+  it('returns the 40-hex response on a successful tap', () => {
+    const resp = 'a'.repeat(40);
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: `  ${resp}\n` });
+    expect(computeChallengeResponse('cafe')).toBe(resp);
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'ykman',
+      ['otp', 'calculate', '2', 'cafe'],
+      expect.anything(),
+    );
+  });
+
+  it('throws ChallengeResponseError when ykman is not installed (ENOENT)', () => {
+    childProcess.spawnSync.mockReturnValue({ error: { code: 'ENOENT' } });
+    expect(() => computeChallengeResponse('cafe')).toThrow(ChallengeResponseError);
+  });
+
+  it('throws ChallengeResponseError on a missed touch (non-zero exit)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 1, stdout: '' });
+    expect(() => computeChallengeResponse('cafe')).toThrow(/missed touch/i);
+  });
+
+  it('throws ChallengeResponseError on unexpected (non-40-hex) output', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: 'not-hex' });
+    expect(() => computeChallengeResponse('cafe')).toThrow(ChallengeResponseError);
+  });
+});
+
+describe('createDedicatedKeychain', () => {
+  it('returns "created" when SecKeychainCreate succeeds (exit 0)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
+    expect(createDedicatedKeychain('/tmp/k.keychain-db', 'pw')).toBe('created');
+  });
+
+  it('returns "exists" when the keychain is already there (exit 4)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 4 });
+    expect(createDedicatedKeychain('/tmp/k.keychain-db', 'pw')).toBe('exists');
+  });
+
+  it('throws on any other failure', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 1 });
+    expect(() => createDedicatedKeychain('/tmp/k.keychain-db', 'pw')).toThrow();
+  });
+});
+
+describe('unlockDedicatedKeychain', () => {
+  it('succeeds on exit 0', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
+    expect(() => unlockDedicatedKeychain('/tmp/k.keychain-db', 'pw')).not.toThrow();
+  });
+
+  it('throws "not found" on exit 3', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 3 });
+    expect(() => unlockDedicatedKeychain('/tmp/k.keychain-db', 'pw')).toThrow(/not found/i);
+  });
+
+  it('throws "wrong response" on exit 2', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 2 });
+    expect(() => unlockDedicatedKeychain('/tmp/k.keychain-db', 'pw')).toThrow(/wrong response/i);
+  });
+});
+
+describe('keychainLockState', () => {
+  it.each(['unlocked', 'locked', 'missing'] as const)('maps swift output "%s"', (state) => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: `${state}\n` });
+    expect(keychainLockState('/tmp/k.keychain-db')).toBe(state);
+  });
+
+  it('falls back to "missing" on unexpected output', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: 'garbage' });
+    expect(keychainLockState('/tmp/k.keychain-db')).toBe('missing');
+  });
+});
+
+describe('readDedicatedSecret', () => {
+  it('decodes base64 stdout on exit 0', () => {
+    const secret = JSON.stringify({ client_id: 'x' });
+    childProcess.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: Buffer.from(secret, 'utf-8').toString('base64'),
+    });
+    expect(readDedicatedSecret('profile:default', '/tmp/k.keychain-db')).toBe(secret);
+  });
+
+  it('throws KeychainLockedError on exit 2 (locked / interaction not allowed)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 2, stdout: '' });
+    expect(() => readDedicatedSecret('profile:default', '/tmp/k.keychain-db')).toThrow(
+      KeychainLockedError,
+    );
+  });
+
+  it('returns null on exit 3 (item absent)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 3, stdout: '' });
+    expect(readDedicatedSecret('profile:default', '/tmp/k.keychain-db')).toBeNull();
+  });
+
+  it('passes account and keychain path as argv (not interpolated)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 3, stdout: '' });
+    readDedicatedSecret('profile:weird name', '/tmp/odd path.keychain-db');
+    const call = childProcess.spawnSync.mock.calls[0]!;
+    expect(call[0]).toBe('swift');
+    expect(call[1]).toEqual([
+      expect.stringContaining('.swift'),
+      'profile:weird name',
+      '/tmp/odd path.keychain-db',
+    ]);
+  });
+});
+
+describe('security CLI wrappers', () => {
+  it('setLockOnSleep calls `security set-keychain-settings -l <path>`', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
+    setLockOnSleep('/tmp/k.keychain-db');
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'security',
+      ['set-keychain-settings', '-l', '/tmp/k.keychain-db'],
+      expect.anything(),
+    );
+  });
+
+  it('lockKeychain calls `security lock-keychain <path>`', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
+    lockKeychain('/tmp/k.keychain-db');
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'security',
+      ['lock-keychain', '/tmp/k.keychain-db'],
+      expect.anything(),
+    );
+  });
+
+  it('deleteLoginSecret targets the login keychain explicitly and reports success via exit 0', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
+    expect(deleteLoginSecret('profile:default')).toBe(true);
+    const call = childProcess.spawnSync.mock.calls[0]!;
+    expect(call[0]).toBe('security');
+    expect(call[1]).toEqual([
+      'delete-generic-password',
+      '-a',
+      'profile:default',
+      '-s',
+      'fortnox-mcp',
+      loginKeychainPath(),
+    ]);
+  });
+
+  it('deleteLoginSecret returns false when nothing matched (non-zero exit)', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 44 });
+    expect(deleteLoginSecret('profile:none')).toBe(false);
+  });
+});

--- a/tests/keychain-target.test.ts
+++ b/tests/keychain-target.test.ts
@@ -324,3 +324,96 @@ describe('security CLI wrappers', () => {
     expect(deleteLoginSecret('profile:none')).toBe(false);
   });
 });
+
+describe('YubiKey serial enrollment (#33)', () => {
+  it('listYubikeySerials parses one serial per line', async () => {
+    const { listYubikeySerials } = await import('../src/keychain-target.js');
+    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: '12345678\n36014135\n' });
+    expect(listYubikeySerials()).toEqual(['12345678', '36014135']);
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'ykman',
+      ['list', '--serials'],
+      expect.anything(),
+    );
+  });
+
+  it('listYubikeySerials returns [] when ykman fails', async () => {
+    const { listYubikeySerials } = await import('../src/keychain-target.js');
+    childProcess.spawnSync.mockReturnValue({ status: 1, stdout: '' });
+    expect(listYubikeySerials()).toEqual([]);
+  });
+
+  it('enrolledSerialFilePath ends with keychain-serial', async () => {
+    const { enrolledSerialFilePath } = await import('../src/keychain-target.js');
+    expect(enrolledSerialFilePath()).toMatch(/keychain-serial$/);
+  });
+
+  it('readEnrolledSerial returns the trimmed file content or null', async () => {
+    const { readEnrolledSerial } = await import('../src/keychain-target.js');
+    fsSync.default.readFileSync.mockReturnValue(' 12345678\n');
+    expect(readEnrolledSerial()).toBe('12345678');
+    fsSync.default.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(readEnrolledSerial()).toBeNull();
+  });
+
+  it('writeEnrolledSerial persists the serial under the config dir', async () => {
+    const { writeEnrolledSerial, enrolledSerialFilePath } =
+      await import('../src/keychain-target.js');
+    writeEnrolledSerial('12345678');
+    expect(fsSync.default.writeFileSync).toHaveBeenCalledWith(
+      enrolledSerialFilePath(),
+      '12345678\n',
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+});
+
+describe('diagnoseSerialMismatch (#33)', () => {
+  it('is silent when no serial was enrolled', async () => {
+    const { diagnoseSerialMismatch } = await import('../src/keychain-target.js');
+    expect(diagnoseSerialMismatch(null, ['12345678'])).toBeNull();
+  });
+
+  it('is silent when the enrolled key is present', async () => {
+    const { diagnoseSerialMismatch } = await import('../src/keychain-target.js');
+    expect(diagnoseSerialMismatch('12345678', ['12345678', '99999999'])).toBeNull();
+  });
+
+  it('names both serials when a different key is present', async () => {
+    const { diagnoseSerialMismatch } = await import('../src/keychain-target.js');
+    const msg = diagnoseSerialMismatch('12345678', ['36014135']);
+    expect(msg).toContain('12345678');
+    expect(msg).toContain('36014135');
+    expect(msg).toMatch(/different key/i);
+  });
+
+  it('reports when no key is present at all', async () => {
+    const { diagnoseSerialMismatch } = await import('../src/keychain-target.js');
+    const msg = diagnoseSerialMismatch('12345678', []);
+    expect(msg).toContain('12345678');
+    expect(msg).toMatch(/no yubikey/i);
+  });
+});
+
+describe('computeChallengeResponse error rephrasing (#33)', () => {
+  it('explains an unprogrammed slot instead of passing through ykman wording', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'Error: Cannot perform challenge-response on an empty slot.\n',
+    });
+    expect(() => computeChallengeResponse('cafe')).toThrow(/slot 2 is not programmed/i);
+  });
+
+  it('rephrases the misleading "Failed to write" error as a missed touch', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr:
+        'ERROR: Failed to write to the YubiKey. Make sure the device does not have restricted access.\n',
+    });
+    expect(() => computeChallengeResponse('cafe')).toThrow(/missed touch/i);
+  });
+});

--- a/tests/operations/analytics.test.ts
+++ b/tests/operations/analytics.test.ts
@@ -6,6 +6,7 @@ import {
   monthlyRevenueFrom,
   localIsoDate,
   netVatFromVatAccounts,
+  dashboardWindowStart,
 } from '../../src/operations/analytics.js';
 
 const today = '2026-06-10';
@@ -160,5 +161,28 @@ describe('netVatFromVatAccounts', () => {
   it('treats undefined/empty account maps as zero', () => {
     expect(netVatFromVatAccounts(undefined)).toBe(0);
     expect(netVatFromVatAccounts({})).toBe(0);
+  });
+});
+
+describe('dashboardWindowStart', () => {
+  it('is the 1st of the month (months-1) months back, in local time', () => {
+    // 6-month window ending in June -> starts Jan 1.
+    expect(dashboardWindowStart(new Date(2026, 5, 16), 6)).toBe('2026-01-01');
+  });
+
+  it('does not overflow on end-of-month dates (Jul 31, 6mo -> Feb 1, not Mar 1)', () => {
+    // The previous setMonth()/setDate(1) approach normalised "Feb 31" to March,
+    // silently dropping February from the window. Constructing the date pins the
+    // day to 1 first, so the month is exact.
+    expect(dashboardWindowStart(new Date(2026, 6, 31), 6)).toBe('2026-02-01');
+  });
+
+  it('rolls the year back when the window crosses January', () => {
+    // Jan 2026, 6-month window -> Aug 1 2025.
+    expect(dashboardWindowStart(new Date(2026, 0, 15), 6)).toBe('2025-08-01');
+  });
+
+  it('handles a 1-month window (current month start)', () => {
+    expect(dashboardWindowStart(new Date(2026, 6, 31), 1)).toBe('2026-07-01');
   });
 });

--- a/tests/operations/analytics.test.ts
+++ b/tests/operations/analytics.test.ts
@@ -4,6 +4,8 @@ import {
   summarizeUnpaid,
   topCustomersFrom,
   monthlyRevenueFrom,
+  localIsoDate,
+  netVatFromVatAccounts,
 } from '../../src/operations/analytics.js';
 
 const today = '2026-06-10';
@@ -111,5 +113,52 @@ describe('monthlyRevenueFrom', () => {
       { month: '2026-04', total: 3000, invoiceCount: 1 },
       { month: '2026-06', total: 2000, invoiceCount: 1 },
     ]);
+  });
+});
+
+describe('localIsoDate', () => {
+  it('formats local Y-M-D with zero padding', () => {
+    expect(localIsoDate(new Date(2026, 0, 5, 12, 0, 0))).toBe('2026-01-05');
+    expect(localIsoDate(new Date(2026, 8, 9, 0, 0, 0))).toBe('2026-09-09');
+    expect(localIsoDate(new Date(2026, 11, 31, 23, 59, 0))).toBe('2026-12-31');
+  });
+
+  it('uses the LOCAL date near midnight, not the UTC date (off-by-one guard)', () => {
+    const origTz = process.env.TZ;
+    process.env.TZ = 'Europe/Stockholm';
+    try {
+      // 23:30 UTC on 2026-06-16 is 01:30 on 2026-06-17 in Stockholm (UTC+2).
+      // The previous toISOString()-based implementation would wrongly yield
+      // 2026-06-16; localIsoDate must report the local date.
+      const d = new Date('2026-06-16T23:30:00Z');
+      expect(localIsoDate(d)).toBe('2026-06-17');
+    } finally {
+      if (origTz === undefined) delete process.env.TZ;
+      else process.env.TZ = origTz;
+    }
+  });
+});
+
+describe('netVatFromVatAccounts', () => {
+  it('sums debit - credit across accounts (negative = owed to Skatteverket)', () => {
+    // 5000 output VAT (credit) and 1200.50 input VAT (debit) => net 1200.50 - 5000.
+    const net = netVatFromVatAccounts({
+      2610: { debit: 0, credit: 5000 },
+      2640: { debit: 1200.5, credit: 0 },
+    });
+    expect(net).toBeCloseTo(-3799.5, 2);
+  });
+
+  it('returns a positive figure when input VAT exceeds output VAT (refund due)', () => {
+    const net = netVatFromVatAccounts({
+      2610: { debit: 0, credit: 1000 },
+      2640: { debit: 2500, credit: 0 },
+    });
+    expect(net).toBeCloseTo(1500, 2);
+  });
+
+  it('treats undefined/empty account maps as zero', () => {
+    expect(netVatFromVatAccounts(undefined)).toBe(0);
+    expect(netVatFromVatAccounts({})).toBe(0);
   });
 });

--- a/tests/operations/analytics.test.ts
+++ b/tests/operations/analytics.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeOverdue,
+  summarizeUnpaid,
+  topCustomersFrom,
+  monthlyRevenueFrom,
+} from '../../src/operations/analytics.js';
+
+const today = '2026-06-10';
+
+const invoices = [
+  // paid
+  {
+    DocumentNumber: '1',
+    CustomerName: 'Acme',
+    CustomerNumber: '10',
+    InvoiceDate: '2026-01-15',
+    DueDate: '2026-02-14',
+    Total: 1000,
+    Balance: 0,
+    FinalPayDate: '2026-02-01',
+  },
+  // unpaid, not overdue
+  {
+    DocumentNumber: '2',
+    CustomerName: 'Acme',
+    CustomerNumber: '10',
+    InvoiceDate: '2026-06-01',
+    DueDate: '2026-07-01',
+    Total: 2000,
+    Balance: 2000,
+  },
+  // unpaid, overdue
+  {
+    DocumentNumber: '3',
+    CustomerName: 'Beta AB',
+    CustomerNumber: '11',
+    InvoiceDate: '2026-04-01',
+    DueDate: '2026-05-01',
+    Total: 3000,
+    Balance: 1500,
+  },
+  // overdue, older
+  {
+    DocumentNumber: '4',
+    CustomerName: 'Beta AB',
+    CustomerNumber: '11',
+    InvoiceDate: '2026-02-01',
+    DueDate: '2026-03-03',
+    Total: 500,
+    Balance: 500,
+  },
+  // cancelled — must be excluded everywhere
+  {
+    DocumentNumber: '5',
+    CustomerName: 'Ghost',
+    CustomerNumber: '12',
+    InvoiceDate: '2026-06-05',
+    DueDate: '2026-07-05',
+    Total: 9999,
+    Balance: 9999,
+    Cancelled: true,
+  },
+];
+
+describe('summarizeOverdue', () => {
+  it('counts overdue invoices and sums outstanding balance', () => {
+    const s = summarizeOverdue(invoices, today);
+    expect(s.count).toBe(2);
+    expect(s.totalBalance).toBe(2000);
+    expect(s.oldestDueDate).toBe('2026-03-03');
+    expect(s.invoices.map((i) => i.DocumentNumber)).toEqual(['4', '3']); // oldest first
+  });
+
+  it('excludes cancelled and fully paid invoices', () => {
+    const s = summarizeOverdue(invoices, today);
+    expect(s.invoices.find((i) => i.DocumentNumber === '5')).toBeUndefined();
+    expect(s.invoices.find((i) => i.DocumentNumber === '1')).toBeUndefined();
+  });
+});
+
+describe('summarizeUnpaid', () => {
+  it('sums all open balances and splits out the overdue part', () => {
+    const s = summarizeUnpaid(invoices, today);
+    expect(s.count).toBe(3);
+    expect(s.totalBalance).toBe(4000);
+    expect(s.overdueCount).toBe(2);
+    expect(s.overdueBalance).toBe(2000);
+  });
+});
+
+describe('topCustomersFrom', () => {
+  it('ranks customers by invoiced total, excluding cancelled', () => {
+    const top = topCustomersFrom(invoices, 10);
+    expect(top[0]).toMatchObject({ CustomerName: 'Beta AB', total: 3500, invoiceCount: 2 });
+    expect(top[1]).toMatchObject({ CustomerName: 'Acme', total: 3000, invoiceCount: 2 });
+    expect(top.find((c) => c.CustomerName === 'Ghost')).toBeUndefined();
+  });
+
+  it('respects the limit', () => {
+    expect(topCustomersFrom(invoices, 1)).toHaveLength(1);
+  });
+});
+
+describe('monthlyRevenueFrom', () => {
+  it('groups invoiced totals by month, excluding cancelled', () => {
+    const months = monthlyRevenueFrom(invoices);
+    expect(months).toEqual([
+      { month: '2026-01', total: 1000, invoiceCount: 1 },
+      { month: '2026-02', total: 500, invoiceCount: 1 },
+      { month: '2026-04', total: 3000, invoiceCount: 1 },
+      { month: '2026-06', total: 2000, invoiceCount: 1 },
+    ]);
+  });
+});

--- a/tests/operations/contracts.test.ts
+++ b/tests/operations/contracts.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+function mockFetch(response: unknown) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+function calledUrl(): string {
+  return (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+}
+
+function fetchCall(): [string, { method?: string; body?: string }] {
+  return (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+    string,
+    { method?: string; body?: string },
+  ];
+}
+
+describe('contract operations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listContracts', () => {
+    it('passes the filter query param', async () => {
+      mockFetch({ Contracts: [], MetaInformation: {} });
+      const { listContracts } = await import('../../src/operations/contracts.js');
+
+      await listContracts({ filter: 'active' });
+
+      expect(calledUrl()).toContain('contracts');
+      expect(calledUrl()).toContain('filter=active');
+    });
+  });
+
+  describe('getContract', () => {
+    it('unwraps the Contract envelope', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1', CustomerNumber: '25' } });
+      const { getContract } = await import('../../src/operations/contracts.js');
+
+      const result = await getContract('1');
+      expect(result.DocumentNumber).toBe('1');
+    });
+
+    it('rejects path traversal in document numbers', async () => {
+      mockFetch({ Contract: {} });
+      const { getContract } = await import('../../src/operations/contracts.js');
+
+      await expect(getContract('../companyinformation')).rejects.toThrow();
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('createContract', () => {
+    it('wraps params in Contract envelope for POST', async () => {
+      mockFetch({ Contract: { DocumentNumber: '2' } });
+      const { createContract } = await import('../../src/operations/contracts.js');
+
+      await createContract({ CustomerNumber: '25', InvoiceInterval: 3 });
+
+      const [, init] = fetchCall();
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body!) as { Contract: Record<string, unknown> };
+      expect(body.Contract.CustomerNumber).toBe('25');
+    });
+  });
+
+  describe('updateContract', () => {
+    it('uses PUT against the document number', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1' } });
+      const { updateContract } = await import('../../src/operations/contracts.js');
+
+      await updateContract('1', { Comments: 'Updated' });
+
+      const [url, init] = fetchCall();
+      expect(url).toContain('contracts/1');
+      expect(init.method).toBe('PUT');
+    });
+  });
+
+  describe('contract actions', () => {
+    it('finishContract PUTs to /finish', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1' } });
+      const { finishContract } = await import('../../src/operations/contracts.js');
+
+      await finishContract('1');
+
+      const [url, init] = fetchCall();
+      expect(url).toContain('contracts/1/finish');
+      expect(init.method).toBe('PUT');
+    });
+
+    it('createInvoiceFromContract PUTs to /createinvoice and unwraps Invoice', async () => {
+      mockFetch({ Invoice: { DocumentNumber: '99' } });
+      const { createInvoiceFromContract } = await import('../../src/operations/contracts.js');
+
+      const result = await createInvoiceFromContract('1');
+
+      const [url, init] = fetchCall();
+      expect(url).toContain('contracts/1/createinvoice');
+      expect(init.method).toBe('PUT');
+      expect(result.DocumentNumber).toBe('99');
+    });
+
+    it('increaseInvoiceCount PUTs to /increaseinvoicecount', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1', InvoicesRemaining: 5 } });
+      const { increaseInvoiceCount } = await import('../../src/operations/contracts.js');
+
+      await increaseInvoiceCount('1');
+
+      const [url, init] = fetchCall();
+      expect(url).toContain('contracts/1/increaseinvoicecount');
+      expect(init.method).toBe('PUT');
+    });
+  });
+});

--- a/tests/operations/customers.test.ts
+++ b/tests/operations/customers.test.ts
@@ -94,6 +94,31 @@ describe('customer operations', () => {
       const result = await createCustomer({ Name: 'New Corp' });
       expect(result.CustomerNumber).toBe('2');
     });
+
+    it('strips server-derived read-only fields so read→create round-trips work', async () => {
+      mockFetch({ Customer: { CustomerNumber: '2', Name: 'AFRY AB' } });
+      const { createCustomer } = await import('../../src/operations/customers.js');
+
+      await createCustomer({
+        Name: 'AFRY AB',
+        Country: 'Sverige',
+        CountryCode: 'SE',
+        DeliveryCountry: 'Sverige',
+        DeliveryCountryCode: 'SE',
+        VisitingCountry: 'Sverige',
+        VisitingCountryCode: 'SE',
+      });
+
+      const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body) as {
+        Customer: Record<string, unknown>;
+      };
+      expect(body.Customer.Country).toBeUndefined();
+      expect(body.Customer.DeliveryCountry).toBeUndefined();
+      expect(body.Customer.VisitingCountry).toBeUndefined();
+      expect(body.Customer.CountryCode).toBe('SE');
+      expect(body.Customer.DeliveryCountryCode).toBe('SE');
+      expect(body.Customer.VisitingCountryCode).toBe('SE');
+    });
   });
 
   describe('updateCustomer', () => {
@@ -109,6 +134,19 @@ describe('customer operations', () => {
       const body = JSON.parse(fetchCall[1].body);
       expect(body.Customer.Name).toBe('Updated');
       expect(body.Customer.customerNumber).toBeUndefined();
+    });
+
+    it('strips server-derived read-only fields', async () => {
+      mockFetch({ Customer: { CustomerNumber: '1', Name: 'Updated' } });
+      const { updateCustomer } = await import('../../src/operations/customers.js');
+
+      await updateCustomer('1', { Name: 'Updated', Country: 'Sverige', CountryCode: 'SE' });
+
+      const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body) as {
+        Customer: Record<string, unknown>;
+      };
+      expect(body.Customer.Country).toBeUndefined();
+      expect(body.Customer.CountryCode).toBe('SE');
     });
   });
 });

--- a/tests/operations/financial-years.test.ts
+++ b/tests/operations/financial-years.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+function mockFetch(response: unknown) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+describe('financial year operations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listFinancialYears', () => {
+    it('fetches financialyears and returns the envelope', async () => {
+      const response = {
+        FinancialYears: [{ Id: 1, FromDate: '2025-01-01', ToDate: '2025-12-31' }],
+        MetaInformation: { '@TotalResources': 1, '@TotalPages': 1, '@CurrentPage': 1 },
+      };
+      mockFetch(response);
+      const { listFinancialYears } = await import('../../src/operations/financial-years.js');
+
+      const result = await listFinancialYears();
+      expect(result.FinancialYears).toHaveLength(1);
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('financialyears');
+    });
+
+    it('passes Date filter to find the year containing a date', async () => {
+      mockFetch({ FinancialYears: [] });
+      const { listFinancialYears } = await import('../../src/operations/financial-years.js');
+
+      await listFinancialYears({ date: '2026-03-15' });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('Date=2026-03-15');
+    });
+  });
+
+  describe('getFinancialYear', () => {
+    it('unwraps the FinancialYear envelope', async () => {
+      mockFetch({ FinancialYear: { Id: 2, FromDate: '2026-01-01' } });
+      const { getFinancialYear } = await import('../../src/operations/financial-years.js');
+
+      const result = await getFinancialYear(2);
+      expect(result.Id).toBe(2);
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('financialyears/2');
+    });
+  });
+
+  describe('getLockedPeriod', () => {
+    it('unwraps the LockedPeriod envelope', async () => {
+      mockFetch({ LockedPeriod: { EndDate: '2026-01-31' } });
+      const { getLockedPeriod } = await import('../../src/operations/financial-years.js');
+
+      const result = await getLockedPeriod();
+      expect(result.EndDate).toBe('2026-01-31');
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('settings/lockedperiod');
+    });
+
+    it('returns an empty object when no period is locked', async () => {
+      mockFetch({ LockedPeriod: {} });
+      const { getLockedPeriod } = await import('../../src/operations/financial-years.js');
+
+      const result = await getLockedPeriod();
+      expect(result).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary

One commit per issue, red/green TDD where substantive. 552 unit tests passing (up from 499), lint clean.

### Bugs
- **#31** — `customers create/update` now strip the server-derived read-only fields `Country`, `DeliveryCountry`, `VisitingCountry` (operations layer, so CLI and MCP both benefit). Read→create round-trips just work.
- **#34** — Single-resource JSON output is now consistently wrapped under its resource key (`{"Invoice": {...}}`), matching the list convention; `-o` help documents the default mode (table on TTY, JSON when piped).

### Enhancements
- **#32** — JSON mode failures emit `{"error": {status?, message, hint?, source}}` to stderr instead of plain text.
- **#6** — the y/N confirmation shows the exact request payload before prompting.
- **#8** — `noxctl completion bash|zsh|fish` generated from the Commander command tree (bash/zsh outputs syntax-checked).
- **#9** — `--period Q1|2025-Q3|march|mars|last-quarter|ytd|...` on list/report commands. Calendar-year based; the fiscal-year-aware design stays open as noted in the issue.
- **#33** — `keychain init` records the enrolled YubiKey serial; `unlock` preflights `ykman list --serials` and names both serials on mismatch. ykman's misleading "empty slot" / "Failed to write" errors are translated.
- **#11** — Financial years + locked period (operations, MCP tools, CLI).
- **#10** — Contracts API: list/get/create/update/finish/create-invoice/increase-invoice-count (operations, MCP tools, CLI).
- **#7** — analytics views: overdue summary, unpaid totals, top customers, VAT summary with net VAT position (pure aggregation functions unit-tested separately).
- **#12** — `noxctl dashboard` composing the analytics ops.

### Breaking note
The #34 envelope change means scripts consuming bare single-resource JSON must unwrap one level (documented in CHANGELOG under Unreleased → Changed).

Closes #31
Closes #34
Closes #32
Closes #6
Closes #8
Closes #9
Closes #33
Closes #11
Closes #10
Closes #7
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)