### PR TITLE
chore: Dependabot + disable legacy credential dual-write (#53)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Legacy credential dual-write disabled** (#53) — `saveCredentialBlob` no longer mirrors writes to the pre-0.2.0 unnamespaced keychain/DPAPI slot. The 0.2.x compatibility window (`LEGACY_DUAL_WRITE`) has passed; new credential saves go only to the namespaced `profile:default` slot. Reading the legacy slot is unaffected — `loadCredentialBlob` still transparently falls back to it, so already-migrated 0.1.x installs keep working. See `docs/legacy-credential-removal-plan.md` for the planned 0.5.0 removal of the legacy reader.
+
+### Added
+
+- `.github/dependabot.yml` — weekly npm dependency update PRs.
+
 ## [0.4.0] - 2026-06-17
 
 ### Added

--- a/docs/legacy-credential-removal-plan.md
+++ b/docs/legacy-credential-removal-plan.md
@@ -1,0 +1,63 @@
+# Legacy credential reader removal plan
+
+## Background
+
+`noxctl` 0.2.0 introduced per-profile credential storage: instead of a single
+unnamespaced keychain/DPAPI entry, credentials are stored under a
+`profile:<name>` account (or `credentials.<name>.dpapi` file on Windows), with
+`default` as the implicit profile for single-tenant setups.
+
+To avoid breaking installs still on the pre-0.2.0 layout, `noxctl` shipped two
+compatibility mechanisms in `src/credentials-store.ts`:
+
+- **Dual-write** — on every credential save for the `default` profile, also
+  mirror the blob to the legacy unnamespaced slot, so a not-yet-upgraded 0.1.x
+  binary could keep reading credentials written by a newer version.
+- **Legacy read fallback** — `loadCredentialBlob` falls back to the legacy
+  slot (and, before that, a legacy plaintext `credentials.json` file) when the
+  namespaced slot is empty, so upgrading to 0.2.0+ doesn't strand a user's
+  existing session.
+
+Dual-write was scoped to "the 0.2.x compatibility window" and self-labeled
+`REMOVE IN 0.3.0`. That didn't happen in 0.3.0; as of 0.4.0 the flag was still
+`true`. It was flipped to `false` in #53 (this repo, 2026-07-03) — the
+compatibility window has clearly passed, and disabling the write side carries
+no migration risk since it's purely additive (removing it means one less
+keychain write, not a behavior newer clients depend on).
+
+## What's staying for now: the legacy reader
+
+The **read** fallback in `loadCredentialBlob` (the `legacy` / `both-*-preferred`
+/ `legacy-plaintext` source branches) is intentionally **not** being removed
+yet. Unlike the write side, removing the reader is a breaking change: any
+external `noxctl` npm install that
+
+- installed before 0.2.0,
+- has not run `noxctl init` or otherwise re-authenticated since (so no
+  namespaced `profile:default` entry was ever written), and
+- upgrades straight to a version without the legacy reader
+
+would suddenly find `noxctl` unable to locate its stored credentials, with no
+error pointing at the cause — it would look like a fresh, unauthenticated
+install.
+
+## Removal plan
+
+- **Target release: 0.5.0.** Per semver, dropping read support for the 0.1.x
+  credential layout is a breaking change and gets a minor bump (this project
+  is pre-1.0, so breaking changes are signaled via the minor version).
+- **Migration note in the 0.5.0 changelog entry:** users upgrading from a
+  version prior to 0.2.0 (or who have not re-authenticated since 0.2.0 shipped)
+  must run `noxctl init` (or otherwise trigger a credential save) on 0.4.x
+  *before* upgrading to 0.5.0, so their credentials are migrated to the
+  namespaced slot while the legacy reader is still present to seed it.
+- **Removal scope:** delete the `legacy` / `both-new-preferred` /
+  `both-legacy-preferred` / `legacy-plaintext` branches in
+  `loadCredentialBlob`, `loadLegacyPlaintextSecret`, `removeLegacyPlaintextSecret`,
+  and the now-fully-dead `LEGACY_DUAL_WRITE` write path in
+  `saveCredentialBlob` (already inert since #53, but the flag and branch can be
+  deleted outright once the reader goes).
+- **Pre-removal check:** before cutting 0.5.0, confirm via the existing test
+  suite (`tests/credentials-store.test.ts`) that no code path outside
+  `credentials-store.ts` depends on the `legacy*` / `both-*` `LoadSource`
+  variants, and update `LoadSource`'s type accordingly.

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -30,11 +30,13 @@ function windowsCredentialsFile(profile: string): string {
   return path.join(configDir(), `credentials.${sanitizeForFilename(profile)}.dpapi`);
 }
 
