### PR TITLE
feat: voucher file attachments (vouchers attach + MCP tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Voucher file attachments** (#37) — `noxctl vouchers attach <series> <number> <file...> [--year]` uploads receipt/underlag files to the Fortnox inbox and links them to a voucher; matching `fortnox_attach_voucher_files` MCP tool. The financial year is resolved from the voucher's transaction date when `--year` is omitted. Requires the Fortnox "archive" scope enabled on the app. Also delivers the file-attachments half of #13.
 - **Contracts API** (#10) — recurring invoicing: `noxctl contracts list|get|create|update|finish|create-invoice|increase-invoice-count` and matching MCP tools.
 - **Financial years / locked period** (#11) — `noxctl financial-years list|get|locked-period` and MCP tools; context for period-aware operations.
 - **Analytics views** (#7) — overdue summary, unpaid totals, top customers, VAT summary with net VAT position: `noxctl analytics ...` and MCP tools.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl vouchers list [--series <s>] [--from <date>] [--to <date>]` | `fortnox_list_vouchers` | List vouchers, optionally filtered by series and date range |
 | `noxctl vouchers get <series> <number>` | `fortnox_get_voucher` | Get a single voucher with rows |
 | `noxctl vouchers create --input <file>` | `fortnox_create_voucher` | Create a voucher with debit/credit rows (mutation) |
+| `noxctl vouchers attach <series> <number> <file...> [--year]` | `fortnox_attach_voucher_files` | Upload receipt/underlag files and link them to a voucher (mutation; needs the Fortnox archive scope) |
 | `noxctl accounts list [--search <term>]` | `fortnox_list_accounts` | View chart of accounts, search by name or number |
 
 ### Financial reports

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2021,7 +2021,7 @@ Examples:
         financialYear: opts.year,
       });
       if (json()) {
-        console.log(JSON.stringify({ VoucherFileConnections: results }, null, 2));
+        console.log(JSON.stringify({ Attachments: results }, null, 2));
       } else {
         outputList(
           results as unknown as Record<string, unknown>[],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ import {
   contractDetailColumns,
   topCustomerColumns,
   monthlyRevenueColumns,
+  voucherAttachmentColumns,
 } from './views.js';
 
 const program = new Command();
@@ -1982,6 +1983,55 @@ Examples:
     const data = await createVoucher(params);
     outputDetail(data as Record<string, unknown>, voucherDetailColumns, json(), 'Voucher');
   });
+
+vouchers
+  .command('attach <series> <number> <files...>')
+  .description('Upload receipt/underlag files and link them to a voucher')
+  .option('--year <number>', 'Financial year (resolved from the voucher date if omitted)', parseInt)
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without uploading')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  noxctl vouchers attach A 60 receipt.pdf
+  noxctl vouchers attach A 61 ica.pdf lunch.jpg --year 4`,
+  )
+  .action(
+    async (
+      series: string,
+      voucherNumber: string,
+      files: string[],
+      opts: { year?: number; yes?: boolean; dryRun?: boolean },
+    ) => {
+      const { attachVoucherFiles } = await import('./operations/vouchers.js');
+      if (
+        !(await confirmMutation(
+          `Attach ${files.length} file(s) to voucher ${series}/${voucherNumber}`,
+          opts,
+          { files, year: opts.year },
+        ))
+      ) {
+        return;
+      }
+      const results = await attachVoucherFiles({
+        series,
+        voucherNumber,
+        filePaths: files,
+        financialYear: opts.year,
+      });
+      if (json()) {
+        console.log(JSON.stringify({ VoucherFileConnections: results }, null, 2));
+      } else {
+        outputList(
+          results as unknown as Record<string, unknown>[],
+          voucherAttachmentColumns,
+          false,
+          results,
+        );
+      }
+    },
+  );
 
 // --- invoice-payments ---
 const invoicePayments = program

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -166,7 +166,6 @@ export async function fortnoxRequest<T>(
 
     const headers: Record<string, string> = {
       Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
       Accept: 'application/json',
     };
 
@@ -176,11 +175,15 @@ export async function fortnoxRequest<T>(
     };
 
     if (options.rawBody !== undefined) {
+      // A raw body (e.g. FormData for a multipart file upload): do NOT set
+      // Content-Type — fetch/undici derives it (and the multipart boundary)
+      // from the body itself.
       fetchOptions.body = options.rawBody;
-      // Let fetch/undici set the multipart boundary itself.
-      delete (headers as Record<string, string>)['Content-Type'];
-    } else if (options.body) {
-      fetchOptions.body = JSON.stringify(options.body);
+    } else {
+      headers['Content-Type'] = 'application/json';
+      if (options.body) {
+        fetchOptions.body = JSON.stringify(options.body);
+      }
     }
 
     const response = await fetch(url.toString(), fetchOptions);

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -95,6 +95,9 @@ function endpointToScope(endpoint: string): string | undefined {
     taxreductions: 'invoice',
     pricelists: 'price',
     prices: 'price',
+    inbox: 'archive',
+    archive: 'archive',
+    voucherfileconnections: 'archive',
   };
   for (const [prefix, scope] of Object.entries(mapping)) {
     if (path.startsWith(prefix)) return scope;
@@ -136,6 +139,7 @@ async function retryWithBackoff<T>(
 export interface RequestOptions {
   method?: string;
   body?: unknown;
+  rawBody?: BodyInit;
   params?: Record<string, string | number | undefined>;
 }
 
@@ -171,7 +175,11 @@ export async function fortnoxRequest<T>(
       headers,
     };
 
-    if (options.body) {
+    if (options.rawBody !== undefined) {
+      fetchOptions.body = options.rawBody;
+      // Let fetch/undici set the multipart boundary itself.
+      delete (headers as Record<string, string>)['Content-Type'];
+    } else if (options.body) {
       fetchOptions.body = JSON.stringify(options.body);
     }
 

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import { fortnoxRequest, fetchAllPages } from '../fortnox-client.js';
 import { voucherSeriesSegment } from '../identifiers.js';
+import { listFinancialYears } from './financial-years.js';
 
 interface VoucherResponse {
   Voucher: Record<string, unknown>;
@@ -73,4 +76,87 @@ export async function createVoucher(
     },
   });
   return data.Voucher;
+}
+
+interface InboxFileResponse {
+  File: Record<string, unknown>;
+}
+interface VoucherFileConnectionResponse {
+  VoucherFileConnection: Record<string, unknown>;
+}
+
+// Upload a single file to the Fortnox inbox; returns the archived File object (has .Id).
+export async function uploadInboxFile(filePath: string): Promise<Record<string, unknown>> {
+  const buf = readFileSync(filePath);
+  const form = new FormData();
+  form.append('file', new Blob([buf]), basename(filePath));
+  const data = await fortnoxRequest<InboxFileResponse>('inbox', { method: 'POST', rawBody: form });
+  return data.File;
+}
+
+// Link an already-uploaded file (by id) to a voucher.
+export async function createVoucherFileConnection(
+  series: string,
+  voucherNumber: string,
+  fileId: string,
+  financialYear?: number,
+): Promise<Record<string, unknown>> {
+  const connection: Record<string, unknown> = {
+    FileId: fileId,
+    VoucherSeries: series,
+    VoucherNumber: voucherNumber,
+  };
+  if (financialYear !== undefined) connection.VoucherYear = financialYear;
+  const data = await fortnoxRequest<VoucherFileConnectionResponse>('voucherfileconnections', {
+    method: 'POST',
+    body: { VoucherFileConnection: connection },
+  });
+  return data.VoucherFileConnection;
+}
+
+export interface AttachVoucherFilesParams {
+  series: string;
+  voucherNumber: string;
+  filePaths: string[];
+  financialYear?: number;
+}
+export interface VoucherFileAttachment {
+  fileName: string;
+  fileId: string;
+  connection: Record<string, unknown>;
+}
+
+// Resolve the financial year from the voucher's transaction date when not given.
+async function resolveVoucherFinancialYear(
+  series: string,
+  voucherNumber: string,
+): Promise<number | undefined> {
+  const voucher = await getVoucher(series, voucherNumber);
+  const date = (voucher as Record<string, unknown>).TransactionDate as string | undefined;
+  if (!date) return undefined;
+  const fy = await listFinancialYears({ date });
+  const list = (fy.FinancialYears ?? []) as Record<string, unknown>[];
+  return list.length ? Number(list[0]!.Id) : undefined;
+}
+
+// Orchestrate: resolve year if omitted, then upload+connect each file in order.
+export async function attachVoucherFiles(
+  params: AttachVoucherFilesParams,
+): Promise<VoucherFileAttachment[]> {
+  const year =
+    params.financialYear ??
+    (await resolveVoucherFinancialYear(params.series, params.voucherNumber));
+  const results: VoucherFileAttachment[] = [];
+  for (const filePath of params.filePaths) {
+    const file = await uploadInboxFile(filePath);
+    const fileId = String((file as Record<string, unknown>).Id);
+    const connection = await createVoucherFileConnection(
+      params.series,
+      params.voucherNumber,
+      fileId,
+      year,
+    );
+    results.push({ fileName: basename(filePath), fileId, connection });
+  }
+  return results;
 }

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs';
-import { basename } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, extname } from 'node:path';
 import { fortnoxRequest, fetchAllPages } from '../fortnox-client.js';
 import { voucherSeriesSegment } from '../identifiers.js';
 import { listFinancialYears } from './financial-years.js';
@@ -85,11 +85,30 @@ interface VoucherFileConnectionResponse {
   VoucherFileConnection: Record<string, unknown>;
 }
 
+const MIME_BY_EXT: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.heic': 'image/heic',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.xml': 'application/xml',
+};
+
+function mimeForFile(filePath: string): string {
+  return MIME_BY_EXT[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
 // Upload a single file to the Fortnox inbox; returns the archived File object (has .Id).
 export async function uploadInboxFile(filePath: string): Promise<Record<string, unknown>> {
   const buf = readFileSync(filePath);
   const form = new FormData();
-  form.append('file', new Blob([buf]), basename(filePath));
+  form.append('file', new Blob([buf], { type: mimeForFile(filePath) }), basename(filePath));
   const data = await fortnoxRequest<InboxFileResponse>('inbox', { method: 'POST', rawBody: form });
   return data.File;
 }
@@ -123,40 +142,69 @@ export interface AttachVoucherFilesParams {
 export interface VoucherFileAttachment {
   fileName: string;
   fileId: string;
+  voucherYear: number;
   connection: Record<string, unknown>;
 }
 
 // Resolve the financial year from the voucher's transaction date when not given.
-async function resolveVoucherFinancialYear(
-  series: string,
-  voucherNumber: string,
-): Promise<number | undefined> {
+// Throws (rather than silently leaving the year undefined) when it can't be
+// determined, so the user knows to pass --year explicitly — e.g. for a voucher
+// in a past financial year, which getVoucher can't fetch without the year.
+async function resolveVoucherFinancialYear(series: string, voucherNumber: string): Promise<number> {
   const voucher = await getVoucher(series, voucherNumber);
   const date = (voucher as Record<string, unknown>).TransactionDate as string | undefined;
-  if (!date) return undefined;
+  if (!date) {
+    throw new Error(
+      `Could not determine the financial year: voucher ${series}/${voucherNumber} has no TransactionDate. Pass --year explicitly.`,
+    );
+  }
   const fy = await listFinancialYears({ date });
   const list = (fy.FinancialYears ?? []) as Record<string, unknown>[];
-  return list.length ? Number(list[0]!.Id) : undefined;
+  if (!list.length) {
+    throw new Error(`No financial year found for voucher date ${date}. Pass --year explicitly.`);
+  }
+  return Number(list[0]!.Id);
 }
 
 // Orchestrate: resolve year if omitted, then upload+connect each file in order.
 export async function attachVoucherFiles(
   params: AttachVoucherFilesParams,
 ): Promise<VoucherFileAttachment[]> {
+  // Pre-flight: confirm every file exists before uploading any of them, so a
+  // typo in a later path can't leave earlier files orphaned in the inbox.
+  for (const filePath of params.filePaths) {
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+  }
+
   const year =
     params.financialYear ??
     (await resolveVoucherFinancialYear(params.series, params.voucherNumber));
+
   const results: VoucherFileAttachment[] = [];
   for (const filePath of params.filePaths) {
-    const file = await uploadInboxFile(filePath);
-    const fileId = String((file as Record<string, unknown>).Id);
-    const connection = await createVoucherFileConnection(
-      params.series,
-      params.voucherNumber,
-      fileId,
-      year,
-    );
-    results.push({ fileName: basename(filePath), fileId, connection });
+    try {
+      const file = await uploadInboxFile(filePath);
+      // Per Fortnox docs (best-practices/vouchers): use the uploaded file's
+      // `Id` as the VoucherFileConnection FileId — NOT ArchiveFileId.
+      const fileId = String((file as Record<string, unknown>).Id);
+      const connection = await createVoucherFileConnection(
+        params.series,
+        params.voucherNumber,
+        fileId,
+        year,
+      );
+      results.push({ fileName: basename(filePath), fileId, voucherYear: year, connection });
+    } catch (err) {
+      // Surface what already succeeded so the user can locate/clean up any files
+      // uploaded to the inbox before this failure.
+      const done = results.map((r) => r.fileName).join(', ') || 'none';
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed attaching "${basename(filePath)}" to voucher ${params.series}/${params.voucherNumber}: ${detail}. Files already attached this run: ${done}.`,
+      );
+    }
   }
   return results;
 }

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { basename, extname } from 'node:path';
 import { fortnoxRequest, fetchAllPages } from '../fortnox-client.js';
 import { voucherSeriesSegment } from '../identifiers.js';
