### PR TITLE
chore: MCP registry metadata (server.json + mcpName + glama.json)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Magnus-Gille"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "noxctl",
   "version": "0.4.0",
+  "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.magnus-gille/noxctl",
+  "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, VAT, and payroll (Lön)",
+  "repository": {
+    "url": "https://github.com/Magnus-Gille/noxctl",
+    "source": "github"
+  },
+  "version": "0.4.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "noxctl",
+      "version": "0.4.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "NOXCTL_PROFILE",
+          "description": "Optional Fortnox profile to bind. Authenticate first with `noxctl init` (credentials are stored in the OS keychain, not passed as env vars). Defaults to the 'default' profile.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the metadata needed to list noxctl in the MCP registries (the discoverability gap from the competitive review — currently only the peer erp-mafia/fortnox-mcp is registered).

## Added
- **`server.json`** — official MCP Registry schema (2025-12-11): npm package `noxctl`, `stdio` transport, `serve` subcommand. noxctl's MCP server authenticates via the OS keychain after `noxctl init` (no secret env var), so `environmentVariables` lists only the optional `NOXCTL_PROFILE`.
- **`mcpName: "io.github.magnus-gille/noxctl"`** in package.json — must equal the `server.json` name; the registry verifies npm ownership via this field.
- **`glama.json`** — maintainer entry for the Glama ownership claim.

## Coverage
- Official MCP Registry + **PulseMCP** (ingests the official registry) — both from `server.json` + `mcpName`.
- Glama — `glama.json` + a one-click GitHub claim.
- Smithery (MCPB bundle) and mcp.so (GitHub issue / form) need no repo file — see the submission runbook.

## Notes
- The metadata files are **repo-only** — not shipped in the npm tarball (`files: dist/+README+LICENSE`). Only package.json's `mcpName` ships, which is required.
- `mcpName` takes effect for registry verification on the **next npm publish** (e.g. 0.4.1).
- `server.json` is validated by `mcp-publisher publish`; running `mcp-publisher init` can reconcile it if the schema drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)