-// Dual-write to the legacy slot during the 0.2.x compatibility window so an
-// older 0.1 binary can still read credentials written by this one. Flip to
-// `false` in 0.3.0 and delete the legacy reader branch below.
-// REMOVE IN 0.3.0
-export const LEGACY_DUAL_WRITE = true;
+// Dual-write to the legacy slot was needed during the 0.2.x compatibility
+// window so an older 0.1 binary could still read credentials written by this
+// one. That window has passed (shipping 0.4.0+), so new writes go only to the
+// per-profile slot. The legacy reader branches (loadCredentialBlob) stay in
+// place — removing them is a breaking change for external npm installs still
+// on the 0.1.x layout; see docs/legacy-credential-removal-plan.md.
+export const LEGACY_DUAL_WRITE = false;
 
 export type LoadSource =
   | 'new'
@@ -357,12 +359,11 @@ export async function saveCredentialBlob(
   // `credentials.default.dpapi`.
   writeToBackend(keychainAccount(normalized), windowsCredentialsFile(normalized), secret);
 
-  // Compatibility dual-write: for the default profile only, and only when the
-  // caller observed a legacy blob during load. This keeps an older 0.1 binary
-  // functional during the 0.2.x window without silently creating a legacy slot
-  // for users who never had one. Best-effort — a failure here must not break
-  // the auth flow, since the authoritative new-slot write already succeeded.
-  // REMOVE IN 0.3.0.
+  // Compatibility dual-write: disabled now that LEGACY_DUAL_WRITE is false
+  // (see its definition above). Kept behind the flag rather than deleted so
+  // it can be re-enabled without resurrecting the write-side logic, should
+  // that ever be needed. Best-effort — a failure here must not break the auth
+  // flow, since the authoritative new-slot write already succeeded.
   if (LEGACY_DUAL_WRITE && isDefault && options.alsoWriteLegacy) {
     try {
       writeToBackend(LEGACY_KEYCHAIN_ACCOUNT, legacyWindowsCredentialsFile(), secret);

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -371,35 +371,9 @@ describe('saveCredentialBlob (darwin)', () => {
     expect(writtenAccounts()).toEqual(['profile:default']);
   });
 
-  it('default profile dual-writes to legacy when alsoWriteLegacy is set', async () => {
+  it('does not dual-write to legacy when alsoWriteLegacy is set, since LEGACY_DUAL_WRITE is false', async () => {
     await saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true });
-    expect(writtenAccounts()).toEqual(expect.arrayContaining(['profile:default', 'default']));
-    expect(writtenAccounts()).toHaveLength(2);
-  });
-
-  it('swallows a legacy-slot write failure when primary write succeeded', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    // Primary (profile:default) write succeeds via the Swift helper; legacy
-    // (account=default) write fails at the security CLI fallback.
-    childProcess.spawnSync.mockImplementationOnce(() => ({
-      status: 0,
-      stderr: '',
-      stdout: '',
-    }));
-    childProcess.spawnSync.mockImplementationOnce(() => ({
-      status: 1,
-      stderr: 'legacy keychain unavailable',
-      stdout: '',
-    }));
-    childProcess.execFileSync.mockImplementation(() => {
-      throw new Error('security CLI also unavailable');
-    });
-
-    await expect(
-      saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true }),
-    ).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/legacy slot/i));
-    warnSpy.mockRestore();
+    expect(writtenAccounts()).toEqual(['profile:default']);
   });
 
   it('non-default profile ignores alsoWriteLegacy', async () => {
@@ -419,7 +393,7 @@ describe('saveCredentialBlob (darwin)', () => {
 
   it('treats mixed-case Default as the default profile (case-insensitive)', async () => {
     await saveCredentialBlob('{"x":1}', 'Default', { alsoWriteLegacy: true });
-    expect(writtenAccounts()).toEqual(expect.arrayContaining(['profile:default', 'default']));
+    expect(writtenAccounts()).toEqual(['profile:default']);
   });
 
   it('rejects invalid profile names', async () => {
@@ -540,7 +514,7 @@ describe('Linux secret-tool backend', () => {
     expect(accounts).toEqual(['profile:default']);
   });
 
-  it('dual-writes to legacy account=default when alsoWriteLegacy is set', async () => {
+  it('does not dual-write to legacy account=default when alsoWriteLegacy is set, since LEGACY_DUAL_WRITE is false', async () => {
     childProcess.execFileSync.mockReturnValue('');
     await saveCredentialBlob('{"x":1}', 'default', { alsoWriteLegacy: true });
 
@@ -552,8 +526,7 @@ describe('Linux secret-tool backend', () => {
       const idx = args.indexOf('account');
       return args[idx + 1];
     });
-    expect(accounts).toEqual(expect.arrayContaining(['profile:default', 'default']));
-    expect(accounts).toHaveLength(2);
+    expect(accounts).toEqual(['profile:default']);
   });
 });
 


### PR DESCRIPTION
## Summary

Two maintenance items from the grimnir ecosystem gap analysis (2026-07-03):

- **`.github/dependabot.yml`** — the repo had CI but no automated dependency-update PRs. Added weekly npm ecosystem checks.
- **`LEGACY_DUAL_WRITE` flipped to `false`** in `src/credentials-store.ts`. This flag gated mirroring credential writes to the pre-0.2.0 unnamespaced keychain/DPAPI slot, so an old 0.1.x binary could keep reading credentials written by newer versions. It was self-labeled `REMOVE IN 0.3.0` but was still `true` in the shipped 0.4.0. The compatibility window has clearly passed, and disabling the write side is safe — it's purely additive removal, not something a current client depends on.
- **Legacy credential *reader* is intentionally left in place.** Removing it would break external `noxctl` npm installs still on the pre-0.2.0 credential layout who haven't re-authenticated since. `docs/legacy-credential-removal-plan.md` documents the plan to drop it in a semver-signaled **0.5.0** release, with a migration note (run `noxctl init` on 0.4.x before upgrading to 0.5.0 if you installed before 0.2.0 and haven't re-authenticated since).
- `CHANGELOG.md` updated under `[Unreleased]`.

## Test plan

- [x] Wrote failing tests first (red) asserting the new default-off dual-write behavior in `tests/credentials-store.test.ts`, confirmed they failed against the unmodified `LEGACY_DUAL_WRITE = true` code.
- [x] Flipped the flag to `false`; tests went green.
- [x] Removed one test (`swallows a legacy-slot write failure...`) that exercised a code path now unreachable with the flag off — kept the `LEGACY_DUAL_WRITE && ...` guard in the source so the branch can be re-enabled without resurrecting write-side logic.
- [x] Full suite: `npm run build && npm test` → **715/715 pass**.
- [x] `npm run lint` clean.
- [x] Confirmed the legacy credential *reader* path (`loadCredentialBlob`) is untouched — its tests are unaffected.
- [x] Verified an unrelated, pre-existing timing flake in `tests/mcp-integration-profile.test.ts` under full-suite load is not caused by this change (reproduced on a stashed/clean checkout of `main`, and confirmed it passes in isolation on this branch).

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)