@@ -175,6 +175,9 @@ export async function attachVoucherFiles(
   for (const filePath of params.filePaths) {
     if (!existsSync(filePath)) {
       throw new Error(`File not found: ${filePath}`);
+    }
+    if (!statSync(filePath).isFile()) {
+      throw new Error(`Not a file: ${filePath}`);
     }
   }
 

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -1,7 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { listAccounts } from '../operations/accounts.js';
-import { listVouchers, getVoucher, createVoucher } from '../operations/vouchers.js';
+import {
+  listVouchers,
+  getVoucher,
+  createVoucher,
+  attachVoucherFiles,
+} from '../operations/vouchers.js';
 import {
   accountListColumns,
   voucherDetailColumns,
@@ -13,6 +18,7 @@ import {
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 const VoucherRowSchema = z.object({
@@ -124,6 +130,52 @@ export function registerBookkeepingTools(server: McpServer): void {
         data,
         data.MetaInformation,
         includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_attach_voucher_files',
+    'Ladda upp kvitto/underlagsfiler och koppla dem till en verifikation i Fortnox',
+    {
+      series: z.string().describe('Verifikationsserie (t.ex. "A")'),
+      voucherNumber: z.string().describe('Verifikationsnummer'),
+      files: z.array(z.string()).describe('Sökvägar till filer som ska laddas upp och kopplas'),
+      year: z
+        .number()
+        .optional()
+        .describe('Räkenskapsår (härleds från verifikationsdatum om utelämnat)'),
+      confirm: z.boolean().optional().describe('Bekräfta att filerna ska kopplas'),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe('Visa vad som skulle skickas utan att ladda upp filerna'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ series, voucherNumber, files, year, confirm, dryRun }) => {
+      if (dryRun) {
+        return dryRunResponse(
+          `attach ${files.length} file(s) to voucher ${series}/${voucherNumber}`,
+          {
+            series,
+            voucherNumber,
+            files,
+            year,
+          },
+        );
+      }
+      if (!confirm) {
+        requireConfirmation(`attach ${files.length} file(s) to voucher ${series}/${voucherNumber}`);
+      }
+      const results = await attachVoucherFiles({
+        series,
+        voucherNumber,
+        filePaths: files,
+        financialYear: year,
+      });
+      const ids = results.map((r) => r.fileId).join(', ');
+      return textResponse(
+        `Kopplade ${results.length} fil(er) till verifikation ${series}/${voucherNumber}. Fil-ID: ${ids}`,
       );
     },
   );

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -152,7 +152,7 @@ export function registerBookkeepingTools(server: McpServer): void {
         .describe('Visa vad som skulle skickas utan att ladda upp filerna'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
     },
-    async ({ series, voucherNumber, files, year, confirm, dryRun }) => {
+    async ({ series, voucherNumber, files, year, confirm, dryRun, includeRaw }) => {
       if (dryRun) {
         return dryRunResponse(
           `attach ${files.length} file(s) to voucher ${series}/${voucherNumber}`,
@@ -174,8 +174,9 @@ export function registerBookkeepingTools(server: McpServer): void {
         financialYear: year,
       });
       const ids = results.map((r) => r.fileId).join(', ');
+      const summary = `Kopplade ${results.length} fil(er) till verifikation ${series}/${voucherNumber}. Fil-ID: ${ids}`;
       return textResponse(
-        `Kopplade ${results.length} fil(er) till verifikation ${series}/${voucherNumber}. Fil-ID: ${ids}`,
+        includeRaw ? `${summary}\n\n${JSON.stringify(results, null, 2)}` : summary,
       );
     },
   );

--- a/src/views.ts
+++ b/src/views.ts
@@ -456,3 +456,10 @@ export const monthlyRevenueColumns: Column[] = [
   { key: 'total', header: 'Invoiced', width: 14, align: 'right', format: currency },
   { key: 'invoiceCount', header: 'Invoices', width: 8, align: 'right' },
 ];
+
+// --- Voucher file attachment views ---
+
+export const voucherAttachmentColumns: Column[] = [
+  { key: 'fileName', header: 'File', width: 40 },
+  { key: 'fileId', header: 'File ID', width: 36 },
+];

--- a/src/views.ts
+++ b/src/views.ts
@@ -462,4 +462,5 @@ export const monthlyRevenueColumns: Column[] = [
 export const voucherAttachmentColumns: Column[] = [
   { key: 'fileName', header: 'File', width: 40 },
   { key: 'fileId', header: 'File ID', width: 36 },
+  { key: 'voucherYear', header: 'Year', width: 5, align: 'right' },
 ];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -50,6 +50,17 @@ describe('CLI smoke tests', () => {
     const output = execFileSync('node', [CLI_PATH, 'vouchers', '--help'], execOpts) as string;
     expect(output).toContain('list');
     expect(output).toContain('create');
+    expect(output).toContain('attach');
+  });
+
+  it('noxctl vouchers attach --help shows file and year options', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'vouchers', 'attach', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('--year');
+    expect(output).toContain('--dry-run');
   });
 
   it('noxctl reports --help shows report subcommands', () => {

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -245,4 +245,23 @@ describe('fortnox-client', () => {
       }
     });
   });
+
+  it('sends a raw (FormData) body without a JSON Content-Type so fetch sets the multipart boundary', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: () => Promise.resolve(JSON.stringify({ File: { Id: 'x' } })),
+    });
+    const form = new FormData();
+    form.append('file', new Blob([Buffer.from('data')]), 'r.pdf');
+
+    await fortnoxRequest('inbox', { method: 'POST', rawBody: form });
+
+    const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(form);
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBeUndefined();
+    expect(headers.Authorization).toBe('Bearer mock-token');
+  });
 });

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -7,12 +7,18 @@ vi.mock('../../src/auth.js', () => ({
 const fsMock = vi.hoisted(() => {
   const readFileSync = vi.fn(() => Buffer.from('fake-file-content'));
   const existsSync = vi.fn(() => true);
-  return { readFileSync, existsSync };
+  const statSync = vi.fn(() => ({ isFile: () => true }));
+  return { readFileSync, existsSync, statSync };
 });
 vi.mock('node:fs', () => ({
-  default: { readFileSync: fsMock.readFileSync, existsSync: fsMock.existsSync },
+  default: {
+    readFileSync: fsMock.readFileSync,
+    existsSync: fsMock.existsSync,
+    statSync: fsMock.statSync,
+  },
   readFileSync: fsMock.readFileSync,
   existsSync: fsMock.existsSync,
+  statSync: fsMock.statSync,
 }));
 
 function mockFetch(response: unknown) {
@@ -29,6 +35,7 @@ describe('voucher operations', () => {
     // Re-establish fs defaults each test (restoreAllMocks below clears them).
     fsMock.readFileSync.mockReturnValue(Buffer.from('fake-file-content'));
     fsMock.existsSync.mockReturnValue(true);
+    fsMock.statSync.mockReturnValue({ isFile: () => true });
   });
 
   afterEach(() => {
@@ -348,6 +355,23 @@ describe('voucher operations', () => {
           financialYear: 4,
         }),
       ).rejects.toThrow(/File not found: \/tmp\/missing\.pdf/);
+
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('rejects a directory path before uploading (no EISDIR mid-batch)', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+      fsMock.statSync.mockReturnValue({ isFile: () => false });
+      mockFetch({});
+
+      await expect(
+        attachVoucherFiles({
+          series: 'A',
+          voucherNumber: '60',
+          filePaths: ['/tmp/adir'],
+          financialYear: 4,
+        }),
+      ).rejects.toThrow(/Not a file: \/tmp\/adir/);
 
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     });

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -1,14 +1,18 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
 }));
 
+const fsMock = vi.hoisted(() => {
+  const readFileSync = vi.fn(() => Buffer.from('fake-file-content'));
+  const existsSync = vi.fn(() => true);
+  return { readFileSync, existsSync };
+});
 vi.mock('node:fs', () => ({
-  default: {
-    readFileSync: vi.fn().mockReturnValue(Buffer.from('fake-file-content')),
-  },
-  readFileSync: vi.fn().mockReturnValue(Buffer.from('fake-file-content')),
+  default: { readFileSync: fsMock.readFileSync, existsSync: fsMock.existsSync },
+  readFileSync: fsMock.readFileSync,
+  existsSync: fsMock.existsSync,
 }));
 
 function mockFetch(response: unknown) {
@@ -21,6 +25,12 @@ function mockFetch(response: unknown) {
 }
 
 describe('voucher operations', () => {
+  beforeEach(() => {
+    // Re-establish fs defaults each test (restoreAllMocks below clears them).
+    fsMock.readFileSync.mockReturnValue(Buffer.from('fake-file-content'));
+    fsMock.existsSync.mockReturnValue(true);
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -243,8 +253,8 @@ describe('voucher operations', () => {
       });
 
       expect(results).toHaveLength(2);
-      expect(results[0]).toMatchObject({ fileName: 'a.pdf', fileId: 'id1' });
-      expect(results[1]).toMatchObject({ fileName: 'b.jpg', fileId: 'id2' });
+      expect(results[0]).toMatchObject({ fileName: 'a.pdf', fileId: 'id1', voucherYear: 4 });
+      expect(results[1]).toMatchObject({ fileName: 'b.jpg', fileId: 'id2', voucherYear: 4 });
     });
 
     it('resolves financialYear from voucher when not provided', async () => {
@@ -323,6 +333,81 @@ describe('voucher operations', () => {
       const connectionCall = mockFn.mock.calls[3] as [string, RequestInit];
       const body = JSON.parse(connectionCall[1].body as string);
       expect(body.VoucherFileConnection.VoucherYear).toBe(4);
+    });
+
+    it('fails fast (before any upload) when a file path does not exist', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+      fsMock.existsSync.mockReturnValue(false);
+      mockFetch({}); // a fetch spy so we can assert it was never called
+
+      await expect(
+        attachVoucherFiles({
+          series: 'A',
+          voucherNumber: '60',
+          filePaths: ['/tmp/missing.pdf'],
+          financialYear: 4,
+        }),
+      ).rejects.toThrow(/File not found: \/tmp\/missing\.pdf/);
+
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('throws (telling the user to pass --year) when the financial year cannot be resolved', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+      const mockFn = vi
+        .fn()
+        // getVoucher
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(JSON.stringify({ Voucher: { TransactionDate: '2025-03-15' } })),
+        })
+        // listFinancialYears -> empty
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ FinancialYears: [] })),
+        });
+      global.fetch = mockFn;
+
+      await expect(
+        attachVoucherFiles({ series: 'A', voucherNumber: '60', filePaths: ['/tmp/c.pdf'] }),
+      ).rejects.toThrow(/pass --year/i);
+    });
+
+    it('surfaces already-attached files when an upload fails mid-batch', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+      const mockFn = vi
+        .fn()
+        // file 1 upload OK
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () => Promise.resolve(JSON.stringify({ File: { Id: 'id1', Name: 'a.pdf' } })),
+        })
+        // file 1 connection OK
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () => Promise.resolve(JSON.stringify({ VoucherFileConnection: { FileId: 'id1' } })),
+        })
+        // file 2 upload FAILS
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve(JSON.stringify({ ErrorInformation: { message: 'boom' } })),
+        });
+      global.fetch = mockFn;
+
+      await expect(
+        attachVoucherFiles({
+          series: 'A',
+          voucherNumber: '60',
+          filePaths: ['/tmp/a.pdf', '/tmp/b.jpg'],
+          financialYear: 4,
+        }),
+      ).rejects.toThrow(/already attached this run: a\.pdf/);
     });
   });
 });

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -4,6 +4,13 @@ vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
 }));
 
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: vi.fn().mockReturnValue(Buffer.from('fake-file-content')),
+  },
+  readFileSync: vi.fn().mockReturnValue(Buffer.from('fake-file-content')),
+}));
+
 function mockFetch(response: unknown) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
