### PR TITLE
ci: dedup api-drift fetch-failure issues

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -80,18 +80,44 @@ jobs:
         with:
           script: |
             const summary = process.env.DIFF_SUMMARY;
-            await github.rest.issues.create({
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Dedup: the fetch can fail every week for the same reason (e.g. a
+            // persistent HTTP 429). Rather than open a fresh issue each Monday,
+            // append a comment to the existing open fetch-failure issue if one
+            // exists, so the failure history lives in a single tracker.
+            const open = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Fortnox API spec fetch failed (${new Date().toISOString().slice(0, 10)})`,
-              body: [
-                'The weekly API drift check could not fetch the OpenAPI spec.',
-                '',
-                '```',
-                summary,
-                '```',
-                '',
-                'This may be transient (rate limiting) or indicate a URL change.',
-              ].join('\n'),
-              labels: ['api-drift'],
+              state: 'open',
+              labels: 'api-drift',
+              per_page: 100,
             });
+            const existing = open.data.find(
+              (i) => !i.pull_request && /fetch failed|drift check|429/i.test(i.title),
+            );
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: ['Still failing on ' + today + ':', '', '```', summary, '```'].join('\n'),
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Fortnox API spec fetch failed (${today})`,
+                body: [
+                  'The weekly API drift check could not fetch the OpenAPI spec.',
+                  '',
+                  '```',
+                  summary,
+                  '```',
+                  '',
+                  'This may be transient (rate limiting) or indicate a URL change.',
+                ].join('\n'),
+                labels: ['api-drift'],
+              });
+            }


### PR DESCRIPTION
The API-drift workflow opened a fresh issue every Monday the spec fetch failed, with no dedup — producing **12 identical HTTP 429 issues** over 12 weeks (#5–#36, now closed and consolidated into #39).

This makes the fetch-error step **append a dated comment to the existing open fetch-failure issue** when one is present, and only open a new issue when none exists. A persistent failure now lives as a running log in a single tracker instead of spamming new issues each week.

Refs #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)