### PR TITLE
fix: make voucher file attachments actually work (live-verified)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,7 +11,7 @@ const FORTNOX_TOKEN_URL = 'https://apps.fortnox.se/oauth-v1/token';
 const CALLBACK_HOST = '127.0.0.1';
 
 export const SCOPES =
-  'article customer invoice payment supplier supplierinvoice bookkeeping companyinformation settings';
+  'article customer invoice payment supplier supplierinvoice bookkeeping companyinformation settings inbox connectfile';
 
 export const CREDENTIAL_SCHEMA_VERSION = 2;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -876,6 +876,8 @@ program
       bookkeeping: 'vouchers?limit=1',
       companyinformation: 'companyinformation',
       settings: 'settings/company',
+      inbox: 'inbox',
+      connectfile: 'voucherfileconnections?limit=1',
     };
 
     const required = SCOPES.split(' ');
@@ -887,10 +889,15 @@ program
       try {
         await fortnoxRequest(endpoint);
       } catch (err) {
-        if (err instanceof FortnoxApiError && err.statusCode === 403) {
+        // A missing scope shows up as a 403, OR (for some endpoints, e.g. the
+        // archive/inbox family) a 400 whose message names the scope. Treat both
+        // as "not authorized"; other errors (500, etc.) aren't scope problems.
+        if (
+          err instanceof FortnoxApiError &&
+          (err.statusCode === 403 || /scope/i.test(err.fortnoxMessage ?? ''))
+        ) {
           missing.push(scope);
         }
-        // Non-403 errors (e.g. 500) are not scope problems — ignore here
       }
     }
 

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -95,9 +95,9 @@ function endpointToScope(endpoint: string): string | undefined {
     taxreductions: 'invoice',
     pricelists: 'price',
     prices: 'price',
-    inbox: 'archive',
+    inbox: 'inbox',
     archive: 'archive',
-    voucherfileconnections: 'archive',
+    voucherfileconnections: 'connectfile',
   };
   for (const [prefix, scope] of Object.entries(mapping)) {
     if (path.startsWith(prefix)) return scope;

--- a/src/operations/financial-years.ts
+++ b/src/operations/financial-years.ts
@@ -21,9 +21,19 @@ export interface ListFinancialYearsParams {
 export async function listFinancialYears(
   params: ListFinancialYearsParams = {},
 ): Promise<FinancialYearsResponse> {
-  return fortnoxRequest<FinancialYearsResponse>('financialyears', {
-    params: { Date: params.date },
+  // Fortnox's /3/financialyears does NOT support a date query filter — passing
+  // ?Date=... returns 400 "Ogiltig parameter" (error 2000588). So fetch all
+  // years and, when a date is given, filter locally to the year whose
+  // From/To-date range brackets it (YYYY-MM-DD compares lexicographically).
+  const data = await fortnoxRequest<FinancialYearsResponse>('financialyears');
+  if (!params.date) return data;
+  const d = params.date;
+  const matching = (data.FinancialYears ?? []).filter((fy) => {
+    const from = String(fy.FromDate ?? '');
+    const to = String(fy.ToDate ?? '');
+    return from !== '' && to !== '' && from <= d && d <= to;
   });
+  return { ...data, FinancialYears: matching };
 }
 
 export async function getFinancialYear(id: number): Promise<Record<string, unknown>> {

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -113,22 +113,26 @@ export async function uploadInboxFile(filePath: string): Promise<Record<string, 
   return data.File;
 }
 
-// Link an already-uploaded file (by id) to a voucher.
+// Link an already-uploaded file (by id) to a voucher. The financial year goes in
+// the `financialyear` query param, NOT the body: Fortnox treats VoucherYear in
+// the body as read-only (rejects it with error 2000321) and derives it from the
+// voucher itself.
 export async function createVoucherFileConnection(
   series: string,
   voucherNumber: string,
   fileId: string,
   financialYear?: number,
 ): Promise<Record<string, unknown>> {
-  const connection: Record<string, unknown> = {
-    FileId: fileId,
-    VoucherSeries: series,
-    VoucherNumber: voucherNumber,
-  };
-  if (financialYear !== undefined) connection.VoucherYear = financialYear;
   const data = await fortnoxRequest<VoucherFileConnectionResponse>('voucherfileconnections', {
     method: 'POST',
-    body: { VoucherFileConnection: connection },
+    body: {
+      VoucherFileConnection: {
+        FileId: fileId,
+        VoucherSeries: series,
+        VoucherNumber: voucherNumber,
+      },
+    },
+    params: financialYear !== undefined ? { financialyear: financialYear } : undefined,
   });
   return data.VoucherFileConnection;
 }

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -89,6 +89,8 @@ export function registerStatusTools(server: McpServer): void {
         bookkeeping: 'vouchers?limit=1',
         companyinformation: 'companyinformation',
         settings: 'settings/company',
+        inbox: 'inbox',
+        connectfile: 'voucherfileconnections?limit=1',
       };
 
       const required = SCOPES.split(' ');
@@ -100,7 +102,12 @@ export function registerStatusTools(server: McpServer): void {
         try {
           await fortnoxRequest(endpoint);
         } catch (err) {
-          if (err instanceof FortnoxApiError && err.statusCode === 403) {
+          // Missing scope = 403, or a 400 whose message names the scope
+          // (archive/inbox family). Other errors aren't scope problems.
+          if (
+            err instanceof FortnoxApiError &&
+            (err.statusCode === 403 || /scope/i.test(err.fortnoxMessage ?? ''))
+          ) {
             missing.push(scope);
           }
         }

--- a/tests/operations/financial-years.test.ts
+++ b/tests/operations/financial-years.test.ts
@@ -33,14 +33,22 @@ describe('financial year operations', () => {
       expect(calledUrl).toContain('financialyears');
     });
 
-    it('passes Date filter to find the year containing a date', async () => {
-      mockFetch({ FinancialYears: [] });
+    it('filters locally to the year containing a date (no Date query param)', async () => {
+      mockFetch({
+        FinancialYears: [
+          { Id: 1, FromDate: '2025-01-01', ToDate: '2025-12-31' },
+          { Id: 2, FromDate: '2026-01-01', ToDate: '2026-12-31' },
+        ],
+      });
       const { listFinancialYears } = await import('../../src/operations/financial-years.js');
 
-      await listFinancialYears({ date: '2026-03-15' });
+      const result = await listFinancialYears({ date: '2026-03-15' });
 
+      // Fortnox rejects ?Date= (error 2000588), so we must filter client-side.
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-      expect(calledUrl).toContain('Date=2026-03-15');
+      expect(calledUrl).not.toContain('Date=');
+      expect(result.FinancialYears).toHaveLength(1);
+      expect(result.FinancialYears[0]!.Id).toBe(2);
     });
   });
 

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -180,30 +180,33 @@ describe('voucher operations', () => {
       expect(result).toMatchObject(conn);
     });
 
-    it('includes VoucherYear when provided', async () => {
+    it('passes the financial year as the financialyear query param (never in the body)', async () => {
       const { createVoucherFileConnection } = await import('../../src/operations/vouchers.js');
       mockFetch({ VoucherFileConnection: { FileId: 'f2', VoucherYear: 4 } });
 
       await createVoucherFileConnection('A', '61', 'f2', 4);
 
-      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
         string,
         RequestInit,
       ];
+      // VoucherYear is read-only on POST (Fortnox 2000321) — must NOT be in the body.
+      expect(url).toContain('financialyear=4');
       const body = JSON.parse(init.body as string);
-      expect(body.VoucherFileConnection.VoucherYear).toBe(4);
+      expect('VoucherYear' in body.VoucherFileConnection).toBe(false);
     });
 
-    it('omits VoucherYear when not provided', async () => {
+    it('omits the financialyear query param when no year is given', async () => {
       const { createVoucherFileConnection } = await import('../../src/operations/vouchers.js');
       mockFetch({ VoucherFileConnection: { FileId: 'f3' } });
 
       await createVoucherFileConnection('A', '62', 'f3');
 
-      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
         string,
         RequestInit,
       ];
+      expect(url).not.toContain('financialyear');
       const body = JSON.parse(init.body as string);
       expect('VoucherYear' in body.VoucherFileConnection).toBe(false);
     });
@@ -336,10 +339,11 @@ describe('voucher operations', () => {
       // Connection should carry VoucherYear 4
       expect((results[0]!.connection as Record<string, unknown>).VoucherYear).toBe(4);
 
-      // Verify the connection call included VoucherYear 4
+      // Verify the connection call passed the resolved year as the query param
       const connectionCall = mockFn.mock.calls[3] as [string, RequestInit];
+      expect(connectionCall[0]).toContain('financialyear=4');
       const body = JSON.parse(connectionCall[1].body as string);
-      expect(body.VoucherFileConnection.VoucherYear).toBe(4);
+      expect('VoucherYear' in body.VoucherFileConnection).toBe(false);
     });
 
     it('fails fast (before any upload) when a file path does not exist', async () => {

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { SCOPES } from '../src/auth.js';
+
+// Guards the bug where the voucher file-attachment feature (#37) shipped without
+// requesting the scopes it needs: noxctl only ever gets scopes it lists here, so
+// every implemented endpoint family must have its scope in this set.
+describe('OAuth SCOPES', () => {
+  const requested = SCOPES.split(' ');
+
+  it('requests the scopes backing the implemented features', () => {
+    for (const scope of [
+      'article',
+      'customer',
+      'invoice',
+      'supplier',
+      'supplierinvoice',
+      'bookkeeping',
+      'companyinformation',
+      'settings',
+      'inbox', // POST /3/inbox — voucher file upload (#37)
+      'connectfile', // POST /3/voucherfileconnections — link file to voucher (#37)
+    ]) {
+      expect(requested).toContain(scope);
+    }
+  });
+
+  it('has no duplicate scope tokens', () => {
+    expect(new Set(requested).size).toBe(requested.length);
+  });
+});


### PR DESCRIPTION
Three #37 bugs found by live-verifying against the Fortnox demo company (all passed mock tests):

1. **Missing OAuth scopes** — `inbox` + `connectfile` were never requested (upload → "Har inte behörighet för scope", 2000663). Added to `SCOPES`; corrected the endpoint→scope hint map; `doctor`/`status` now test them and detect the 400 scope-error form. New regression test.
2. **VoucherYear read-only** — moved the year from the connection body to the `?financialyear=` query param (was 400 "Fältet VoucherYear är endast läsbart", 2000321).
3. **financialyears date filter unsupported** — `?Date=` returns 400 (2000588); now fetch all years and filter locally to the bracketing one.

Verified end-to-end on demo (MagnusGilleConsultingDEMO): upload → auto year-resolution → connection; PDF linked to voucher A/1. 590 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)