### PR TITLE
release: noxctl 0.4.1 hardening patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
       - run: npm test
       - run: npm run format:check
+      - run: npm audit --omit=dev
+      - run: npm pack --dry-run --ignore-scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-13
+
 ### Fixed
 
 - Coalesce concurrent OAuth refreshes per profile so refresh-token rotation cannot race or overwrite newer credentials.
@@ -104,5 +106,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Table and JSON output modes (auto-detected by TTY, override with `-o`).
 - `noxctl doctor` / `fortnox_status` for setup validation.
 
+[0.4.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.4.0...v0.4.1
 [0.2.0]: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Coalesce concurrent OAuth refreshes per profile so refresh-token rotation cannot race or overwrite newer credentials.
+- Bound Fortnox and OAuth network calls with explicit deadlines. Read-only requests retry transient network failures and retryable HTTP responses with capped backoff; mutations remain single-attempt and timeout errors warn that their outcome may be unknown.
+
 ### Changed
 
 - **Legacy credential dual-write disabled** (#53) — `saveCredentialBlob` no longer mirrors writes to the pre-0.2.0 unnamespaced keychain/DPAPI slot. The 0.2.x compatibility window (`LEGACY_DUAL_WRITE`) has passed; new credential saves go only to the namespaced `profile:default` slot. Reading the legacy slot is unaffected — `loadCredentialBlob` still transparently falls back to it, so already-migrated 0.1.x installs keep working. See `docs/legacy-credential-removal-plan.md` for the planned 0.5.0 removal of the legacy reader.
+- Default employee detail output now redacts personnummer and exact pay. Exact values remain available through explicit CLI JSON output or MCP `includeRaw`, whose descriptions now warn that payroll data can include sensitive personal information.
+- CI and package publishing now require lint, formatting, build, tests, a production dependency audit, and a package manifest dry-run. Safe transitive dependency updates remove the currently reported npm audit findings.
 
 ### Added
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -43,9 +43,8 @@ If the scope changes, re-check the Fortnox terms and the privacy wording before 
 
 ## Release Checks
 
-- `npm test`
-- `npm run lint`
-- `npm run build`
+- `npm run check:release` (lint, formatting, build, tests, production dependency audit, package manifest dry-run)
+- `npm audit` (record any dev-only findings separately; they are not shipped but still affect contributors/CI)
 - Review `git diff --stat origin/main..HEAD`
 - Sanity-read `README.md`, `PRIVACY.md`, and the tax tool descriptions
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,67 +1,36 @@
 # Project Status
 
-**Last session:** 2026-06-17
-**Branch:** `release/0.4.0` — prepping the 0.4.0 release PR. Payroll (Lön) **merged to `main`** via PR #49 (squash `a9d3e14`); npm latest is still `0.3.0`.
+**Updated:** 2026-07-13
+**Branch:** `hardening/reliability-2026-07-13`
+**Base:** `origin/main` at `933631964b12bc07ee70bc1e7e89f77476c17df4`
+**State:** implementation complete; awaiting parent/fallback PR review before any push, PR, merge, publish, or deployment action.
 
-## 0.4.0 release (in progress)
+## Hardening completed
 
-Version bumped 0.3.0 → 0.4.0 (package.json, cli.ts, index.ts), CHANGELOG `[Unreleased]` → `[0.4.0]`, README disclaimer/integration + PRIVACY payroll-data updated. After this PR merges: `npm publish` + GitHub release `v0.4.0`. Release notes MUST tell users the Lön scope is opt-in → re-run `noxctl init --with-salary`.
+- OAuth refreshes are single-flighted per case-insensitive profile, preventing concurrent refresh-token rotation and duplicate credential writes. OAuth calls have a 30-second deadline.
+- Fortnox calls have explicit deadlines (30 seconds; 120 seconds for raw-body uploads). Only reads retry transient network failures and HTTP 429/5xx responses, with three retries and a 30-second delay cap. Mutations remain single-attempt; mutation timeouts explicitly report that the remote outcome may be unknown.
+- Rate-limit admission is serialized so concurrent callers cannot exceed the existing 25-requests-per-5-seconds budget.
+- Default employee detail summaries redact personnummer and exact monthly/hourly pay. Exact fields require explicit CLI JSON or MCP `includeRaw`; MCP descriptions warn about sensitive payroll data. Mutation payload previews remain exact by design.
+- CI/publishing now require lint, formatting, build, tests, production audit, and package dry-run. The lockfile received audit-compatible transitive-only updates; direct dependency ranges did not change.
 
-## Shipped in 0.4.0 — Payroll (Lön) integration ✅ (merged via PR #49)
+## Verification
 
-Full coverage of the Fortnox salary API — the endpoints were in the spec all along; the unlock was Fortnox now exposing the **Lön** Behörighet to integrations.
+- `npm run check:release` — passed on Node `v22.17.0`: lint, Prettier check, TypeScript build, **66 test files / 722 tests**, production audit, and package dry-run.
+- `npm audit` — **0 vulnerabilities** across production and development dependencies (277 dependencies total).
+- `npm ls --depth=0` — clean dependency tree.
+- No live Fortnox calls or real accounting/payroll mutations were performed.
 
-- **employees** (list/get/create/update), **salary-transactions**, **attendance-transactions** (närvaro), **absence-transactions** (frånvaro) [each list/get/create/delete], **schedule-times** (get/update/reset-day — composite EmployeeId+Date key). Operations + MCP tools (Swedish) + CLI + views + tests for each.
-- **`salary` scope is OPT-IN** (not in default `SCOPES` — would break `init` for apps lacking the Lön permission). Enable via `noxctl init --with-salary` (or `FORTNOX_WITH_SALARY=1`). Granted scopes persisted per-profile (`FortnoxCredentials.scopes`); client-credentials refresh + `doctor`/`fortnox_status` honor it via `effectiveScopes(creds)`. Existing installs unaffected until they re-init with the flag.
-- Adversarial review caught 1 bug (attendance list dropped the employeeid/date filter on the `all` branch) — fixed red/green.
-- **681 unit tests**, lint + format + build green.
+## Review and rollout
 
-### Payroll — live-verified on demo (2026-06-17) ✅
-Re-authed demo with `--with-salary`, then ran the full round-trip against the real Fortnox API:
-- ✅ `salary` scope authorized (`doctor`: 12/12).
-- ✅ **employees** create / get / update — create needs **EmploymentForm + PersonelType + SalaryForm** so Fortnox can assign a company agreement (otherwise the cryptic 400 `ftgavtalid`). Not a missing API field, not a demo-config gap.
-- ✅ **attendance** + **absence** create → get → delete (clean round-trips).
-- ✅ **schedule-times** get + update (Hours 0→8).
-- ⚠️ **salary-transactions** reaches the API & validates correctly, but needs a valid löneart for the active agreement (no list-lönearter endpoint exists to discover codes). Path proven; not a code bug.
-- Ergonomics added (commit `47d78d6`): `employees create` flags for the agreement fields + a targeted hint on the ftgavtalid error. Test employee left inactivated on demo (Employee API has no hard DELETE).
-- **681 unit tests**, lint + format + build green.
+1. Parent or Claude Opus reviews the local commit and diff.
+2. After approval, push the branch, open the PR, let Node 20/22 CI run, and merge only when green.
+3. This repository has no daemon or host deployment. Release, if desired, is an npm patch publish after the normal release/version process; no Heimdall change is appropriate.
 
-### Payroll — PR #49 open
-- Merge PR #49, then cut a release (include the opt-in `salary` scope re-init note in the release notes, like #37's inbox/connectfile).
-- Optional: find a valid löneart on a configured Lön company to prove a green salary-transaction create.
+Rollback after a future npm publish: revert the merge commit; restore `latest` to `noxctl@0.4.0` with `npm dist-tag add noxctl@0.4.0 latest`; deprecate the superseded patch if needed. Existing installations remain on their installed version unless explicitly upgraded.
 
-## 0.3.0 — SHIPPED ✅
+## Residual risks
 
-- Published to **npm** (`noxctl@0.3.0`, latest) + public **GitHub release v0.3.0**.
-- Features: voucher file attachments (#37), Contracts API (#10), financial years / locked period (#11), analytics views + `dashboard` (#7/#12), natural date periods (#9), shell completions (#8), confirmation payload preview (#6), YubiKey serial diagnostics (#33), customer read-only field stripping (#31). **BREAKING (#34):** single-resource JSON output wrapped under the singular resource key.
-- Earlier PR #35 went through 5 Codex review rounds + 9 fixes; PR #38 added #37.
-
-## Live verification (demo company)
-
-#37 was live-verified against the Fortnox demo company (**MagnusGilleConsultingDEMO**, tenant 1818238) — which caught **3 bugs every mock test passed** (PR #45):
-
-1. noxctl never requested the `inbox` / `connectfile` OAuth scopes → added to `SCOPES` (+ `doctor`/`status` now test them and detect the 400 scope-error form).
-2. `VoucherYear` is read-only on the voucherfileconnections POST → moved to the `?financialyear=` query param.
-3. `/3/financialyears` rejects a `?Date=` filter (error 2000588) → date→FY resolution now filters locally.
-
-CHANGELOG corrected (PR #46); `v0.3.0` tag re-pointed to include all fixes.
-
-## Setup added
-
-- Reusable **`demo` profile** → MagnusGilleConsultingDEMO, authorized via the `noxctl` app with `inbox`+`connectfile` scopes. Use `--profile demo` for live write-testing. (Sandbox test data left there: voucher A/1 + a few inbox files — ignorable.)
-- **api-drift check restored** (#39, PR #42): extracts the spec from the ReDoc docs page (openapi.json endpoint is hard-429'd). Verified green in CI.
-
-## Open Issues
-
-- **#13** — bank transactions only (attachments half shipped via #37). The refreshed spec exposes `/3/noxfinansinvoices` (Fortnox Finans) — worth checking whether it covers part of this.
-
-## Next Steps
-
-- (Optional) re-auth the `default` (real-company) profile with `inbox`+`connectfile` if you want attachments there too; live-verify the other new endpoints against real data.
-- `LEGACY_DUAL_WRITE` ("REMOVE IN 0.3.0"): recommend removing the legacy *reader* in 0.4.0 (avoids stranding 0.1.x→0.3.0 direct upgraders).
-- Investigate `/3/noxfinansinvoices` for #13.
-
-## Notes
-
-- 677 unit tests, lint + build green.
-- Lesson reinforced: mock tests can't validate Fortnox scope / read-only / query-param semantics — **live-verify write features against the demo company before publishing.**
+- Node 20 was not available locally; the PR's existing Node 20/22 matrix is the remaining compatibility gate.
+- Fixed 30/120-second deadlines may need tuning from field evidence, but retries and delays are now bounded.
+- Explicit CLI JSON, MCP `includeRaw`, mutation confirmations, and dry-run payloads can still contain payroll PII by design; callers must treat them as sensitive.
+- Tests mock Fortnox transport. No mutation was live-tested in this hardening pass because preserving production data was a hard constraint.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 **Updated:** 2026-07-13
 **Branch:** `hardening/reliability-2026-07-13`
 **Base:** `origin/main` at `933631964b12bc07ee70bc1e7e89f77476c17df4`
-**State:** implementation complete; awaiting parent/fallback PR review before any push, PR, merge, publish, or deployment action.
+**State:** `0.4.1` release candidate is open as draft PR #65; parent Codex approved the initial hardening commit because Claude Opus was unavailable. Awaiting CI and final merge/release approval. Nothing has been published.
 
 ## Hardening completed
 
@@ -22,9 +22,9 @@
 
 ## Review and rollout
 
-1. Parent or Claude Opus reviews the local commit and diff.
-2. After approval, push the branch, open the PR, let Node 20/22 CI run, and merge only when green.
-3. This repository has no daemon or host deployment. Release, if desired, is an npm patch publish after the normal release/version process; no Heimdall change is appropriate.
+1. Review the release-version commit and require PR #65's Node 20/22 CI to pass.
+2. Merge only after approval and green CI.
+3. Tag/release `v0.4.1` and publish `noxctl@0.4.1` to npm using the normal release process. This npm patch is the deployment; the repository has no daemon or host rollout, and no Heimdall change is appropriate.
 
 Rollback after a future npm publish: revert the merge commit; restore `latest` to `noxctl@0.4.0` with `npm dist-tag add noxctl@0.4.0 latest`; deprecate the superseded patch if needed. Existing installations remain on their installed version unless explicitly upgraded.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,21 +31,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -283,36 +283,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -320,9 +312,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -337,9 +329,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -354,9 +346,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -371,9 +363,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -388,9 +380,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -405,16 +397,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -425,16 +414,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -445,16 +431,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -465,16 +448,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -485,16 +465,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -505,16 +482,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -525,9 +499,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -542,9 +516,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -552,16 +526,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -576,9 +552,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -593,9 +569,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -607,9 +583,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1165,9 +1141,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1483,9 +1459,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1790,12 +1766,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1828,9 +1804,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -2076,9 +2052,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2088,9 +2064,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2175,9 +2151,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2455,9 +2431,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2479,9 +2452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2503,9 +2473,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2527,9 +2494,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2808,9 +2772,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3014,9 +2978,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3036,9 +3000,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -3056,7 +3020,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3114,12 +3078,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3186,14 +3151,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.115.0",
-        "@rolldown/pluginutils": "1.0.0-rc.9"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3202,21 +3167,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -3327,14 +3292,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3346,13 +3311,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3529,14 +3494,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3699,18 +3664,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.9",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3726,8 +3690,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.0.0-alpha.31",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "lint": "eslint src/ tests/",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
+    "verify": "npm run lint && npm run format:check && npm run build && npm test",
+    "check:release": "npm run verify && npm audit --omit=dev && npm pack --dry-run --ignore-scripts",
     "check:api": "bash scripts/check-api-changes.sh",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run check:release",
     "prepare": "husky"
   },
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Magnus-Gille/noxctl",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "noxctl",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,6 +9,14 @@ import { migrateLegacyIfNeeded, readProfileIndex, upsertProfile } from './profil
 const FORTNOX_AUTH_URL = 'https://apps.fortnox.se/oauth-v1/auth';
 const FORTNOX_TOKEN_URL = 'https://apps.fortnox.se/oauth-v1/token';
 const CALLBACK_HOST = '127.0.0.1';
+const AUTH_REQUEST_TIMEOUT_MS = 30_000;
+
+function authFetch(input: string | URL, init: RequestInit = {}): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(AUTH_REQUEST_TIMEOUT_MS),
+  });
+}
 
 export const SCOPES =
   'article customer invoice payment supplier supplierinvoice bookkeeping companyinformation settings inbox connectfile';
@@ -60,6 +68,11 @@ export interface FortnoxAppConfig {
 // instance would share this state. Revisit if the MCP SDK grows request-local
 // context that handlers can read.
 let resolvedProfile: string = DEFAULT_PROFILE;
+
+// Token endpoints may rotate refresh tokens, so concurrent requests for the
+// same profile must share one refresh and one credential-store write. Profile
+// names are case-insensitive throughout the storage layer.
+const tokenRefreshes = new Map<string, Promise<string>>();
 
 // Whether the legacy (pre-0.2) credential slot was observed on the most recent
 // successful load of the default profile. Set only by loadCredentials; read by
@@ -152,7 +165,7 @@ export async function exchangeCodeForTokens(
     redirect_uri: redirectUri,
   });
 
-  const response = await fetch(FORTNOX_TOKEN_URL, {
+  const response = await authFetch(FORTNOX_TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -188,7 +201,7 @@ export async function getTokenViaClientCredentials(
     scope: effectiveScopes(creds),
   });
 
-  const response = await fetch(FORTNOX_TOKEN_URL, {
+  const response = await authFetch(FORTNOX_TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -229,7 +242,7 @@ export async function refreshAccessToken(
     refresh_token: creds.refresh_token,
   });
 
-  const response = await fetch(FORTNOX_TOKEN_URL, {
+  const response = await authFetch(FORTNOX_TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -278,23 +291,39 @@ export async function getValidToken(profile?: string): Promise<string> {
     return creds.access_token;
   }
 
-  // Prefer client credentials when tenant_id is available (no refresh token management needed)
-  if (creds.tenant_id) {
-    try {
-      const refreshed = await getTokenViaClientCredentials(creds, target);
-      return refreshed.access_token;
-    } catch {
-      // Fall through to refresh_token flow
-    }
-  }
+  const refreshKey = target.toLowerCase();
+  const existing = tokenRefreshes.get(refreshKey);
+  if (existing) return existing;
 
-  // Fallback: standard refresh token flow
-  const refreshed = await refreshAccessToken(creds, target);
-  return refreshed.access_token;
+  const refresh = (async (): Promise<string> => {
+    // Prefer client credentials when tenant_id is available (no refresh token
+    // rotation). Retain the refresh-token fallback for existing profiles whose
+    // service-account setup is unavailable or revoked.
+    if (creds.tenant_id) {
+      try {
+        const refreshed = await getTokenViaClientCredentials(creds, target);
+        return refreshed.access_token;
+      } catch {
+        // Fall through to refresh_token flow
+      }
+    }
+
+    const refreshed = await refreshAccessToken(creds, target);
+    return refreshed.access_token;
+  })();
+
+  tokenRefreshes.set(refreshKey, refresh);
+  try {
+    return await refresh;
+  } finally {
+    // Do not delete a newer refresh that could have been installed after this
+    // one settled (defensive; normal execution never overlaps them).
+    if (tokenRefreshes.get(refreshKey) === refresh) tokenRefreshes.delete(refreshKey);
+  }
 }
 
 export async function fetchTenantId(accessToken: string): Promise<string | undefined> {
-  const response = await fetch('https://api.fortnox.se/3/companyinformation', {
+  const response = await authFetch('https://api.fortnox.se/3/companyinformation', {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: 'application/json',
@@ -312,7 +341,7 @@ export async function fetchTenantId(accessToken: string): Promise<string | undef
 
 export async function fetchCompanyNameSafe(accessToken: string): Promise<string | undefined> {
   try {
-    const response = await fetch('https://api.fortnox.se/3/companyinformation', {
+    const response = await authFetch('https://api.fortnox.se/3/companyinformation', {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: 'application/json',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ const program = new Command();
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.4.0')
+  .version('0.4.1')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -2,26 +2,44 @@ import { getResolvedProfile, getValidToken } from './auth.js';
 import { DEFAULT_PROFILE } from './profile-name.js';
 
 const BASE_URL = 'https://api.fortnox.se/3';
+const REQUEST_TIMEOUT_MS = 30_000;
+const UPLOAD_TIMEOUT_MS = 120_000;
+const MAX_RETRIES = 3;
+const MAX_RETRY_DELAY_MS = 30_000;
 
 // Rate limiter: max 25 requests per 5 seconds
 const RATE_WINDOW_MS = 5000;
 const RATE_LIMIT = 25;
 const requestTimestamps: number[] = [];
+let rateLimitTail: Promise<void> = Promise.resolve();
 
 async function waitForRateLimit(): Promise<void> {
-  const now = Date.now();
-  // Remove timestamps older than the window
-  while (requestTimestamps.length > 0 && requestTimestamps[0]! < now - RATE_WINDOW_MS) {
-    requestTimestamps.shift();
-  }
+  let release!: () => void;
+  const previous = rateLimitTail;
+  rateLimitTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
 
-  if (requestTimestamps.length >= RATE_LIMIT) {
-    const oldestInWindow = requestTimestamps[0]!;
-    const waitMs = oldestInWindow + RATE_WINDOW_MS - now + 50; // 50ms buffer
-    await new Promise((resolve) => setTimeout(resolve, waitMs));
-  }
+  await previous;
+  try {
+    while (true) {
+      const now = Date.now();
+      while (requestTimestamps.length > 0 && requestTimestamps[0]! <= now - RATE_WINDOW_MS) {
+        requestTimestamps.shift();
+      }
 
-  requestTimestamps.push(Date.now());
+      if (requestTimestamps.length < RATE_LIMIT) {
+        requestTimestamps.push(now);
+        return;
+      }
+
+      const oldestInWindow = requestTimestamps[0]!;
+      const waitMs = Math.max(1, oldestInWindow + RATE_WINDOW_MS - now + 50);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  } finally {
+    release();
+  }
 }
 
 export interface FortnoxError {
@@ -38,6 +56,7 @@ export class FortnoxApiError extends Error {
     public readonly fortnoxMessage: string,
     public readonly details?: string,
     endpoint?: string,
+    public readonly retryAfterMs?: number,
   ) {
     const hint = getErrorHint(statusCode, fortnoxMessage, endpoint);
     const profile = getResolvedProfile();
@@ -47,6 +66,20 @@ export class FortnoxApiError extends Error {
     super(parts.join('\n'));
     this.name = 'FortnoxApiError';
     this.hint = hint;
+  }
+}
+
+export class FortnoxRequestTimeoutError extends Error {
+  public readonly outcomeUnknown: boolean;
+
+  constructor(method: string, endpoint: string, timeoutMs: number) {
+    const mutation = !['GET', 'HEAD', 'OPTIONS'].includes(method);
+    const suffix = mutation
+      ? ' The outcome is unknown; verify the result in Fortnox before retrying to avoid duplicate side effects.'
+      : ' It is safe to retry the read request.';
+    super(`Fortnox ${method} ${endpoint} timed out after ${timeoutMs} ms.${suffix}`);
+    this.name = 'FortnoxRequestTimeoutError';
+    this.outcomeUnknown = mutation;
   }
 }
 
@@ -73,7 +106,7 @@ function getErrorHint(statusCode: number, message: string, endpoint?: string): s
     case 404:
       return 'Resource not found. Verify the ID/number exists in Fortnox.';
     case 429:
-      return 'Rate limited by Fortnox. The request will be retried automatically.';
+      return 'Rate limited by Fortnox. Read requests are retried automatically; mutations are not retried to avoid duplicate side effects.';
     default:
       if (statusCode >= 500) {
         return 'Fortnox server error. Try again in a moment.';
@@ -118,10 +151,49 @@ function endpointToScope(endpoint: string): string | undefined {
   return undefined;
 }
 
+function errorCode(err: unknown): string | undefined {
+  let current: unknown = err;
+  for (let depth = 0; depth < 4 && current && typeof current === 'object'; depth++) {
+    const value = current as { code?: unknown; cause?: unknown };
+    if (typeof value.code === 'string') return value.code;
+    current = value.cause;
+  }
+  return undefined;
+}
+
+function isTimeoutError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'TimeoutError' || err.name === 'AbortError' || errorCode(err) === 'ABORT_ERR')
+  );
+}
+
+function isTransientNetworkError(err: unknown): boolean {
+  if (isTimeoutError(err)) return true;
+  const code = errorCode(err);
+  if (
+    code &&
+    ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'ENETUNREACH', 'ECONNREFUSED'].includes(code)
+  ) {
+    return true;
+  }
+  return err instanceof TypeError && /fetch failed/i.test(err.message);
+}
+
+function retryAfterDelay(response: Response): number | undefined {
+  const raw = response.headers?.get?.('retry-after');
+  if (!raw) return undefined;
+
+  const seconds = Number(raw);
+  const delay = Number.isFinite(seconds) ? seconds * 1000 : new Date(raw).getTime() - Date.now();
+  if (!Number.isFinite(delay)) return undefined;
+  return Math.min(Math.max(0, delay), MAX_RETRY_DELAY_MS);
+}
+
 async function retryWithBackoff<T>(
   fn: () => Promise<T>,
   retryable: boolean,
-  maxRetries = 3,
+  maxRetries = MAX_RETRIES,
 ): Promise<T> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -134,15 +206,14 @@ async function retryWithBackoff<T>(
       if (err instanceof FortnoxApiError) {
         const retryable = [429, 500, 502, 503, 504];
         if (!retryable.includes(err.statusCode)) throw err;
-      } else if (
-        err instanceof Error &&
-        !err.message.includes('ECONNRESET') &&
-        !err.message.includes('ETIMEDOUT')
-      ) {
+      } else if (!isTransientNetworkError(err)) {
         throw err;
       }
 
-      const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
+      const delay =
+        err instanceof FortnoxApiError && err.retryAfterMs !== undefined
+          ? err.retryAfterMs
+          : Math.min(1000 * Math.pow(2, attempt), MAX_RETRY_DELAY_MS);
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
@@ -163,67 +234,83 @@ export async function fortnoxRequest<T>(
   const method = (options.method || 'GET').toUpperCase();
   const retryable = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
 
-  return retryWithBackoff(async () => {
-    await waitForRateLimit();
+  const timeoutMs = options.rawBody === undefined ? REQUEST_TIMEOUT_MS : UPLOAD_TIMEOUT_MS;
 
-    const token = await getValidToken();
-    const url = new URL(`${BASE_URL}/${endpoint}`);
+  try {
+    return await retryWithBackoff(async () => {
+      await waitForRateLimit();
 
-    if (options.params) {
-      for (const [key, value] of Object.entries(options.params)) {
-        if (value !== undefined) {
-          url.searchParams.set(key, String(value));
+      const token = await getValidToken();
+      const url = new URL(`${BASE_URL}/${endpoint}`);
+
+      if (options.params) {
+        for (const [key, value] of Object.entries(options.params)) {
+          if (value !== undefined) {
+            url.searchParams.set(key, String(value));
+          }
         }
       }
-    }
 
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/json',
-    };
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      };
 
-    const fetchOptions: RequestInit = {
-      method,
-      headers,
-    };
+      const fetchOptions: RequestInit = {
+        method,
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+      };
 
-    if (options.rawBody !== undefined) {
-      // A raw body (e.g. FormData for a multipart file upload): do NOT set
-      // Content-Type — fetch/undici derives it (and the multipart boundary)
-      // from the body itself.
-      fetchOptions.body = options.rawBody;
-    } else {
-      headers['Content-Type'] = 'application/json';
-      if (options.body) {
-        fetchOptions.body = JSON.stringify(options.body);
-      }
-    }
-
-    const response = await fetch(url.toString(), fetchOptions);
-
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}`;
-      let details: string | undefined;
-      try {
-        const errorBody = (await response.json()) as {
-          ErrorInformation?: { message?: string; code?: number };
-        };
-        if (errorBody?.ErrorInformation) {
-          errorMessage = errorBody.ErrorInformation.message || errorMessage;
-          details = `Error code: ${errorBody.ErrorInformation.code}`;
+      if (options.rawBody !== undefined) {
+        // A raw body (e.g. FormData for a multipart file upload): do NOT set
+        // Content-Type — fetch/undici derives it (and the multipart boundary)
+        // from the body itself.
+        fetchOptions.body = options.rawBody;
+      } else {
+        headers['Content-Type'] = 'application/json';
+        if (options.body) {
+          fetchOptions.body = JSON.stringify(options.body);
         }
-      } catch {
-        // ignore parse errors
       }
-      throw new FortnoxApiError(response.status, errorMessage, details, endpoint);
+
+      const response = await fetch(url.toString(), fetchOptions);
+
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}`;
+        let details: string | undefined;
+        try {
+          const errorBody = (await response.json()) as {
+            ErrorInformation?: { message?: string; code?: number };
+          };
+          if (errorBody?.ErrorInformation) {
+            errorMessage = errorBody.ErrorInformation.message || errorMessage;
+            details = `Error code: ${errorBody.ErrorInformation.code}`;
+          }
+        } catch {
+          // ignore parse errors
+        }
+        throw new FortnoxApiError(
+          response.status,
+          errorMessage,
+          details,
+          endpoint,
+          retryAfterDelay(response),
+        );
+      }
+
+      // Some endpoints return empty responses (e.g., DELETE)
+      const text = await response.text();
+      if (!text) return undefined as T;
+
+      return JSON.parse(text) as T;
+    }, retryable);
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      throw new FortnoxRequestTimeoutError(method, endpoint, timeoutMs);
     }
-
-    // Some endpoints return empty responses (e.g., DELETE)
-    const text = await response.text();
-    if (!text) return undefined as T;
-
-    return JSON.parse(text) as T;
-  }, retryable);
+    throw err;
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.4.0',
+    version: '0.4.1',
   });
 
   registerCustomerTools(server);

--- a/src/tools/employees.ts
+++ b/src/tools/employees.ts
@@ -66,7 +66,10 @@ export function registerEmployeeTools(server: McpServer): void {
       page: z.number().optional().describe('Sidnummer (default 1)'),
       limit: z.number().optional().describe('Antal per sida (default 100)'),
       all: z.boolean().optional().describe('Hämta alla sidor (ignorerar page/limit)'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      includeRaw: z
+        .boolean()
+        .optional()
+        .describe('Inkludera rå JSON; kan exponera personnummer, lön och bankuppgifter'),
     },
     async ({ page, limit, all, includeRaw }) => {
       const data = await listEmployees({ page, limit, all });
@@ -85,7 +88,10 @@ export function registerEmployeeTools(server: McpServer): void {
     'Hämta en enskild anställd från Fortnox (kräver Lön-behörigheten).',
     {
       employeeId: z.string().describe('EmployeeId för den anställde'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      includeRaw: z
+        .boolean()
+        .optional()
+        .describe('Inkludera rå JSON; kan exponera personnummer, lön och bankuppgifter'),
     },
     async ({ employeeId, includeRaw }) => {
       const data = await getEmployee(employeeId);
@@ -107,7 +113,10 @@ export function registerEmployeeTools(server: McpServer): void {
       ...employeeWritableFields,
       confirm: z.boolean().optional().describe('Bekräfta att den anställde ska skapas'),
       dryRun: z.boolean().optional().describe('Visa vad som skulle skickas utan att skapa'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      includeRaw: z
+        .boolean()
+        .optional()
+        .describe('Inkludera rå JSON; kan exponera personnummer, lön och bankuppgifter'),
     },
     async ({ confirm, dryRun, includeRaw, ...params }) => {
       if (dryRun) {
@@ -133,7 +142,10 @@ export function registerEmployeeTools(server: McpServer): void {
       ...employeeWritableFields,
       confirm: z.boolean().optional().describe('Bekräfta att den anställde ska uppdateras'),
       dryRun: z.boolean().optional().describe('Visa vad som skulle skickas utan att uppdatera'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      includeRaw: z
+        .boolean()
+        .optional()
+        .describe('Inkludera rå JSON; kan exponera personnummer, lön och bankuppgifter'),
     },
     async ({ employeeId, confirm, dryRun, includeRaw, ...fields }) => {
       if (dryRun) {

--- a/src/views.ts
+++ b/src/views.ts
@@ -467,6 +467,8 @@ export const voucherAttachmentColumns: Column[] = [
 
 // --- Payroll / Lön views (target ≤80 cols) ---
 
+const redactPayrollValue = (): string => '[redacted — use JSON/includeRaw for explicit access]';
+
 // Employees
 export const employeeListColumns: Column[] = [
   { key: 'EmployeeId', header: 'Emp #', width: 12 },
@@ -481,15 +483,32 @@ export const employeeDetailColumns: Column[] = [
   { key: 'LastName', header: 'Last Name', width: 20 },
   { key: 'FullName', header: 'Full Name', width: 30 },
   { key: 'Email', header: 'Email', width: 30 },
-  { key: 'PersonalIdentityNumber', header: 'Personnr', width: 14 },
+  {
+    key: 'PersonalIdentityNumber',
+    header: 'Personnr',
+    width: 14,
+    format: redactPayrollValue,
+  },
   { key: 'JobTitle', header: 'Job Title', width: 30 },
   { key: 'EmploymentDate', header: 'Employed', width: 10 },
   { key: 'EmployedTo', header: 'Employed To', width: 10 },
   { key: 'EmploymentForm', header: 'Form', width: 6 },
   { key: 'PersonelType', header: 'Type', width: 6 },
   { key: 'SalaryForm', header: 'Salary Form', width: 6 },
-  { key: 'MonthlySalary', header: 'Monthly', width: 12, align: 'right' },
-  { key: 'HourlyPay', header: 'Hourly', width: 12, align: 'right' },
+  {
+    key: 'MonthlySalary',
+    header: 'Monthly',
+    width: 12,
+    align: 'right',
+    format: redactPayrollValue,
+  },
+  {
+    key: 'HourlyPay',
+    header: 'Hourly',
+    width: 12,
+    align: 'right',
+    format: redactPayrollValue,
+  },
   { key: 'TaxTable', header: 'Tax Table', width: 10 },
   { key: 'TaxColumn', header: 'Tax Col', width: 7, align: 'right' },
   { key: 'Inactive', header: 'Inactive', width: 8 },

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -265,7 +265,7 @@ describe('auth', () => {
       expect(result).toEqual(mockResponse);
       expect(global.fetch).toHaveBeenCalledWith(
         'https://apps.fortnox.se/oauth-v1/token',
-        expect.objectContaining({ method: 'POST' }),
+        expect.objectContaining({ method: 'POST', signal: expect.any(AbortSignal) }),
       );
     });
 
@@ -520,6 +520,58 @@ describe('auth', () => {
 
       const token = await getValidToken();
       expect(token).toBe('cc-fresh-token');
+    });
+
+    it('single-flights concurrent refreshes for the same profile', async () => {
+      const expired = { ...mockCredentials, expires_at: Date.now() - 1000 };
+      credentialStore.loadCredentialBlob.mockResolvedValue(blobResult(JSON.stringify(expired)));
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: 'shared-fresh-token',
+            refresh_token: 'shared-refresh-token',
+            expires_in: 3600,
+          }),
+      });
+
+      const tokens = await Promise.all([
+        getValidToken('default'),
+        getValidToken('default'),
+        getValidToken('Default'),
+      ]);
+
+      expect(tokens).toEqual(['shared-fresh-token', 'shared-fresh-token', 'shared-fresh-token']);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(credentialStore.saveCredentialBlob).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears a failed single-flight so a later refresh can recover', async () => {
+      const expired = { ...mockCredentials, expires_at: Date.now() - 1000 };
+      credentialStore.loadCredentialBlob.mockResolvedValue(blobResult(JSON.stringify(expired)));
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve('Unauthorized'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: 'recovered-token',
+              refresh_token: 'recovered-refresh',
+              expires_in: 3600,
+            }),
+        });
+
+      const first = await Promise.allSettled([getValidToken('default'), getValidToken('default')]);
+      expect(first.every((result) => result.status === 'rejected')).toBe(true);
+      await expect(getValidToken('default')).resolves.toBe('recovered-token');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('falls back to refresh token when client credentials fails', async () => {

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fortnoxRequest, FortnoxApiError } from '../src/fortnox-client.js';
+import {
+  fortnoxRequest,
+  FortnoxApiError,
+  FortnoxRequestTimeoutError,
+} from '../src/fortnox-client.js';
 import { getResolvedProfile } from '../src/auth.js';
 
 vi.mock('../src/auth.js', () => ({
@@ -9,6 +13,7 @@ vi.mock('../src/auth.js', () => ({
 
 describe('fortnox-client', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -26,6 +31,7 @@ describe('fortnox-client', () => {
       'https://api.fortnox.se/3/customers/1',
       expect.objectContaining({
         method: 'GET',
+        signal: expect.any(AbortSignal),
         headers: expect.objectContaining({
           Authorization: 'Bearer mock-token',
           'Content-Type': 'application/json',
@@ -135,6 +141,73 @@ describe('fortnox-client', () => {
         body: { Customer: { Name: 'New' } },
       }),
     ).rejects.toThrow(FortnoxApiError);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a GET when Node fetch reports a transient error in its cause', async () => {
+    const transient = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }),
+    });
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+    await expect(fortnoxRequest('customers')).resolves.toEqual({ ok: true });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps Retry-After before retrying a read request', async () => {
+    vi.useFakeTimers();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: { get: () => '120' },
+        json: () => Promise.resolve({ ErrorInformation: { message: 'Rate limited', code: 0 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+    const request = fortnoxRequest('customers');
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds mutation requests and marks a timeout outcome as unknown', async () => {
+    const controller = new AbortController();
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    global.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const request = fortnoxRequest('customers', {
+      method: 'POST',
+      body: { Customer: { Name: 'Acme AB' } },
+    });
+    const rejection = expect(request).rejects.toMatchObject({
+      name: 'FortnoxRequestTimeoutError',
+      outcomeUnknown: true,
+    } satisfies Partial<FortnoxRequestTimeoutError>);
+
+    controller.abort(new DOMException('request timed out', 'TimeoutError'));
+    await rejection;
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/tools/employees.test.ts
+++ b/tests/tools/employees.test.ts
@@ -63,6 +63,52 @@ describe('employee tools', () => {
       );
       expect(parsed.EmployeeId).toBe('1');
     });
+
+    it('redacts identity number and exact salary from the default MCP summary', async () => {
+      mockFetch({
+        Employee: {
+          EmployeeId: '1',
+          FirstName: 'Anna',
+          LastName: 'Andersson',
+          PersonalIdentityNumber: '19900101-1234',
+          MonthlySalary: '50000',
+          HourlyPay: '350',
+        },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_employee',
+        arguments: { employeeId: '1' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).not.toContain('19900101-1234');
+      expect(text).not.toContain('50000');
+      expect(text).not.toContain('350');
+      expect(text).toContain('redacted');
+    });
+
+    it('keeps sensitive employee fields available only through explicit includeRaw', async () => {
+      mockFetch({
+        Employee: {
+          EmployeeId: '1',
+          PersonalIdentityNumber: '19900101-1234',
+          MonthlySalary: '50000',
+        },
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_employee',
+        arguments: { employeeId: '1', includeRaw: true },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
+      expect(parsed.PersonalIdentityNumber).toBe('19900101-1234');
+      expect(parsed.MonthlySalary).toBe('50000');
+    });
   });
 
   describe('fortnox_create_employee', () => {


### PR DESCRIPTION
## Summary

This is the deliberate `noxctl@0.4.1` hardening patch release.

- coalesce concurrent OAuth refreshes per profile and add explicit OAuth request deadlines
- bound Fortnox request time and retry behavior while preserving single-attempt mutation semantics
- serialize rate-limit admission for concurrent callers
- redact personnummer and exact pay from default employee summaries while preserving explicit JSON/`includeRaw` access
- strengthen CI and npm release gates, and update audited transitive dependencies
- align package, lockfile, CLI, MCP handshake, and registry metadata on version `0.4.1`
- move all previously unreleased changes from `main` plus this hardening work into the dated `0.4.1` changelog entry

## Why

The hardening audit found reliability gaps around concurrent refresh-token rotation, unbounded network waits, and concurrent rate-limit admission. It also found that default payroll summaries exposed more personal data than needed and that release checks did not enforce every existing quality/security gate.

This PR adds no endpoints or product functionality. It keeps read/write safety semantics unchanged: only safe reads retry; mutations never retry automatically, and mutation timeouts state that the Fortnox outcome may be unknown.

## Validation

Validated at head `5d6b7a0` on Node 22.17.0:

- `npm run check:release`
  - ESLint passed
  - Prettier check passed
  - TypeScript build passed
  - 66 test files / 722 tests passed
  - production dependency audit: 0 vulnerabilities
  - package dry-run: `noxctl@0.4.1`, 271 files
- full `npm audit`: 0 vulnerabilities across production and development dependencies
- `npm ls --depth=0`: clean
- built CLI reports `0.4.1`
- no live Fortnox calls or mutations performed

## Review

Claude Opus was unavailable for this repository pass. Parent Codex performed the fallback review of the hardening commit `7a0eb8331d17dd6a50e633059983f1f4e3efb511` and approved the transport semantics, OAuth singleflight, serialized rate admission, and explicitly bypassable payroll redaction. The follow-up release commit contains version, changelog, and rollout metadata only.

## Rollout

This repository has no daemon or host deployment. After approval, green Node 20/22 CI, and merge:

1. create the `v0.4.1` GitHub tag/release
2. publish `noxctl@0.4.1` through the normal npm release process
3. verify npm's `latest` dist-tag resolves to `0.4.1`

Do not publish from this draft PR. No Heimdall change is appropriate because noxctl is an on-demand CLI/MCP package.

Rollback after publication: restore `latest` with `npm dist-tag add noxctl@0.4.0 latest`, deprecate `0.4.1` if needed, and revert the merge. Existing installations remain pinned until explicitly upgraded.

## Residual risks

- Node 20 was unavailable locally; this PR's Node 20/22 CI matrix is the compatibility gate.
- Fixed 30-second request and 120-second upload deadlines may need future tuning from field evidence.
- Explicit CLI JSON, MCP `includeRaw`, mutation confirmations, and dry-run payloads intentionally still expose payroll PII and must be treated as sensitive.
- Transport behavior is mock-tested; no live mutation verification was performed.