@@ -115,6 +122,207 @@ describe('voucher operations', () => {
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       const body = JSON.parse(fetchCall[1].body);
       expect(body.Voucher.VoucherSeries).toBe('B');
+    });
+  });
+
+  describe('uploadInboxFile', () => {
+    it('POSTs to inbox with a FormData body and returns File object', async () => {
+      const { uploadInboxFile } = await import('../../src/operations/vouchers.js');
+      mockFetch({ File: { Id: 'abc-123', Name: 'receipt.pdf', ArchiveFileId: 'arch-1' } });
+
+      const result = await uploadInboxFile('/tmp/receipt.pdf');
+
+      const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(fetchCalls).toHaveLength(1);
+      const [url, init] = fetchCalls[0] as [string, RequestInit];
+      expect(url).toContain('inbox');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBeInstanceOf(FormData);
+      expect(result).toMatchObject({ Id: 'abc-123', Name: 'receipt.pdf' });
+    });
+  });
+
+  describe('createVoucherFileConnection', () => {
+    it('POSTs to voucherfileconnections with required fields', async () => {
+      const { createVoucherFileConnection } = await import('../../src/operations/vouchers.js');
+      const conn = { FileId: 'f1', VoucherSeries: 'A', VoucherNumber: '60' };
+      mockFetch({ VoucherFileConnection: conn });
+
+      const result = await createVoucherFileConnection('A', '60', 'f1');
+
+      const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(fetchCalls).toHaveLength(1);
+      const [url, init] = fetchCalls[0] as [string, RequestInit];
+      expect(url).toContain('voucherfileconnections');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body as string);
+      expect(body.VoucherFileConnection.FileId).toBe('f1');
+      expect(body.VoucherFileConnection.VoucherSeries).toBe('A');
+      expect(body.VoucherFileConnection.VoucherNumber).toBe('60');
+      expect(body.VoucherFileConnection.VoucherYear).toBeUndefined();
+      expect(result).toMatchObject(conn);
+    });
+
+    it('includes VoucherYear when provided', async () => {
+      const { createVoucherFileConnection } = await import('../../src/operations/vouchers.js');
+      mockFetch({ VoucherFileConnection: { FileId: 'f2', VoucherYear: 4 } });
+
+      await createVoucherFileConnection('A', '61', 'f2', 4);
+
+      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      const body = JSON.parse(init.body as string);
+      expect(body.VoucherFileConnection.VoucherYear).toBe(4);
+    });
+
+    it('omits VoucherYear when not provided', async () => {
+      const { createVoucherFileConnection } = await import('../../src/operations/vouchers.js');
+      mockFetch({ VoucherFileConnection: { FileId: 'f3' } });
+
+      await createVoucherFileConnection('A', '62', 'f3');
+
+      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      const body = JSON.parse(init.body as string);
+      expect('VoucherYear' in body.VoucherFileConnection).toBe(false);
+    });
+  });
+
+  describe('attachVoucherFiles', () => {
+    it('uploads and connects multiple files with explicit financialYear', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+
+      const mockFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () => Promise.resolve(JSON.stringify({ File: { Id: 'id1', Name: 'a.pdf' } })),
+          json: () => Promise.resolve({ File: { Id: 'id1', Name: 'a.pdf' } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                VoucherFileConnection: { FileId: 'id1', VoucherYear: 4 },
+              }),
+            ),
+          json: () => Promise.resolve({ VoucherFileConnection: { FileId: 'id1', VoucherYear: 4 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () => Promise.resolve(JSON.stringify({ File: { Id: 'id2', Name: 'b.jpg' } })),
+          json: () => Promise.resolve({ File: { Id: 'id2', Name: 'b.jpg' } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                VoucherFileConnection: { FileId: 'id2', VoucherYear: 4 },
+              }),
+            ),
+          json: () => Promise.resolve({ VoucherFileConnection: { FileId: 'id2', VoucherYear: 4 } }),
+        });
+
+      global.fetch = mockFn;
+
+      const results = await attachVoucherFiles({
+        series: 'A',
+        voucherNumber: '60',
+        filePaths: ['/tmp/a.pdf', '/tmp/b.jpg'],
+        financialYear: 4,
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({ fileName: 'a.pdf', fileId: 'id1' });
+      expect(results[1]).toMatchObject({ fileName: 'b.jpg', fileId: 'id2' });
+    });
+
+    it('resolves financialYear from voucher when not provided', async () => {
+      const { attachVoucherFiles } = await import('../../src/operations/vouchers.js');
+
+      const mockFn = vi
+        .fn()
+        // getVoucher: GET vouchers/A/1
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                Voucher: { VoucherSeries: 'A', VoucherNumber: 1, TransactionDate: '2025-03-15' },
+              }),
+            ),
+          json: () =>
+            Promise.resolve({
+              Voucher: { VoucherSeries: 'A', VoucherNumber: 1, TransactionDate: '2025-03-15' },
+            }),
+        })
+        // listFinancialYears: GET financialyears
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                FinancialYears: [{ Id: 4, FromDate: '2025-01-01', ToDate: '2025-12-31' }],
+              }),
+            ),
+          json: () =>
+            Promise.resolve({
+              FinancialYears: [{ Id: 4, FromDate: '2025-01-01', ToDate: '2025-12-31' }],
+            }),
+        })
+        // uploadInboxFile: POST inbox
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(JSON.stringify({ File: { Id: 'id-resolved', Name: 'c.pdf' } })),
+          json: () => Promise.resolve({ File: { Id: 'id-resolved', Name: 'c.pdf' } }),
+        })
+        // createVoucherFileConnection: POST voucherfileconnections
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                VoucherFileConnection: { FileId: 'id-resolved', VoucherYear: 4 },
+              }),
+            ),
+          json: () =>
+            Promise.resolve({
+              VoucherFileConnection: { FileId: 'id-resolved', VoucherYear: 4 },
+            }),
+        });
+
+      global.fetch = mockFn;
+
+      const results = await attachVoucherFiles({
+        series: 'A',
+        voucherNumber: '1',
+        filePaths: ['/tmp/c.pdf'],
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ fileName: 'c.pdf', fileId: 'id-resolved' });
+      // Connection should carry VoucherYear 4
+      expect((results[0]!.connection as Record<string, unknown>).VoucherYear).toBe(4);
+
+      // Verify the connection call included VoucherYear 4
+      const connectionCall = mockFn.mock.calls[3] as [string, RequestInit];
+      const body = JSON.parse(connectionCall[1].body as string);
+      expect(body.VoucherFileConnection.VoucherYear).toBe(4);
     });
   });
 });

