### PR TITLE
test: MCP round-trip coverage parity + live payroll read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ credentials.dpapi
 PLAN.md
 .claude/
 debate/
+.playwright-mcp/
 
 # Fortnox's OpenAPI spec is its "call structure" (Developer Agreement cl. 6.1/6.3)
 # — not redistributed in this repo. Fetched on demand into this local cache by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ See `TODO.md` for the prioritized backlog and instructions for adding new resour
 
 ```bash
 npm run build       # TypeScript compile
-npm test            # Vitest (681 unit tests)
+npm test            # Vitest (716 unit tests)
 npm run test:live   # Live API tests (needs credentials)
 npm run lint        # ESLint
 npm run format      # Prettier

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 - 23 operations modules: invoices, customers, suppliers, articles, vouchers, accounts, financial reports, tax, company, invoice payments, supplier invoice payments, offers, orders, projects, cost centers, tax reductions (ROT/RUT), price lists, prices, employees, salary transactions, attendance transactions, absence transactions, schedule times
 - Full sales pipeline: offer → order → invoice → payment
 - Payroll (Lön): employees + salary/attendance/absence transactions + schedule times (opt-in `salary` scope via `init --with-salary`)
-- 681 unit tests
+- 716 unit tests
 
 ## API Drift Detection
 

--- a/tests/live/payroll.live.test.ts
+++ b/tests/live/payroll.live.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { salaryScopeAvailable, setupLiveClientServer, getText } from './setup.js';
+
+// Read-only live check for the payroll (Lön) path. Requires a profile that was
+// authorized with the opt-in `salary` scope (e.g. `noxctl init --with-salary`),
+// so it skips against the default/non-payroll company rather than 403-ing.
+let hasSalary = false;
+
+beforeAll(async () => {
+  hasSalary = await salaryScopeAvailable();
+});
+
+describe('live: fortnox_list_employees (payroll/Lön)', () => {
+  it('lists employees from the real Salary API', async () => {
+    if (!hasSalary) {
+      console.log('SKIP: no salary-scoped credentials — skipping live payroll tests.');
+      return;
+    }
+
+    const { client } = await setupLiveClientServer();
+    const result = await client.callTool({
+      name: 'fortnox_list_employees',
+      arguments: { limit: 1 },
+    });
+
+    // A 200 (even with zero employees) proves the scope + endpoint work live.
+    expect(result.isError).toBeFalsy();
+    expect(typeof getText(result)).toBe('string');
+  });
+});

--- a/tests/live/setup.ts
+++ b/tests/live/setup.ts
@@ -8,7 +8,7 @@
 import { createServer } from '../../src/index.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { loadCredentials } from '../../src/auth.js';
+import { effectiveScopes, loadCredentials, SALARY_SCOPE } from '../../src/auth.js';
 
 /**
  * Returns true when real Fortnox credentials are available in the keychain.
@@ -17,6 +17,21 @@ export async function credentialsAvailable(): Promise<boolean> {
   try {
     const creds = await loadCredentials();
     return creds !== null && typeof creds.access_token === 'string';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when the active profile's credentials were granted the opt-in
+ * `salary` (Lön) scope. Payroll live tests skip otherwise, so running the live
+ * suite against a non-payroll profile (e.g. the default company) doesn't 403.
+ */
+export async function salaryScopeAvailable(): Promise<boolean> {
+  try {
+    const creds = await loadCredentials();
+    if (!creds || typeof creds.access_token !== 'string') return false;
+    return effectiveScopes(creds).split(' ').includes(SALARY_SCOPE);
   } catch {
     return false;
   }

--- a/tests/tools/analytics.test.ts
+++ b/tests/tools/analytics.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer } from '../../src/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+// Single-page invoice list: fetchAllPages reads MetaInformation['@TotalPages'],
+// so include it (=1) to keep the mock to one fetch call.
+function mockInvoices(invoices: Record<string, unknown>[]) {
+  const response = {
+    Invoices: invoices,
+    MetaInformation: {
+      '@TotalResources': invoices.length,
+      '@TotalPages': 1,
+      '@CurrentPage': 1,
+    },
+  };
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+function textOf(result: unknown): string {
+  return (result as { content: { type: string; text: string }[] }).content[0].text;
+}
+
+describe('analytics tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fortnox_overdue_invoices', () => {
+    it('summarizes overdue invoices (oldest first)', async () => {
+      // DueDates well in the past so they are overdue regardless of run date.
+      mockInvoices([
+        {
+          DocumentNumber: 101,
+          CustomerName: 'Acme AB',
+          InvoiceDate: '2024-12-01',
+          DueDate: '2025-02-01',
+          Total: 1000,
+          Balance: 1000,
+          Cancelled: false,
+        },
+        {
+          DocumentNumber: 102,
+          CustomerName: 'Globex AB',
+          InvoiceDate: '2024-11-01',
+          DueDate: '2025-01-01',
+          Total: 500,
+          Balance: 500,
+          Cancelled: false,
+        },
+      ]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_overdue_invoices',
+        arguments: {},
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Förfallna fakturor: 2 st');
+      expect(text).toContain('1500.00'); // total outstanding
+      expect(text).toContain('Äldsta förfallodatum: 2025-01-01'); // oldest due
+      expect(text).toContain('Acme AB');
+      expect(text).toContain('Globex AB');
+    });
+
+    it('reports when there are no overdue invoices', async () => {
+      mockInvoices([]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_overdue_invoices',
+        arguments: {},
+      });
+
+      expect(textOf(result)).toContain('Inga förfallna fakturor.');
+    });
+  });
+
+  describe('fortnox_unpaid_totals', () => {
+    it('totals unpaid invoices and separates the overdue portion', async () => {
+      mockInvoices([
+        // overdue (past due date, open balance)
+        {
+          DocumentNumber: 201,
+          DueDate: '2025-01-01',
+          Total: 1000,
+          Balance: 1000,
+          Cancelled: false,
+        },
+        // open but not yet due (far-future due date)
+        {
+          DocumentNumber: 202,
+          DueDate: '2099-12-31',
+          Total: 400,
+          Balance: 400,
+          Cancelled: false,
+        },
+      ]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_unpaid_totals',
+        arguments: {},
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Obetalda fakturor: 2 st');
+      expect(text).toContain('1400.00'); // total outstanding
+      expect(text).toContain('Varav förfallna: 1 st');
+      expect(text).toContain('1000.00'); // overdue portion
+    });
+  });
+
+  describe('fortnox_top_customers', () => {
+    it('ranks customers by invoiced total', async () => {
+      mockInvoices([
+        { CustomerNumber: '1', CustomerName: 'Acme AB', Total: 1000, Cancelled: false },
+        { CustomerNumber: '1', CustomerName: 'Acme AB', Total: 500, Cancelled: false },
+        { CustomerNumber: '2', CustomerName: 'Globex AB', Total: 2000, Cancelled: false },
+        // cancelled invoices are excluded from the aggregation
+        { CustomerNumber: '3', CustomerName: 'Skip AB', Total: 9999, Cancelled: true },
+      ]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_top_customers',
+        arguments: { fromDate: '2025-01-01', toDate: '2025-12-31', limit: 5 },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Period: 2025-01-01 — 2025-12-31');
+      expect(text).toContain('Globex AB');
+      expect(text).toContain('2000.00');
+      expect(text).toContain('Acme AB');
+      expect(text).toContain('1500.00'); // 1000 + 500 aggregated
+      expect(text).not.toContain('Skip AB'); // cancelled excluded
+
+      // Globex (2000) should be ranked above Acme (1500).
+      expect(text.indexOf('Globex AB')).toBeLessThan(text.indexOf('Acme AB'));
+    });
+
+    it('reports when there are no invoices in the period', async () => {
+      mockInvoices([]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_top_customers',
+        arguments: {},
+      });
+
+      expect(textOf(result)).toContain('Inga fakturor i perioden.');
+    });
+  });
+
+  describe('fortnox_vat_summary', () => {
+    it('summarizes VAT accounts and net position', async () => {
+      // getVatSummary -> generateTaxReport makes two GETs: accounts, then vouchers.
+      const accountsResponse = {
+        Accounts: [
+          {
+            Number: 2610,
+            Description: 'Utgående moms 25%',
+            SRU: 0,
+            BalanceBroughtForward: 0,
+            BalanceCarriedForward: -12500,
+          },
+          {
+            Number: 2640,
+            Description: 'Ingående moms',
+            SRU: 0,
+            BalanceBroughtForward: 0,
+            BalanceCarriedForward: 3200,
+          },
+        ],
+      };
+      const vouchersResponse = {
+        Vouchers: [
+          {
+            VoucherNumber: 1,
+            VoucherRows: [
+              { Account: 2610, Debit: 0, Credit: 12500, Description: 'Utgående moms' },
+              { Account: 2640, Debit: 3200, Credit: 0, Description: 'Ingående moms' },
+            ],
+          },
+        ],
+      };
+
+      let fetchCallCount = 0;
+      global.fetch = vi.fn().mockImplementation(() => {
+        fetchCallCount++;
+        const response = fetchCallCount === 1 ? accountsResponse : vouchersResponse;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(response)),
+          json: () => Promise.resolve(response),
+        });
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_vat_summary',
+        arguments: { fromDate: '2025-01-01', toDate: '2025-03-31' },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('2025-01-01');
+      expect(text).toContain('2025-03-31');
+      expect(text).toContain('2610');
+      expect(text).toContain('12500.00');
+      expect(text).toContain('2640');
+      expect(text).toContain('3200.00');
+      // Net VAT = (debit - credit) across accounts:
+      // 2610: 0 - 12500 = -12500; 2640: 3200 - 0 = 3200; net = -9300.
+      expect(text).toContain('Netto moms: -9300.00');
+    });
+  });
+});

--- a/tests/tools/contracts.test.ts
+++ b/tests/tools/contracts.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer } from '../../src/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+function mockFetch(response: unknown, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+function textOf(result: unknown): string {
+  return (result as { content: { type: string; text: string }[] }).content[0].text;
+}
+
+describe('contract tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fortnox_list_contracts', () => {
+    it('lists contracts', async () => {
+      mockFetch({
+        Contracts: [
+          { DocumentNumber: '1', CustomerName: 'Acme AB', Total: 1000 },
+          { DocumentNumber: '2', CustomerName: 'Beta HB', Total: 2000 },
+        ],
+        MetaInformation: { '@TotalResources': 2, '@TotalPages': 1, '@CurrentPage': 1 },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({ name: 'fortnox_list_contracts', arguments: {} });
+
+      const text = textOf(result);
+      expect(text).toContain('Acme AB');
+      expect(text).toContain('Beta HB');
+    });
+
+    it('passes filter through to the API', async () => {
+      mockFetch({
+        Contracts: [{ DocumentNumber: '1', CustomerName: 'Acme AB' }],
+        MetaInformation: { '@TotalResources': 1, '@TotalPages': 1, '@CurrentPage': 1 },
+      });
+
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_list_contracts',
+        arguments: { filter: 'active' },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('filter=active');
+    });
+  });
+
+  describe('fortnox_get_contract', () => {
+    it('fetches a single contract', async () => {
+      mockFetch({
+        Contract: { DocumentNumber: '1', CustomerName: 'Acme AB', CustomerNumber: '25' },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_contract',
+        arguments: { documentNumber: '1', includeRaw: true },
+      });
+
+      const parsed = JSON.parse(textOf(result).split('Raw JSON:\n')[1]);
+      expect(parsed.DocumentNumber).toBe('1');
+      expect(parsed.CustomerName).toBe('Acme AB');
+    });
+  });
+
+  describe('fortnox_create_contract', () => {
+    it('creates a contract', async () => {
+      mockFetch({
+        Contract: { DocumentNumber: '5', CustomerNumber: '25', CustomerName: 'Acme AB' },
+      });
+
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_create_contract',
+        arguments: {
+          CustomerNumber: '25',
+          InvoiceRows: [{ ArticleNumber: '10', DeliveredQuantity: 1, Price: 500 }],
+          InvoiceInterval: 1,
+          confirm: true,
+        },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[1].method).toBe('POST');
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.Contract.CustomerNumber).toBe('25');
+      expect(body.Contract.InvoiceRows[0].Price).toBe(500);
+    });
+
+    it('supports dry run', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_contract',
+        arguments: {
+          CustomerNumber: '25',
+          InvoiceRows: [{ ArticleNumber: '10', DeliveredQuantity: 1, Price: 500 }],
+          dryRun: true,
+        },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Dry run');
+      expect(text).toContain('25');
+    });
+
+    it('requires confirmation', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_contract',
+        arguments: {
+          CustomerNumber: '25',
+          InvoiceRows: [{ ArticleNumber: '10', DeliveredQuantity: 1, Price: 500 }],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('fortnox_update_contract', () => {
+    it('updates a contract', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1', Comments: 'Uppdaterad' } });
+
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_update_contract',
+        arguments: { documentNumber: '1', Comments: 'Uppdaterad', confirm: true },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('contracts/1');
+      expect(fetchCall[1].method).toBe('PUT');
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.Contract.Comments).toBe('Uppdaterad');
+    });
+
+    it('supports dry run', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_update_contract',
+        arguments: { documentNumber: '1', Comments: 'Test', dryRun: true },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Dry run');
+    });
+
+    it('requires confirmation', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_update_contract',
+        arguments: { documentNumber: '1', Comments: 'Test' },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('fortnox_finish_contract', () => {
+    it('finishes a contract', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1', Active: false } });
+
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_finish_contract',
+        arguments: { documentNumber: '1', confirm: true },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('contracts/1/finish');
+      expect(fetchCall[1].method).toBe('PUT');
+    });
+
+    it('supports dry run', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_finish_contract',
+        arguments: { documentNumber: '1', dryRun: true },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Dry run');
+    });
+
+    it('requires confirmation', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_finish_contract',
+        arguments: { documentNumber: '1' },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('fortnox_create_invoice_from_contract', () => {
+    it('creates an invoice from a contract', async () => {
+      mockFetch({ Invoice: { DocumentNumber: '99', CustomerName: 'Acme AB', Total: 500 } });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_invoice_from_contract',
+        arguments: { documentNumber: '1', confirm: true },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('contracts/1/createinvoice');
+      expect(fetchCall[1].method).toBe('PUT');
+      expect(textOf(result)).toContain('Acme AB');
+    });
+
+    it('supports dry run', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_invoice_from_contract',
+        arguments: { documentNumber: '1', dryRun: true },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Dry run');
+    });
+
+    it('requires confirmation', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_invoice_from_contract',
+        arguments: { documentNumber: '1' },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('fortnox_increase_contract_invoice_count', () => {
+    it('increases the invoice count', async () => {
+      mockFetch({ Contract: { DocumentNumber: '1', InvoicesRemaining: 3 } });
+
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_increase_contract_invoice_count',
+        arguments: { documentNumber: '1', confirm: true },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('contracts/1/increaseinvoicecount');
+      expect(fetchCall[1].method).toBe('PUT');
+    });
+
+    it('supports dry run', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_increase_contract_invoice_count',
+        arguments: { documentNumber: '1', dryRun: true },
+      });
+
+      const text = textOf(result);
+      expect(text).toContain('Dry run');
+    });
+
+    it('requires confirmation', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_increase_contract_invoice_count',
+        arguments: { documentNumber: '1' },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/tests/tools/financial-reports.test.ts
+++ b/tests/tools/financial-reports.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer } from '../../src/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+/**
+ * The financial-reports operations fetch several endpoints — accounts (paginated),
+ * the vouchers list, and each voucher's detail. Order isn't deterministic because
+ * accounts + vouchers are fetched in parallel, so route the mock by URL instead of
+ * by call sequence.
+ */
+function mockFetchByUrl(routes: { accounts: unknown; vouchers: unknown; voucherDetail: unknown }) {
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    let response: unknown;
+    if (/\/vouchers\/[^/]+\/\d+/.test(url)) {
+      // individual voucher detail: /vouchers/A/1
+      response = routes.voucherDetail;
+    } else if (/\/vouchers(\?|$)/.test(url)) {
+      // vouchers list
+      response = routes.vouchers;
+    } else {
+      // accounts list
+      response = routes.accounts;
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(response)),
+      json: () => Promise.resolve(response),
+    });
+  });
+}
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+describe('financial report tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fortnox_income_statement', () => {
+    it('renders a resultaträkning with grouped revenue and costs', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [
+            { Number: 3001, Description: 'Försäljning', BalanceBroughtForward: 0 },
+            { Number: 5410, Description: 'Förbrukningsinventarier', BalanceBroughtForward: 0 },
+          ],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [{ VoucherSeries: 'A', VoucherNumber: 1 }],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: {
+          Voucher: {
+            VoucherRows: [
+              { Account: 3001, Debit: 0, Credit: 50000 },
+              { Account: 5410, Debit: 3000, Credit: 0 },
+              { Account: 1930, Debit: 47000, Credit: 0 },
+            ],
+          },
+        },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_income_statement',
+        arguments: {},
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('RESULTATRÄKNING');
+      expect(text).toContain('Nettoomsättning');
+      expect(text).toContain('Försäljning');
+      expect(text).toContain('Övriga externa kostnader');
+      expect(text).toContain('RESULTAT');
+      // Revenue 50000 (credit -> shown positive), cost 3000 -> net result shown positive 47000
+      expect(text).toContain('50000.00');
+      expect(text).toContain('47000.00');
+    });
+
+    it('shows the period in the heading when fromDate/toDate are provided', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: { Voucher: { VoucherRows: [] } },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_income_statement',
+        arguments: { fromDate: '2026-01-01', toDate: '2026-03-31' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('2026-01-01');
+      expect(text).toContain('2026-03-31');
+    });
+
+    it('includes raw JSON when includeRaw is set', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [{ Number: 3001, Description: 'Försäljning', BalanceBroughtForward: 0 }],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [{ VoucherSeries: 'A', VoucherNumber: 1 }],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: {
+          Voucher: { VoucherRows: [{ Account: 3001, Debit: 0, Credit: 12000 }] },
+        },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_income_statement',
+        arguments: { includeRaw: true },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
+      expect(parsed.type).toBe('income-statement');
+      expect(parsed.netResult).toBe(-12000);
+    });
+  });
+
+  describe('fortnox_balance_sheet', () => {
+    it('renders a balansräkning split into assets and liabilities/equity', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [
+            { Number: 1930, Description: 'Bank', BalanceBroughtForward: 100000 },
+            { Number: 2081, Description: 'Aktiekapital', BalanceBroughtForward: -25000 },
+            { Number: 2440, Description: 'Leverantörsskulder', BalanceBroughtForward: -75000 },
+          ],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: { Voucher: { VoucherRows: [] } },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_balance_sheet',
+        arguments: {},
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('BALANSRÄKNING');
+      expect(text).toContain('TILLGÅNGAR');
+      expect(text).toContain('SKULDER OCH EGET KAPITAL');
+      expect(text).toContain('Kassa och bank');
+      expect(text).toContain('Eget kapital');
+      expect(text).toContain('Bank');
+      expect(text).toContain('SUMMA TILLGÅNGAR');
+      expect(text).toContain('100000.00');
+    });
+
+    it('shows the as-of date in the heading when toDate is provided', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [{ Number: 1930, Description: 'Bank', BalanceBroughtForward: 50000 }],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: { Voucher: { VoucherRows: [] } },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_balance_sheet',
+        arguments: { toDate: '2026-01-31' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('2026-01-31');
+    });
+
+    it('includes raw JSON when includeRaw is set', async () => {
+      mockFetchByUrl({
+        accounts: {
+          Accounts: [{ Number: 1930, Description: 'Bank', BalanceBroughtForward: 50000 }],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        vouchers: {
+          Vouchers: [],
+          MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+        },
+        voucherDetail: { Voucher: { VoucherRows: [] } },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_balance_sheet',
+        arguments: { includeRaw: true },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
+      expect(parsed.type).toBe('balance-sheet');
+      expect(parsed.totalAssets).toBe(50000);
+    });
+  });
+});

--- a/tests/tools/financial-years.test.ts
+++ b/tests/tools/financial-years.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer } from '../../src/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+function mockFetch(response: unknown, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+describe('financial year tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fortnox_list_financialyears', () => {
+    it('lists financial years', async () => {
+      mockFetch({
+        FinancialYears: [
+          {
+            Id: 1,
+            FromDate: '2024-01-01',
+            ToDate: '2024-12-31',
+            AccountingMethod: 'ACCRUAL',
+            AccountChartType: 'Aktiebolag',
+          },
+          {
+            Id: 2,
+            FromDate: '2025-01-01',
+            ToDate: '2025-12-31',
+            AccountingMethod: 'ACCRUAL',
+            AccountChartType: 'Aktiebolag',
+          },
+        ],
+        MetaInformation: { '@TotalResources': 2, '@TotalPages': 1, '@CurrentPage': 1 },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_financialyears',
+        arguments: {},
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('2024-01-01');
+      expect(text).toContain('2025-12-31');
+    });
+
+    it('filters to the year containing a given date', async () => {
+      mockFetch({
+        FinancialYears: [
+          { Id: 1, FromDate: '2024-01-01', ToDate: '2024-12-31', AccountingMethod: 'ACCRUAL' },
+          { Id: 2, FromDate: '2025-01-01', ToDate: '2025-12-31', AccountingMethod: 'ACCRUAL' },
+        ],
+        MetaInformation: { '@TotalResources': 2, '@TotalPages': 1, '@CurrentPage': 1 },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_financialyears',
+        arguments: { date: '2025-06-15' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('2025-01-01');
+      expect(text).not.toContain('2024-01-01');
+    });
+  });
+
+  describe('fortnox_get_financialyear', () => {
+    it('fetches a single financial year', async () => {
+      mockFetch({
+        FinancialYear: {
+          Id: 2,
+          FromDate: '2025-01-01',
+          ToDate: '2025-12-31',
+          AccountingMethod: 'ACCRUAL',
+          AccountChartType: 'Aktiebolag',
+        },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_financialyear',
+        arguments: { id: 2, includeRaw: true },
+      });
+
+      const parsed = JSON.parse(
+        (result.content as { type: string; text: string }[])[0].text.split('Raw JSON:\n')[1],
+      );
+      expect(parsed.Id).toBe(2);
+      expect(parsed.FromDate).toBe('2025-01-01');
+    });
+  });
+
+  describe('fortnox_get_lockedperiod', () => {
+    it('fetches the locked period', async () => {
+      mockFetch({ LockedPeriod: { EndDate: '2025-03-31' } });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_lockedperiod',
+        arguments: {},
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('2025-03-31');
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('settings/lockedperiod');
+    });
+
+    it('reports when no period is locked', async () => {
+      mockFetch({ LockedPeriod: {} });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_lockedperiod',
+        arguments: {},
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Ingen period är låst.');
+    });
+  });
+});


### PR DESCRIPTION
Closes the MCP-vs-CLI test-coverage gap from the coverage review: four tool groups had operations tests but no MCP round-trip (tools) test.

## Added
- **MCP round-trip tests** (in-memory client↔server via `createServer` + `InMemoryTransport`, mirroring the existing tools-test pattern) for:
  - `analytics` — overdue / unpaid / top-customers / vat (6 tests)
  - `contracts` — list/get/create/update/finish/create-invoice/increase (18 tests)
  - `financial-reports` — income / balance (6 tests)
  - `financial-years` — list / get / locked-period (5 tests)
- **Live suite:** a read-only payroll check (`fortnox_list_employees`) that skips unless the active profile has the opt-in `salary` scope (new `salaryScopeAvailable()` helper). Verified **PASS** against the demo company.

## Result
Hermetic suite: **716 tests** (was 681), lint + format + build green. Docs test count updated.

No source/behavior changes — tests only (plus `.gitignore` for `.playwright-mcp/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)