### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-16
+
 ### Added
 
 - **Voucher file attachments** (#37) — `noxctl vouchers attach <series> <number> <file...> [--year]` uploads receipt/underlag files to the Fortnox inbox and links them to a voucher; matching `fortnox_attach_voucher_files` MCP tool. The financial year is resolved from the voucher's transaction date when `--year` is omitted. Requires the Fortnox "archive" scope enabled on the app. Also delivers the file-attachments half of #13.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ const program = new Command();
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.2.0')
+  .version('0.3.0')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { registerAnalyticsTools } from './tools/analytics.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.2.0',
+    version: '0.3.0',
   });
 
   registerCustomerTools(server);


### PR DESCRIPTION
Version bump to **0.3.0** (package.json + lock, CLI `--version`, MCP server version) and CHANGELOG release entry dated 2026-06-16.

Minor bump (pre-1.0) carrying the breaking #34 JSON-envelope change; headline feature is voucher file attachments (#37). Build + 588 tests green; `noxctl --version` prints 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)