--- a/tests/tools/bookkeeping.test.ts
+++ b/tests/tools/bookkeeping.test.ts
@@ -129,6 +129,45 @@ describe('bookkeeping tools', () => {
     });
   });
 
+  describe('fortnox_attach_voucher_files', () => {
+    it('returns isError when confirm is missing', async () => {
+      mockFetch({});
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_attach_voucher_files',
+        arguments: {
+          series: 'A',
+          voucherNumber: '60',
+          files: ['/tmp/receipt.pdf'],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('returns dryRun preview without uploading', async () => {
+      mockFetch({});
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_attach_voucher_files',
+        arguments: {
+          series: 'A',
+          voucherNumber: '61',
+          files: ['/tmp/ica.pdf'],
+          dryRun: true,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Dry run');
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
   describe('fortnox_list_accounts', () => {
     it('lists all accounts', async () => {
       mockFetch({


### PR DESCRIPTION
Implements **#37** — upload receipt/underlag files and link them to a voucher — and delivers the **file-attachments half of #13**.

## What

- **`noxctl vouchers attach <series> <number> <file...> [--year]`** — uploads each file to the Fortnox inbox (`POST /3/inbox`, multipart) and links it to the voucher (`POST /3/voucherfileconnections`). `--dry-run` / `-y` ergonomics; JSON or table output of the resulting connections.
- **`fortnox_attach_voucher_files`** MCP tool (1:1 parity).
- Financial year is resolved from the voucher's `TransactionDate` when `--year` is omitted (throws, asking for `--year`, when it can't be determined — e.g. a past-year voucher).
- `fortnox-client` gained `rawBody` (multipart) support; `inbox`/`archive`/`voucherfileconnections` mapped to the `archive` scope.

## Robustness (from review)

- Pre-flight validates every path exists and is a file before any upload (no orphaned inbox files from a typo); mid-batch failures name the files already attached.
- `Id` (not `ArchiveFileId`) is used as the connection `FileId`, per [Fortnox's official best-practices/vouchers guide](https://www.fortnox.se/developer/guides-and-good-to-know/best-practices/vouchers).

## Review

Two cross-model Codex review rounds + fixes (credential-argv-style scrutiny of the shared client change, FormData correctness, year-resolution edge cases, doc drift). 588 unit tests, build + lint green.

## ⚠️ Live verification required

The code is unit-tested against mocks. **Live calls require the Fortnox "archive" scope enabled on the app** (a portal/account action). Once enabled, verify with `noxctl vouchers attach A <n> receipt.pdf` and confirm the file appears under the voucher in the Fortnox UI.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)