### PR TITLE
feat(invoices): PDF export command + fix crash on send --method print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **Invoice PDF export** (#66) — `noxctl invoices pdf <docNumber>` and the `fortnox_invoice_pdf` MCP tool download an invoice as a PDF. Writes to `--file <path>`, to stdout with `--file -`, or to `invoice-<docNumber>.pdf` by default (the destination is `--file` because `-o/--output` is globally the output *format*). Uses Fortnox's `/preview` endpoint, which returns the PDF **without** marking the invoice as sent; `--mark-sent` opts into `/print`, which does set `Sent` and therefore prompts for confirmation. Works for credit invoices too.
+- **Invoice PDF export** (#66) — `noxctl invoices pdf <docNumber>` and the `fortnox_invoice_pdf` MCP tool download an invoice as a PDF. Writes to `--file <path>`, to stdout with `--file -`, or to `invoice-<docNumber>.pdf` by default (the destination is `--file` because `-o/--output` is globally the output *format*). The PDF always comes from Fortnox's `/preview` endpoint, which returns the document **without** marking the invoice as sent. `--mark-sent` additionally calls `/print` afterwards to set `Sent`, and therefore prompts for confirmation; the file is written first, so a failed write can never leave an invoice flagged as sent with no PDF to show for it. Works for credit invoices too.
+
+  The MCP tool will not overwrite an existing file unless `overwrite: true` is passed, and defaults to a fresh private temp directory rather than a predictable path — its arguments are agent-generated.
 
 ### Fixed
 
-- `noxctl invoices send <docNumber> --method print` (and `fortnox_send_invoice` with `method: "print"`) crashed with `SyntaxError: Unexpected token '%'`. Fortnox's `/print` endpoint answers with the PDF document rather than JSON, and the response was being parsed as JSON — after Fortnox had already flagged the invoice as sent, so a successful action was reported as a failure. The print path now reads the PDF response correctly and re-reads the invoice to report its true post-print state.
+- `noxctl invoices send <docNumber> --method print` (and `fortnox_send_invoice` with `method: "print"`) crashed with `SyntaxError: Unexpected token '%'`. Fortnox's `/print` endpoint answers with the PDF document rather than JSON, and the response was being parsed as JSON — after Fortnox had already flagged the invoice as sent, so a successful action was reported as a failure. The print path now reads the PDF response correctly and re-reads the invoice to report its true post-print state, still reporting success (with a note) if only that read-back fails.
+- Fortnox exposes `/invoices/{n}/print` as a `GET` even though it sets `Sent`. Requests can now be flagged as mutations independently of their HTTP verb, so `/print` is no longer eligible for automatic retries and a `/print` timeout is correctly reported as an unknown outcome instead of "safe to retry".
 
 ## [0.4.1] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Invoice PDF export** (#66) — `noxctl invoices pdf <docNumber>` and the `fortnox_invoice_pdf` MCP tool download an invoice as a PDF. Writes to `--file <path>`, to stdout with `--file -`, or to `invoice-<docNumber>.pdf` by default (the destination is `--file` because `-o/--output` is globally the output *format*). Uses Fortnox's `/preview` endpoint, which returns the PDF **without** marking the invoice as sent; `--mark-sent` opts into `/print`, which does set `Sent` and therefore prompts for confirmation. Works for credit invoices too.
+
+### Fixed
+
+- `noxctl invoices send <docNumber> --method print` (and `fortnox_send_invoice` with `method: "print"`) crashed with `SyntaxError: Unexpected token '%'`. Fortnox's `/print` endpoint answers with the PDF document rather than JSON, and the response was being parsed as JSON — after Fortnox had already flagged the invoice as sent, so a successful action was reported as a failure. The print path now reads the PDF response correctly and re-reads the invoice to report its true post-print state.
+
 ## [0.4.1] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl invoices create --customer <number> --input <file>` | `fortnox_create_invoice` | Create an invoice (mutation) |
 | `noxctl invoices update <docNumber> --input <file>` | `fortnox_update_invoice` | Update an invoice that has not been bookkeept (mutation) |
 | `noxctl invoices send <docNumber> [--method email\|print\|einvoice] [--subject <s>] [--body <s>] [--bcc <email>]` | `fortnox_send_invoice` | Send via email (default), print, or e-invoice (mutation) |
-| `noxctl invoices pdf <docNumber> [--file <path>\|-] [--mark-sent]` | `fortnox_invoice_pdf` | Download the invoice PDF. Read-only by default; `--mark-sent` also flags it as sent (mutation) |
+| `noxctl invoices pdf <docNumber> [--file <path>\|-] [--mark-sent]` | `fortnox_invoice_pdf` | Download the invoice PDF (via `/preview`, no side effect). `--mark-sent` also flags it as sent afterwards (mutation) |
 | `noxctl invoices bookkeep <docNumber>` | `fortnox_bookkeep_invoice` | Bookkeep an invoice (mutation) |
 | `noxctl invoices credit <docNumber>` | `fortnox_credit_invoice` | Credit an invoice (mutation) |
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl invoices create --customer <number> --input <file>` | `fortnox_create_invoice` | Create an invoice (mutation) |
 | `noxctl invoices update <docNumber> --input <file>` | `fortnox_update_invoice` | Update an invoice that has not been bookkeept (mutation) |
 | `noxctl invoices send <docNumber> [--method email\|print\|einvoice] [--subject <s>] [--body <s>] [--bcc <email>]` | `fortnox_send_invoice` | Send via email (default), print, or e-invoice (mutation) |
+| `noxctl invoices pdf <docNumber> [--file <path>\|-] [--mark-sent]` | `fortnox_invoice_pdf` | Download the invoice PDF. Read-only by default; `--mark-sent` also flags it as sent (mutation) |
 | `noxctl invoices bookkeep <docNumber>` | `fortnox_bookkeep_invoice` | Bookkeep an invoice (mutation) |
 | `noxctl invoices credit <docNumber>` | `fortnox_credit_invoice` | Credit an invoice (mutation) |
 
@@ -480,6 +481,8 @@ CLI:
 noxctl invoices send 1001                              # prompts: "Send invoice 1001 via email. Continue? [y/N]"
 noxctl invoices send 1001 --yes                        # skip prompt (scripting/AI)
 noxctl invoices send 1001 --dry-run                    # preview without sending
+noxctl invoices pdf 1001                               # read-only, no prompt
+noxctl invoices pdf 1001 --mark-sent                   # prompts: also flags the invoice as sent
 noxctl customers update 42 --input customer.json       # prompts for confirmation
 noxctl vouchers create --input voucher.json --dry-run  # preview payload
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1117,21 +1117,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3577,17 +3590,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,17 @@ import {
 
 const program = new Command();
 
+// A closed downstream pipe (`noxctl ... | head`, or a reader that exits early)
+// makes stdout emit EPIPE. That is normal for a CLI, and without this listener
+// Node reports it as an uncaught exception with a stack trace, bypassing the
+// command's own error handling.
+process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') {
+    process.exit(0);
+  }
+  throw err;
+});
+
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
@@ -1447,12 +1458,29 @@ Examples:
       writeFileSync(path, pdf);
 
       // Only now that the PDF is safely on disk do we change Fortnox.
-      if (opts.markSent) await markInvoicePrinted(documentNumber);
+      const printed = opts.markSent ? await markInvoicePrinted(documentNumber) : undefined;
+
+      // Prefer the document /print actually produced, so the saved copy matches
+      // the version that was marked as sent. Best-effort: the /preview copy is
+      // already written and the invoice is already flagged, so a failure here is
+      // reported as a note rather than raised as a failed operation.
+      let bytes = pdf.length;
+      let note = printed?.invoice.Note ? ` ${String(printed.invoice.Note)}` : '';
+      if (printed?.pdf) {
+        try {
+          writeFileSync(path, printed.pdf);
+          bytes = printed.pdf.length;
+        } catch (err) {
+          note += ` Saved file is the /preview copy; rewriting it with the printed version failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+      }
 
       outputConfirmation(
-        `Invoice ${documentNumber} saved to ${path} (${pdf.length} bytes).`,
+        `Invoice ${documentNumber} saved to ${path} (${bytes} bytes).${note}`,
         json(),
-        { DocumentNumber: documentNumber, Path: path, Bytes: pdf.length, Sent: !!opts.markSent },
+        { DocumentNumber: documentNumber, Path: path, Bytes: bytes, Sent: !!opts.markSent },
       );
     },
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command, Option } from 'commander';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import {
   isJsonMode,
@@ -1374,6 +1374,74 @@ invoices
         data,
         invoiceConfirmColumns,
         'Invoice',
+      );
+    },
+  );
+
+invoices
+  .command('pdf <documentNumber>')
+  .description('Download an invoice as a PDF')
+  // Note: -o/--output is already taken globally for the output *format*
+  // (json|table), so the destination path is --file.
+  .option('-f, --file <path>', 'Write the PDF here (- for stdout)')
+  .option('--mark-sent', 'Also flag the invoice as sent in Fortnox (uses /print)')
+  .option('-y, --yes', 'Skip confirmation prompt (only needed with --mark-sent)')
+  .option('--dry-run', 'Preview the action without sending it')
+  .addHelpText(
+    'after',
+    `
+By default this uses Fortnox's /preview endpoint, which returns the PDF without
+changing the invoice. --mark-sent switches to /print, which also sets Sent=true.
+
+Without --file the PDF is written to invoice-<documentNumber>.pdf in the current
+directory.
+
+Examples:
+  noxctl invoices pdf 28
+  noxctl invoices pdf 28 --file ~/Desktop/faktura-28.pdf
+  noxctl invoices pdf 28 --file - > faktura.pdf
+  noxctl invoices pdf 28 --mark-sent --yes`,
+  )
+  .action(
+    async (
+      documentNumber: string,
+      opts: { file?: string; markSent?: boolean; yes?: boolean; dryRun?: boolean },
+    ) => {
+      const { getInvoicePdf } = await import('./operations/invoices.js');
+      const toStdout = opts.file === '-';
+
+      // Only an *explicit* --output json conflicts here. json() alone is not the
+      // test: it defaults to true whenever stdout is piped, which is exactly how
+      // `--file -` is meant to be used.
+      if (toStdout && program.opts().output === 'json') {
+        throw new Error(
+          '--file - writes raw PDF bytes to stdout and cannot be combined with --output json.',
+        );
+      }
+
+      // Only --mark-sent mutates the invoice; a plain download needs no confirmation.
+      if (opts.markSent || opts.dryRun) {
+        const action = opts.markSent
+          ? `Download invoice ${documentNumber} as PDF and flag it as sent`
+          : `Download invoice ${documentNumber} as PDF`;
+        if (!(await confirmMutation(action, opts))) {
+          return;
+        }
+      }
+
+      const pdf = await getInvoicePdf(documentNumber, { markSent: opts.markSent });
+
+      if (toStdout) {
+        process.stdout.write(pdf);
+        return;
+      }
+
+      const path = opts.file ?? `invoice-${documentNumber}.pdf`;
+      writeFileSync(path, pdf);
+      outputConfirmation(
+        `Invoice ${documentNumber} saved to ${path} (${pdf.length} bytes).`,
+        json(),
+        { DocumentNumber: documentNumber, Path: path, Bytes: pdf.length, Sent: !!opts.markSent },
       );
     },
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1409,6 +1409,11 @@ with no PDF to show for it.
 Without --file the PDF is written to invoice-<documentNumber>.pdf in the current
 directory.
 
+When writing to a file, --mark-sent replaces it with the document /print itself
+returned, so the saved copy matches the version that was marked. Streaming to
+stdout cannot do that — bytes already written cannot be recalled — so with
+--file - the streamed document is the /preview render.
+
 Examples:
   noxctl invoices pdf 28
   noxctl invoices pdf 28 --file ~/Desktop/faktura-28.pdf
@@ -1480,7 +1485,13 @@ Examples:
       outputConfirmation(
         `Invoice ${documentNumber} saved to ${path} (${bytes} bytes).${note}`,
         json(),
-        { DocumentNumber: documentNumber, Path: path, Bytes: bytes, Sent: !!opts.markSent },
+        {
+          DocumentNumber: documentNumber,
+          Path: path,
+          Bytes: bytes,
+          // Report what Fortnox says the invoice's state is, not what we asked for.
+          Sent: printed ? printed.invoice.Sent : undefined,
+        },
       );
     },
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1390,8 +1390,10 @@ invoices
   .addHelpText(
     'after',
     `
-By default this uses Fortnox's /preview endpoint, which returns the PDF without
-changing the invoice. --mark-sent switches to /print, which also sets Sent=true.
+The PDF always comes from Fortnox's /preview endpoint, which does not change the
+invoice. --mark-sent additionally calls /print afterwards to set Sent=true — the
+file is written first, so a failed write never leaves an invoice flagged as sent
+with no PDF to show for it.
 
 Without --file the PDF is written to invoice-<documentNumber>.pdf in the current
 directory.
@@ -1407,7 +1409,7 @@ Examples:
       documentNumber: string,
       opts: { file?: string; markSent?: boolean; yes?: boolean; dryRun?: boolean },
     ) => {
-      const { getInvoicePdf } = await import('./operations/invoices.js');
+      const { getInvoicePdf, markInvoicePrinted } = await import('./operations/invoices.js');
       const toStdout = opts.file === '-';
 
       // Only an *explicit* --output json conflicts here. json() alone is not the
@@ -1429,15 +1431,24 @@ Examples:
         }
       }
 
-      const pdf = await getInvoicePdf(documentNumber, { markSent: opts.markSent });
+      const pdf = await getInvoicePdf(documentNumber);
 
       if (toStdout) {
-        process.stdout.write(pdf);
+        // Wait for the bytes to be flushed before mutating anything: a closed or
+        // broken pipe must not leave the invoice marked as sent.
+        await new Promise<void>((resolve, reject) => {
+          process.stdout.write(pdf, (err) => (err ? reject(err) : resolve()));
+        });
+        if (opts.markSent) await markInvoicePrinted(documentNumber);
         return;
       }
 
       const path = opts.file ?? `invoice-${documentNumber}.pdf`;
       writeFileSync(path, pdf);
+
+      // Only now that the PDF is safely on disk do we change Fortnox.
+      if (opts.markSent) await markInvoicePrinted(documentNumber);
+
       outputConfirmation(
         `Invoice ${documentNumber} saved to ${path} (${pdf.length} bytes).`,
         json(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1470,7 +1470,7 @@ Examples:
       // already written and the invoice is already flagged, so a failure here is
       // reported as a note rather than raised as a failed operation.
       let bytes = pdf.length;
-      let note = printed?.invoice.Note ? ` ${String(printed.invoice.Note)}` : '';
+      let note = '';
       if (printed?.pdf) {
         try {
           writeFileSync(path, printed.pdf);
@@ -1482,6 +1482,15 @@ Examples:
         }
       }
 
+      // Only claim the invoice is sent if Fortnox actually said so.
+      if (printed && !printed.confirmed) {
+        note += ` ${String(printed.invoice.Note)}`;
+      } else if (printed && printed.invoice.Sent === true) {
+        note += ' Marked as sent.';
+      } else if (printed) {
+        note += ' Warning: Fortnox still reports this invoice as not sent.';
+      }
+
       outputConfirmation(
         `Invoice ${documentNumber} saved to ${path} (${bytes} bytes).${note}`,
         json(),
@@ -1489,8 +1498,9 @@ Examples:
           DocumentNumber: documentNumber,
           Path: path,
           Bytes: bytes,
-          // Report what Fortnox says the invoice's state is, not what we asked for.
-          Sent: printed ? printed.invoice.Sent : undefined,
+          // Report what Fortnox says the invoice's state is, not what we asked
+          // for; undefined means "not checked" or "could not be confirmed".
+          Sent: printed?.confirmed ? printed.invoice.Sent : undefined,
         },
       );
     },

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -369,6 +369,38 @@ function describeUnexpectedBody(buf: Buffer): string {
 }
 
 const PDF_MAGIC = '%PDF-';
+const PDF_TRAILER = '%%EOF';
+
+function startsWithPdfMagic(buf: Buffer): boolean {
+  return buf.subarray(0, PDF_MAGIC.length).toString('latin1') === PDF_MAGIC;
+}
+
+/**
+ * A PDF that both starts with the magic number and carries its end-of-file
+ * trailer, i.e. one that was not cut short in transit. Used where a *partial*
+ * document would be worse than none — replacing an already-saved copy, say.
+ * The trailer may be followed by whitespace, so search the tail rather than
+ * requiring it at the very end.
+ */
+function isCompletePdf(buf: Buffer): boolean {
+  if (!startsWithPdfMagic(buf)) return false;
+  const tail = buf.subarray(Math.max(0, buf.length - 1024)).toString('latin1');
+  return tail.includes(PDF_TRAILER);
+}
+
+/** Fortnox can answer 2xx with an error envelope; detect one in a raw body. */
+function fortnoxErrorInBody(buf: Buffer): { message: string; code?: number } | undefined {
+  if (startsWithPdfMagic(buf)) return undefined;
+  try {
+    const parsed = JSON.parse(buf.toString('utf-8', 0, 4096)) as {
+      ErrorInformation?: { message?: string; code?: number };
+    };
+    const info = parsed?.ErrorInformation;
+    return info?.message ? { message: info.message, code: info.code } : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Fetch a PDF from one of Fortnox's document endpoints. Shares rate limiting,
@@ -386,7 +418,7 @@ export async function fortnoxRequestPdf(
   return request<Buffer>(endpoint, options, async (response) => {
     const buf = Buffer.from(await response.arrayBuffer());
 
-    if (buf.subarray(0, PDF_MAGIC.length).toString('latin1') !== PDF_MAGIC) {
+    if (!startsWithPdfMagic(buf)) {
       const contentType = response.headers?.get?.('content-type') || 'an unknown content type';
       throw new Error(
         `Fortnox returned ${contentType} that is not a PDF for ${endpoint}: ${describeUnexpectedBody(buf)}`,
@@ -412,14 +444,35 @@ export async function fortnoxRequestPdfFromMutation(
   options: RequestOptions = {},
 ): Promise<Buffer | undefined> {
   return request<Buffer | undefined>(endpoint, { ...options, mutation: true }, async (response) => {
+    let buf: Buffer;
     try {
-      const buf = Buffer.from(await response.arrayBuffer());
-      return buf.subarray(0, PDF_MAGIC.length).toString('latin1') === PDF_MAGIC ? buf : undefined;
+      buf = Buffer.from(await response.arrayBuffer());
     } catch {
-      // Body unreadable (truncated stream, aborted transfer). The action
-      // itself already succeeded server-side; report it as such.
+      // Body unreadable (truncated stream, aborted transfer). The status line
+      // already said the action succeeded; report it as such.
       return undefined;
     }
+
+    if (isCompletePdf(buf)) return buf;
+
+    // A well-formed Fortnox error envelope is positive evidence that the action
+    // did NOT happen — unlike an unreadable body, which is merely inconclusive.
+    // Fortnox can send these with a 2xx status, so this has to be checked here
+    // rather than left to the status code.
+    const failure = fortnoxErrorInBody(buf);
+    if (failure) {
+      throw new FortnoxApiError(
+        response.status,
+        failure.message,
+        `Error code: ${failure.code}`,
+        endpoint,
+      );
+    }
+
+    // Something else came back — an incomplete PDF, or a payload we cannot
+    // interpret. Inconclusive, so treat the action as done but offer no
+    // document: callers must not overwrite a good file with this.
+    return undefined;
   });
 }
 

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -72,8 +72,8 @@ export class FortnoxApiError extends Error {
 export class FortnoxRequestTimeoutError extends Error {
   public readonly outcomeUnknown: boolean;
 
-  constructor(method: string, endpoint: string, timeoutMs: number) {
-    const mutation = !['GET', 'HEAD', 'OPTIONS'].includes(method);
+  constructor(method: string, endpoint: string, timeoutMs: number, isMutation?: boolean) {
+    const mutation = isMutation ?? !['GET', 'HEAD', 'OPTIONS'].includes(method);
     const suffix = mutation
       ? ' The outcome is unknown; verify the result in Fortnox before retrying to avoid duplicate side effects.'
       : ' It is safe to retry the read request.';
@@ -225,6 +225,13 @@ export interface RequestOptions {
   body?: unknown;
   rawBody?: BodyInit;
   params?: Record<string, string | number | undefined>;
+  /**
+   * Override the safety classification that would otherwise be derived from the
+   * HTTP verb. Fortnox exposes some state-changing actions as GET — notably
+   * `/invoices/{n}/print`, which sets `Sent` — and those must not be retried
+   * automatically, nor have their timeouts reported as "safe to retry".
+   */
+  mutation?: boolean;
 }
 
 // Issue the HTTP request and translate a non-2xx answer into a FortnoxApiError.
@@ -311,7 +318,9 @@ async function request<T>(
   readBody: (response: Response) => Promise<T>,
 ): Promise<T> {
   const method = (options.method || 'GET').toUpperCase();
-  const retryable = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+  const isMutation =
+    options.mutation ?? !(method === 'GET' || method === 'HEAD' || method === 'OPTIONS');
+  const retryable = !isMutation;
 
   const timeoutMs = options.rawBody === undefined ? REQUEST_TIMEOUT_MS : UPLOAD_TIMEOUT_MS;
 
@@ -322,7 +331,7 @@ async function request<T>(
     );
   } catch (err) {
     if (isTimeoutError(err)) {
-      throw new FortnoxRequestTimeoutError(method, endpoint, timeoutMs);
+      throw new FortnoxRequestTimeoutError(method, endpoint, timeoutMs, isMutation);
     }
     throw err;
   }
@@ -359,26 +368,28 @@ function describeUnexpectedBody(buf: Buffer): string {
   return text.slice(0, 200) || '<empty body>';
 }
 
+const PDF_MAGIC = '%PDF-';
+
 /**
- * Fetch a binary payload (currently: the PDF that Fortnox's invoice
- * print/preview endpoints return). Shares rate limiting, retries, timeouts and
- * error mapping with `fortnoxRequest`.
+ * Fetch a PDF from one of Fortnox's document endpoints. Shares rate limiting,
+ * retries, timeouts and error mapping with `fortnoxRequest`.
  *
- * Guards against writing a non-PDF body to disk: Fortnox can answer 200 with a
- * JSON error envelope, and silently saving that as `invoice-1001.pdf` would look
- * like success until someone opens the file.
+ * The returned bytes are validated by their magic number rather than by the
+ * Content-Type header: Fortnox can answer 200 with a JSON error envelope, and a
+ * proxy can return an HTML error page, either of which would otherwise be saved
+ * as `invoice-1001.pdf` and look like success until someone opened the file.
  */
-export async function fortnoxRequestBinary(
+export async function fortnoxRequestPdf(
   endpoint: string,
   options: RequestOptions = {},
 ): Promise<Buffer> {
   return request<Buffer>(endpoint, options, async (response) => {
-    const contentType = response.headers?.get?.('content-type') ?? '';
     const buf = Buffer.from(await response.arrayBuffer());
 
-    if (!/application\/(pdf|octet-stream)/i.test(contentType)) {
+    if (buf.subarray(0, PDF_MAGIC.length).toString('latin1') !== PDF_MAGIC) {
+      const contentType = response.headers?.get?.('content-type') || 'an unknown content type';
       throw new Error(
-        `Fortnox returned ${contentType || 'an unknown content type'} instead of a PDF for ${endpoint}: ${describeUnexpectedBody(buf)}`,
+        `Fortnox returned ${contentType} that is not a PDF for ${endpoint}: ${describeUnexpectedBody(buf)}`,
       );
     }
 

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -227,9 +227,88 @@ export interface RequestOptions {
   params?: Record<string, string | number | undefined>;
 }
 
-export async function fortnoxRequest<T>(
+// Issue the HTTP request and translate a non-2xx answer into a FortnoxApiError.
+// Returns the raw Response so callers can decide how to read the body.
+async function sendRequest(
   endpoint: string,
-  options: RequestOptions = {},
+  options: RequestOptions,
+  method: string,
+  timeoutMs: number,
+): Promise<Response> {
+  await waitForRateLimit();
+
+  const token = await getValidToken();
+  const url = new URL(`${BASE_URL}/${endpoint}`);
+
+  if (options.params) {
+    for (const [key, value] of Object.entries(options.params)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  // Accept is always application/json, even for the endpoints that answer with a
+  // PDF. This looks wrong but is not: Fortnox rejects Accept: application/pdf (and
+  // application/octet-stream) on its PDF endpoints with
+  // {"ErrorInformation":{"error":1,"message":"Invalid response type","code":1000030}}.
+  // Do not "fix" this header.
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/json',
+  };
+
+  const fetchOptions: RequestInit = {
+    method,
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  };
+
+  if (options.rawBody !== undefined) {
+    // A raw body (e.g. FormData for a multipart file upload): do NOT set
+    // Content-Type — fetch/undici derives it (and the multipart boundary)
+    // from the body itself.
+    fetchOptions.body = options.rawBody;
+  } else {
+    headers['Content-Type'] = 'application/json';
+    if (options.body) {
+      fetchOptions.body = JSON.stringify(options.body);
+    }
+  }
+
+  const response = await fetch(url.toString(), fetchOptions);
+
+  if (!response.ok) {
+    let errorMessage = `HTTP ${response.status}`;
+    let details: string | undefined;
+    try {
+      const errorBody = (await response.json()) as {
+        ErrorInformation?: { message?: string; code?: number };
+      };
+      if (errorBody?.ErrorInformation) {
+        errorMessage = errorBody.ErrorInformation.message || errorMessage;
+        details = `Error code: ${errorBody.ErrorInformation.code}`;
+      }
+    } catch {
+      // ignore parse errors
+    }
+    throw new FortnoxApiError(
+      response.status,
+      errorMessage,
+      details,
+      endpoint,
+      retryAfterDelay(response),
+    );
+  }
+
+  return response;
+}
+
+// Shared retry/timeout envelope; `readBody` turns a successful Response into T.
+async function request<T>(
+  endpoint: string,
+  options: RequestOptions,
+  readBody: (response: Response) => Promise<T>,
 ): Promise<T> {
   const method = (options.method || 'GET').toUpperCase();
   const retryable = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
@@ -237,80 +316,74 @@ export async function fortnoxRequest<T>(
   const timeoutMs = options.rawBody === undefined ? REQUEST_TIMEOUT_MS : UPLOAD_TIMEOUT_MS;
 
   try {
-    return await retryWithBackoff(async () => {
-      await waitForRateLimit();
-
-      const token = await getValidToken();
-      const url = new URL(`${BASE_URL}/${endpoint}`);
-
-      if (options.params) {
-        for (const [key, value] of Object.entries(options.params)) {
-          if (value !== undefined) {
-            url.searchParams.set(key, String(value));
-          }
-        }
-      }
-
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/json',
-      };
-
-      const fetchOptions: RequestInit = {
-        method,
-        headers,
-        signal: AbortSignal.timeout(timeoutMs),
-      };
-
-      if (options.rawBody !== undefined) {
-        // A raw body (e.g. FormData for a multipart file upload): do NOT set
-        // Content-Type — fetch/undici derives it (and the multipart boundary)
-        // from the body itself.
-        fetchOptions.body = options.rawBody;
-      } else {
-        headers['Content-Type'] = 'application/json';
-        if (options.body) {
-          fetchOptions.body = JSON.stringify(options.body);
-        }
-      }
-
-      const response = await fetch(url.toString(), fetchOptions);
-
-      if (!response.ok) {
-        let errorMessage = `HTTP ${response.status}`;
-        let details: string | undefined;
-        try {
-          const errorBody = (await response.json()) as {
-            ErrorInformation?: { message?: string; code?: number };
-          };
-          if (errorBody?.ErrorInformation) {
-            errorMessage = errorBody.ErrorInformation.message || errorMessage;
-            details = `Error code: ${errorBody.ErrorInformation.code}`;
-          }
-        } catch {
-          // ignore parse errors
-        }
-        throw new FortnoxApiError(
-          response.status,
-          errorMessage,
-          details,
-          endpoint,
-          retryAfterDelay(response),
-        );
-      }
-
-      // Some endpoints return empty responses (e.g., DELETE)
-      const text = await response.text();
-      if (!text) return undefined as T;
-
-      return JSON.parse(text) as T;
-    }, retryable);
+    return await retryWithBackoff(
+      async () => readBody(await sendRequest(endpoint, options, method, timeoutMs)),
+      retryable,
+    );
   } catch (err) {
     if (isTimeoutError(err)) {
       throw new FortnoxRequestTimeoutError(method, endpoint, timeoutMs);
     }
     throw err;
   }
+}
+
+export async function fortnoxRequest<T>(
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  return request<T>(endpoint, options, async (response) => {
+    // Some endpoints return empty responses (e.g., DELETE)
+    const text = await response.text();
+    if (!text) return undefined as T;
+
+    return JSON.parse(text) as T;
+  });
+}
+
+// Summarize an unexpected (non-binary) body for an error message, preferring the
+// Fortnox error envelope when the body turns out to be one.
+function describeUnexpectedBody(buf: Buffer): string {
+  const text = buf.toString('utf-8', 0, 2000).trim();
+  try {
+    const parsed = JSON.parse(text) as {
+      ErrorInformation?: { message?: string; code?: number };
+    };
+    const info = parsed?.ErrorInformation;
+    if (info?.message) {
+      return info.code === undefined ? info.message : `${info.message} (code ${info.code})`;
+    }
+  } catch {
+    // not JSON — fall through to the raw excerpt
+  }
+  return text.slice(0, 200) || '<empty body>';
+}
+
+/**
+ * Fetch a binary payload (currently: the PDF that Fortnox's invoice
+ * print/preview endpoints return). Shares rate limiting, retries, timeouts and
+ * error mapping with `fortnoxRequest`.
+ *
+ * Guards against writing a non-PDF body to disk: Fortnox can answer 200 with a
+ * JSON error envelope, and silently saving that as `invoice-1001.pdf` would look
+ * like success until someone opens the file.
+ */
+export async function fortnoxRequestBinary(
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<Buffer> {
+  return request<Buffer>(endpoint, options, async (response) => {
+    const contentType = response.headers?.get?.('content-type') ?? '';
+    const buf = Buffer.from(await response.arrayBuffer());
+
+    if (!/application\/(pdf|octet-stream)/i.test(contentType)) {
+      throw new Error(
+        `Fortnox returned ${contentType || 'an unknown content type'} instead of a PDF for ${endpoint}: ${describeUnexpectedBody(buf)}`,
+      );
+    }
+
+    return buf;
+  });
 }
 
 /**

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -398,6 +398,32 @@ export async function fortnoxRequestPdf(
 }
 
 /**
+ * For endpoints where the PDF is a by-product of a state change — Fortnox's
+ * `/print` both returns the document and sets `Sent`.
+ *
+ * Once the server has answered 2xx the mutation has happened, so nothing about
+ * the body may raise: a truncated or malformed payload is reported as "no PDF"
+ * rather than as an error, because throwing here would turn a completed
+ * accounting change into a reported failure. Always treated as a mutation, so
+ * it is never auto-retried.
+ */
+export async function fortnoxRequestPdfFromMutation(
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<Buffer | undefined> {
+  return request<Buffer | undefined>(endpoint, { ...options, mutation: true }, async (response) => {
+    try {
+      const buf = Buffer.from(await response.arrayBuffer());
+      return buf.subarray(0, PDF_MAGIC.length).toString('latin1') === PDF_MAGIC ? buf : undefined;
+    } catch {
+      // Body unreadable (truncated stream, aborted transfer). The action
+      // itself already succeeded server-side; report it as such.
+      return undefined;
+    }
+  });
+}
+
+/**
  * Fetch all pages of a paginated Fortnox list endpoint.
  * `dataKey` is the envelope key (e.g. "Invoices", "Customers").
  */

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -1,4 +1,4 @@
-import { fortnoxRequest, fetchAllPages } from '../fortnox-client.js';
+import { fortnoxRequest, fortnoxRequestBinary, fetchAllPages } from '../fortnox-client.js';
 import { documentSegment } from '../identifiers.js';
 
 interface InvoiceResponse {
@@ -104,10 +104,35 @@ export async function sendInvoice(
     });
   }
 
-  const endpointSuffix =
-    method === 'email' ? 'email' : method === 'einvoice' ? 'einvoice' : 'print';
+  if (method === 'print') {
+    // /print answers with the PDF itself rather than JSON, so it cannot go
+    // through fortnoxRequest. The bytes are discarded here — this action means
+    // "mark as printed"; use getInvoicePdf to keep the file — and the invoice is
+    // re-read so the caller sees its real post-print state (Sent = true).
+    await fortnoxRequestBinary(`invoices/${documentId}/print`);
+    return getInvoice(documentNumber);
+  }
+
+  const endpointSuffix = method === 'einvoice' ? 'einvoice' : 'email';
   const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentId}/${endpointSuffix}`);
   return data?.Invoice || {};
+}
+
+export interface InvoicePdfOptions {
+  /**
+   * Use /print instead of /preview. Both return the same PDF, but /print also
+   * sets the invoice's `Sent` flag — a side effect you rarely want when you are
+   * just downloading a copy to attach to an email.
+   */
+  markSent?: boolean;
+}
+
+export async function getInvoicePdf(
+  documentNumber: string,
+  options: InvoicePdfOptions = {},
+): Promise<Buffer> {
+  const action = options.markSent ? 'print' : 'preview';
+  return fortnoxRequestBinary(`invoices/${documentSegment(documentNumber)}/${action}`);
 }
 
 export async function bookkeepInvoice(documentNumber: string): Promise<Record<string, unknown>> {

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -1,4 +1,9 @@
-import { fortnoxRequest, fortnoxRequestPdf, fetchAllPages } from '../fortnox-client.js';
+import {
+  fortnoxRequest,
+  fortnoxRequestPdf,
+  fortnoxRequestPdfFromMutation,
+  fetchAllPages,
+} from '../fortnox-client.js';
 import { documentSegment } from '../identifiers.js';
 
 interface InvoiceResponse {
@@ -105,7 +110,7 @@ export async function sendInvoice(
   }
 
   if (method === 'print') {
-    return markInvoicePrinted(documentNumber);
+    return (await markInvoicePrinted(documentNumber)).invoice;
   }
 
   // Exhaustive on purpose: no silent fallback. 'email' and 'einvoice' both send
@@ -132,30 +137,50 @@ export async function getInvoicePdf(documentNumber: string): Promise<Buffer> {
   return fortnoxRequestPdf(`invoices/${documentSegment(documentNumber)}/preview`);
 }
 
+export interface MarkInvoicePrintedResult {
+  /** The invoice's state after printing. */
+  invoice: Record<string, unknown>;
+  /**
+   * The document Fortnox generated for this print action, when it came back
+   * intact. Callers saving a copy should prefer these bytes over a separately
+   * fetched /preview: the two are distinct requests, so a concurrent edit could
+   * otherwise leave the saved file a version behind the one marked as sent.
+   */
+  pdf?: Buffer;
+}
+
 /**
  * Mark an invoice as sent via Fortnox's /print action, and report its resulting
  * state. /print is a GET that changes data, so it is flagged as a mutation to
  * keep it out of the automatic retry path.
+ *
+ * Once the /print request succeeds the invoice has been changed, so from that
+ * point on this function does not throw: neither a malformed PDF body nor a
+ * failed read-back may turn a completed accounting change into a reported
+ * failure.
  */
-export async function markInvoicePrinted(documentNumber: string): Promise<Record<string, unknown>> {
+export async function markInvoicePrinted(
+  documentNumber: string,
+): Promise<MarkInvoicePrintedResult> {
   const documentId = documentSegment(documentNumber);
 
-  // The response body is the PDF, not JSON. It is discarded here — this action
-  // means "mark as printed"; use getInvoicePdf to keep the file.
-  await fortnoxRequestPdf(`invoices/${documentId}/print`, { mutation: true });
+  const pdf = await fortnoxRequestPdfFromMutation(`invoices/${documentId}/print`);
 
   try {
-    return await getInvoice(documentNumber);
+    return { invoice: await getInvoice(documentNumber), pdf };
   } catch (err) {
     // Fortnox has already flagged the invoice; only reading it back failed.
     // Report the action as the success it was, but keep the read error visible
     // rather than pretending nothing went wrong.
     return {
-      DocumentNumber: documentNumber,
-      Sent: true,
-      Note: `Invoice was marked as sent, but reading it back failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      invoice: {
+        DocumentNumber: documentNumber,
+        Sent: true,
+        Note: `Invoice was marked as sent, but reading it back failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      },
+      pdf,
     };
   }
 }

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -141,6 +141,12 @@ export interface MarkInvoicePrintedResult {
   /** The invoice's state after printing. */
   invoice: Record<string, unknown>;
   /**
+   * Whether that state was actually read back from Fortnox. When false, the
+   * print request was accepted but its effect could not be confirmed — callers
+   * must report the outcome as unknown rather than as sent.
+   */
+  confirmed: boolean;
+  /**
    * The document Fortnox generated for this print action, when it came back
    * intact. Callers saving a copy should prefer these bytes over a separately
    * fetched /preview: the two are distinct requests, so a concurrent edit could
@@ -167,19 +173,20 @@ export async function markInvoicePrinted(
   const pdf = await fortnoxRequestPdfFromMutation(`invoices/${documentId}/print`);
 
   try {
-    return { invoice: await getInvoice(documentNumber), pdf };
+    return { invoice: await getInvoice(documentNumber), confirmed: true, pdf };
   } catch (err) {
-    // Fortnox has already flagged the invoice; only reading it back failed.
-    // Report the action as the success it was, but keep the read error visible
-    // rather than pretending nothing went wrong.
+    // Fortnox accepted the print request, so the change has most likely been
+    // applied — but "most likely" is not "confirmed". Deliberately no
+    // `Sent: true` here: synthesizing it would present an unverified outcome as
+    // established fact about someone's accounting records.
     return {
       invoice: {
         DocumentNumber: documentNumber,
-        Sent: true,
-        Note: `Invoice was marked as sent, but reading it back failed: ${
+        Note: `Fortnox accepted the print request, but reading the invoice back failed, so its sent status could not be confirmed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       },
+      confirmed: false,
       pdf,
     };
   }

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -1,4 +1,4 @@
-import { fortnoxRequest, fortnoxRequestBinary, fetchAllPages } from '../fortnox-client.js';
+import { fortnoxRequest, fortnoxRequestPdf, fetchAllPages } from '../fortnox-client.js';
 import { documentSegment } from '../identifiers.js';
 
 interface InvoiceResponse {
@@ -105,12 +105,7 @@ export async function sendInvoice(
   }
 
   if (method === 'print') {
-    // /print answers with the PDF itself rather than JSON, so it cannot go
-    // through fortnoxRequest. The bytes are discarded here — this action means
-    // "mark as printed"; use getInvoicePdf to keep the file — and the invoice is
-    // re-read so the caller sees its real post-print state (Sent = true).
-    await fortnoxRequestBinary(`invoices/${documentId}/print`);
-    return getInvoice(documentNumber);
+    return markInvoicePrinted(documentNumber);
   }
 
   // Exhaustive on purpose: no silent fallback. 'email' and 'einvoice' both send
@@ -124,21 +119,45 @@ export async function sendInvoice(
   return data?.Invoice || {};
 }
 
-export interface InvoicePdfOptions {
-  /**
-   * Use /print instead of /preview. Both return the same PDF, but /print also
-   * sets the invoice's `Sent` flag — a side effect you rarely want when you are
-   * just downloading a copy to attach to an email.
-   */
-  markSent?: boolean;
+/**
+ * Fetch an invoice as a PDF. Always uses /preview, which returns the same
+ * document as /print but leaves the invoice untouched.
+ *
+ * Marking the invoice as sent is deliberately NOT folded in here: callers that
+ * want both run this first, write the bytes out, and only then call
+ * `markInvoicePrinted`. Doing it the other way round means a full disk or a bad
+ * path leaves an invoice flagged as sent with no PDF to show for it.
+ */
+export async function getInvoicePdf(documentNumber: string): Promise<Buffer> {
+  return fortnoxRequestPdf(`invoices/${documentSegment(documentNumber)}/preview`);
 }
 
-export async function getInvoicePdf(
-  documentNumber: string,
-  options: InvoicePdfOptions = {},
-): Promise<Buffer> {
-  const action = options.markSent ? 'print' : 'preview';
-  return fortnoxRequestBinary(`invoices/${documentSegment(documentNumber)}/${action}`);
+/**
+ * Mark an invoice as sent via Fortnox's /print action, and report its resulting
+ * state. /print is a GET that changes data, so it is flagged as a mutation to
+ * keep it out of the automatic retry path.
+ */
+export async function markInvoicePrinted(documentNumber: string): Promise<Record<string, unknown>> {
+  const documentId = documentSegment(documentNumber);
+
+  // The response body is the PDF, not JSON. It is discarded here — this action
+  // means "mark as printed"; use getInvoicePdf to keep the file.
+  await fortnoxRequestPdf(`invoices/${documentId}/print`, { mutation: true });
+
+  try {
+    return await getInvoice(documentNumber);
+  } catch (err) {
+    // Fortnox has already flagged the invoice; only reading it back failed.
+    // Report the action as the success it was, but keep the read error visible
+    // rather than pretending nothing went wrong.
+    return {
+      DocumentNumber: documentNumber,
+      Sent: true,
+      Note: `Invoice was marked as sent, but reading it back failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
 }
 
 export async function bookkeepInvoice(documentNumber: string): Promise<Record<string, unknown>> {

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -113,8 +113,14 @@ export async function sendInvoice(
     return getInvoice(documentNumber);
   }
 
-  const endpointSuffix = method === 'einvoice' ? 'einvoice' : 'email';
-  const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentId}/${endpointSuffix}`);
+  // Exhaustive on purpose: no silent fallback. 'email' and 'einvoice' both send
+  // the invoice to the customer, so an unrecognised method must fail loudly
+  // rather than pick one of them.
+  if (method !== 'email' && method !== 'einvoice') {
+    throw new Error(`Unsupported send method: ${String(method)}`);
+  }
+
+  const data = await fortnoxRequest<InvoiceResponse>(`invoices/${documentId}/${method}`);
   return data?.Invoice || {};
 }
 

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -1,6 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { closeSync, constants as fsConstants, mkdtempSync, openSync, writeSync } from 'node:fs';
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -43,7 +50,7 @@ const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be 
  * influenced by whatever the model just read. `O_EXCL` already refuses to follow
  * a symlink; `O_NOFOLLOW` gives the overwrite path the same guarantee, so
  * "replace this file" can never silently truncate a symlink's target instead.
- * O_NOFOLLOW is POSIX-only and absent on Windows, hence the `?? 0`.
+ * O_NOFOLLOW is POSIX-only, so Windows falls back to an explicit lstat check.
  */
 function writePdf(target: string, pdf: Buffer, overwrite?: boolean): void {
   const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
@@ -51,10 +58,25 @@ function writePdf(target: string, pdf: Buffer, overwrite?: boolean): void {
     ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
     : O_WRONLY | O_CREAT | O_EXCL;
 
+  // Windows has no O_NOFOLLOW, so the flag above degrades to a no-op there.
+  // Check explicitly instead. This is a TOCTOU-racy fallback rather than an
+  // atomic guarantee, but it closes the ordinary case on the one platform the
+  // kernel flag cannot cover.
+  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    throw new Error(
+      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+    );
+  }
+
   try {
     const fd = openSync(target, flags, 0o600);
     try {
-      writeSync(fd, pdf);
+      // writeSync may return a short count; keep going until the whole buffer
+      // has landed. writeFileSync used to do this loop internally.
+      let written = 0;
+      while (written < pdf.length) {
+        written += writeSync(fd, pdf, written, pdf.length - written);
+      }
     } finally {
       closeSync(fd);
     }
@@ -310,7 +332,13 @@ export function registerInvoiceTools(server: McpServer): void {
           (markSent ? ' Fakturan är nu markerad som skickad.' : '') +
           (printed?.invoice.Note ? ` ${String(printed.invoice.Note)}` : '') +
           refreshNote,
-        { DocumentNumber: documentNumber, Path: target, Bytes: bytes, Sent: !!markSent },
+        {
+          DocumentNumber: documentNumber,
+          Path: target,
+          Bytes: bytes,
+          // Report what Fortnox says, not what we asked for.
+          Sent: printed ? printed.invoice.Sent : undefined,
+        },
       );
     },
   );

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -10,6 +10,7 @@ import {
   updateInvoice,
   sendInvoice,
   getInvoicePdf,
+  markInvoicePrinted,
   bookkeepInvoice,
   creditInvoice,
 } from '../operations/invoices.js';
@@ -211,7 +212,13 @@ export function registerInvoiceTools(server: McpServer): void {
       outputPath: z
         .string()
         .optional()
-        .describe('Sökväg att spara PDF:en till (default: invoice-<nummer>.pdf i temp-katalogen)'),
+        .describe(
+          'Sökväg att spara PDF:en till. Skriver inte över en befintlig fil om inte overwrite är satt. Utelämnas: en ny privat temp-katalog används.',
+        ),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe('Tillåt att en befintlig fil på outputPath skrivs över'),
       markSent: z
         .boolean()
         .optional()
@@ -222,7 +229,7 @@ export function registerInvoiceTools(server: McpServer): void {
         .describe('Bekräfta — krävs endast när markSent är satt, eftersom den ändrar fakturan'),
       dryRun: z.boolean().optional().describe('Visa åtgärden utan att hämta PDF:en'),
     },
-    async ({ documentNumber, outputPath, markSent, confirm, dryRun }) => {
+    async ({ documentNumber, outputPath, overwrite, markSent, confirm, dryRun }) => {
       const action = markSent
         ? `download invoice ${documentNumber} as PDF and mark it as sent`
         : `download invoice ${documentNumber} as PDF`;
@@ -230,13 +237,34 @@ export function registerInvoiceTools(server: McpServer): void {
       // Only the /print variant changes the invoice; a plain download is read-only.
       if (markSent && !confirm) requireConfirmation(action);
 
-      const target = resolve(outputPath ?? join(tmpdir(), `invoice-${documentNumber}.pdf`));
-      const pdf = await getInvoicePdf(documentNumber, { markSent });
-      writeFileSync(target, pdf);
+      // Arguments here are agent-generated, so a stray path must not silently
+      // truncate an existing file. Without an explicit path we use a fresh
+      // private directory rather than a predictable, clobber-prone temp name.
+      const target = outputPath
+        ? resolve(outputPath)
+        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `invoice-${documentNumber}.pdf`);
+
+      const pdf = await getInvoicePdf(documentNumber);
+      try {
+        // 'wx' fails if the path exists and refuses to follow a symlink to an
+        // existing file; 'w' is only used when the caller opted in.
+        writeFileSync(target, pdf, { flag: overwrite ? 'w' : 'wx' });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new Error(
+            `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
+          );
+        }
+        throw err;
+      }
+
+      // Only now that the PDF is safely on disk do we change anything in Fortnox.
+      const printed = markSent ? await markInvoicePrinted(documentNumber) : undefined;
 
       return confirmationResponse(
         `Faktura ${documentNumber} sparad som PDF: ${target} (${pdf.length} bytes).` +
-          (markSent ? ' Fakturan är nu markerad som skickad.' : ''),
+          (markSent ? ' Fakturan är nu markerad som skickad.' : '') +
+          (printed?.Note ? ` ${String(printed.Note)}` : ''),
         { DocumentNumber: documentNumber, Path: target, Bytes: pdf.length, Sent: !!markSent },
       );
     },

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -1,11 +1,15 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import {
   listInvoices,
   getInvoice,
   createInvoice,
   updateInvoice,
   sendInvoice,
+  getInvoicePdf,
   bookkeepInvoice,
   creditInvoice,
 } from '../operations/invoices.js';
@@ -195,6 +199,45 @@ export function registerInvoiceTools(server: McpServer): void {
         invoice,
         invoiceConfirmColumns,
         includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_invoice_pdf',
+    'Hämta en faktura som PDF och spara den på disk. Returnerar sökvägen till filen (inte PDF-innehållet). Använder Fortnox /preview som standard, vilket INTE markerar fakturan som skickad.',
+    {
+      documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
+      outputPath: z
+        .string()
+        .optional()
+        .describe('Sökväg att spara PDF:en till (default: invoice-<nummer>.pdf i temp-katalogen)'),
+      markSent: z
+        .boolean()
+        .optional()
+        .describe('Markera även fakturan som skickad i Fortnox (använder /print)'),
+      confirm: z
+        .boolean()
+        .optional()
+        .describe('Bekräfta — krävs endast när markSent är satt, eftersom den ändrar fakturan'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att hämta PDF:en'),
+    },
+    async ({ documentNumber, outputPath, markSent, confirm, dryRun }) => {
+      const action = markSent
+        ? `download invoice ${documentNumber} as PDF and mark it as sent`
+        : `download invoice ${documentNumber} as PDF`;
+      if (dryRun) return dryRunResponse(action);
+      // Only the /print variant changes the invoice; a plain download is read-only.
+      if (markSent && !confirm) requireConfirmation(action);
+
+      const target = resolve(outputPath ?? join(tmpdir(), `invoice-${documentNumber}.pdf`));
+      const pdf = await getInvoicePdf(documentNumber, { markSent });
+      writeFileSync(target, pdf);
+
+      return confirmationResponse(
+        `Faktura ${documentNumber} sparad som PDF: ${target} (${pdf.length} bytes).` +
+          (markSent ? ' Fakturan är nu markerad som skickad.' : ''),
+        { DocumentNumber: documentNumber, Path: target, Bytes: pdf.length, Sent: !!markSent },
       );
     },
   );

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -206,7 +206,7 @@ export function registerInvoiceTools(server: McpServer): void {
 
   server.tool(
     'fortnox_invoice_pdf',
-    'Hämta en faktura som PDF och spara den på disk. Returnerar sökvägen till filen (inte PDF-innehållet). Använder Fortnox /preview som standard, vilket INTE markerar fakturan som skickad.',
+    'Hämta en faktura som PDF och spara den på disk. Returnerar sökvägen till filen (inte PDF-innehållet). PDF:en hämtas alltid via Fortnox /preview, vilket INTE ändrar fakturan. Med markSent anropas /print efteråt, efter att filen skrivits.',
     {
       documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
       outputPath: z

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -327,17 +327,28 @@ export function registerInvoiceTools(server: McpServer): void {
         }
       }
 
+      // Only state that the invoice is sent if Fortnox confirmed it. Asking for
+      // markSent is not evidence that it took effect.
+      let sentNote = '';
+      if (printed && !printed.confirmed) {
+        sentNote = ` ${String(printed.invoice.Note)}`;
+      } else if (printed && printed.invoice.Sent === true) {
+        sentNote = ' Fakturan är nu markerad som skickad.';
+      } else if (printed) {
+        sentNote = ' Varning: Fortnox rapporterar fortfarande fakturan som ej skickad.';
+      }
+
       return confirmationResponse(
         `Faktura ${documentNumber} sparad som PDF: ${target} (${bytes} bytes).` +
-          (markSent ? ' Fakturan är nu markerad som skickad.' : '') +
-          (printed?.invoice.Note ? ` ${String(printed.invoice.Note)}` : '') +
+          sentNote +
           refreshNote,
         {
           DocumentNumber: documentNumber,
           Path: target,
           Bytes: bytes,
-          // Report what Fortnox says, not what we asked for.
-          Sent: printed ? printed.invoice.Sent : undefined,
+          // Report what Fortnox says, not what we asked for; undefined means
+          // "not checked" or "could not be confirmed".
+          Sent: printed?.confirmed ? printed.invoice.Sent : undefined,
         },
       );
     },

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { closeSync, constants as fsConstants, mkdtempSync, openSync, writeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -35,6 +35,44 @@ const InvoiceRowSchema = z.object({
 });
 
 const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be numeric');
+
+/**
+ * Write a PDF to `target`, refusing to write through a symlink.
+ *
+ * These paths come from tool arguments, i.e. they are model-generated and can be
+ * influenced by whatever the model just read. `O_EXCL` already refuses to follow
+ * a symlink; `O_NOFOLLOW` gives the overwrite path the same guarantee, so
+ * "replace this file" can never silently truncate a symlink's target instead.
+ * O_NOFOLLOW is POSIX-only and absent on Windows, hence the `?? 0`.
+ */
+function writePdf(target: string, pdf: Buffer, overwrite?: boolean): void {
+  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
+  const flags = overwrite
+    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
+    : O_WRONLY | O_CREAT | O_EXCL;
+
+  try {
+    const fd = openSync(target, flags, 0o600);
+    try {
+      writeSync(fd, pdf);
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      throw new Error(
+        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
+      );
+    }
+    if (code === 'ELOOP') {
+      throw new Error(
+        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+      );
+    }
+    throw err;
+  }
+}
 
 export function registerInvoiceTools(server: McpServer): void {
   server.tool(
@@ -245,27 +283,34 @@ export function registerInvoiceTools(server: McpServer): void {
         : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `invoice-${documentNumber}.pdf`);
 
       const pdf = await getInvoicePdf(documentNumber);
-      try {
-        // 'wx' fails if the path exists and refuses to follow a symlink to an
-        // existing file; 'w' is only used when the caller opted in.
-        writeFileSync(target, pdf, { flag: overwrite ? 'w' : 'wx' });
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
-          throw new Error(
-            `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
-          );
-        }
-        throw err;
-      }
+      writePdf(target, pdf, overwrite);
 
       // Only now that the PDF is safely on disk do we change anything in Fortnox.
       const printed = markSent ? await markInvoicePrinted(documentNumber) : undefined;
 
+      // Prefer the document /print actually produced, so the saved copy matches
+      // the version that was marked as sent. Best-effort: the /preview copy is
+      // already on disk, and the invoice is already flagged, so a failure here
+      // must not be raised as if the whole operation failed.
+      let bytes = pdf.length;
+      let refreshNote = '';
+      if (printed?.pdf) {
+        try {
+          writePdf(target, printed.pdf, true);
+          bytes = printed.pdf.length;
+        } catch (err) {
+          refreshNote = ` Den sparade filen är /preview-versionen; kunde inte skriva om den med den utskrivna versionen: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+      }
+
       return confirmationResponse(
-        `Faktura ${documentNumber} sparad som PDF: ${target} (${pdf.length} bytes).` +
+        `Faktura ${documentNumber} sparad som PDF: ${target} (${bytes} bytes).` +
           (markSent ? ' Fakturan är nu markerad som skickad.' : '') +
-          (printed?.Note ? ` ${String(printed.Note)}` : ''),
-        { DocumentNumber: documentNumber, Path: target, Bytes: pdf.length, Sent: !!markSent },
+          (printed?.invoice.Note ? ` ${String(printed.invoice.Note)}` : '') +
+          refreshNote,
+        { DocumentNumber: documentNumber, Path: target, Bytes: bytes, Sent: !!markSent },
       );
     },
   );

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -169,3 +169,19 @@ describe('global --profile validation honors -o json', () => {
     expect(() => JSON.parse(res.stderr.trim())).toThrow();
   });
 });
+
+describe('invoices pdf --file -', () => {
+  // `run` pipes stdout, so isJsonMode() defaults to true here — which is exactly
+  // how `--file -` is used in practice (`... --file - > invoice.pdf`). Guarding
+  // on the resolved mode instead of an explicit -o json made the flag unusable.
+  it('is not refused merely because stdout is piped', () => {
+    const res = run(['invoices', 'pdf', '23', '--file', '-']);
+    expect(res.stderr).not.toMatch(/cannot be combined/i);
+    expect(res.stdout).not.toMatch(/cannot be combined/i);
+  });
+
+  it('is still refused when the caller explicitly asks for -o json', () => {
+    const res = run(['-o', 'json', 'invoices', 'pdf', '23', '--file', '-']);
+    expect(res.stderr).toMatch(/cannot be combined/i);
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -83,8 +83,31 @@ describe('CLI smoke tests', () => {
     expect(output).toContain('get');
     expect(output).toContain('create');
     expect(output).toContain('send');
+    expect(output).toContain('pdf');
     expect(output).toContain('bookkeep');
     expect(output).toContain('credit');
+  });
+
+  it('noxctl invoices pdf --help documents the destination and --mark-sent options', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'invoices', 'pdf', '--help'],
+      execOpts,
+    ) as string;
+    // The destination is --file: -o/--output is globally the output *format*.
+    expect(output).toContain('--file');
+    expect(output).toContain('--mark-sent');
+    // The default must be the non-mutating endpoint.
+    expect(output).toContain('/preview');
+  });
+
+  it('noxctl invoices pdf --file does not collide with the global --output format flag', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'invoices', 'pdf', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).not.toMatch(/-o, --output <path>/);
   });
 
   it('noxctl tax --help shows tax subcommands', () => {

--- a/tests/fortnox-client-pdf.test.ts
+++ b/tests/fortnox-client-pdf.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fortnoxRequest, fortnoxRequestPdf, FortnoxApiError } from '../src/fortnox-client.js';
+
+vi.mock('../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+const PDF_BYTES = Buffer.from('%PDF-1.4\nbinary\x00\x01bytes');
+
+function mockPdfResponse(bytes: Buffer = PDF_BYTES, contentType = 'application/pdf') {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+  });
+}
+
+// Kept in its own file: the client's 25-requests-per-5-seconds rate limiter is
+// module-level state, and vitest gives each test file a fresh module registry.
+// Piling these onto fortnox-client.test.ts pushed that file over the limit and
+// made unrelated tests block on the limiter.
+describe('fortnox-client: PDF and mutation-classified requests', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Fortnox exposes some state-changing actions as GET (e.g. /invoices/{n}/print
+  // sets Sent=true), so the HTTP verb alone cannot decide retry safety.
+  describe('mutation option overriding the verb-derived classification', () => {
+    it('does not retry a GET that is flagged as a mutation', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+      });
+
+      await expect(fortnoxRequest('invoices/1/print', { mutation: true })).rejects.toThrow(
+        FortnoxApiError,
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('still retries an ordinary GET', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          headers: new Headers(),
+          json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+        })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('{"ok":true}') });
+
+      await expect(fortnoxRequest('invoices/1/preview')).resolves.toEqual({ ok: true });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports a flagged GET timeout as an unknown outcome, not "safe to retry"', async () => {
+      const controller = new AbortController();
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+      global.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        const signal = init.signal as AbortSignal;
+        return new Promise((_resolve, reject) => {
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      });
+
+      const request = fortnoxRequest('invoices/1/print', { mutation: true });
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'FortnoxRequestTimeoutError',
+        outcomeUnknown: true,
+      });
+
+      controller.abort(new DOMException('request timed out', 'TimeoutError'));
+      await rejection;
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fortnoxRequestPdf', () => {
+    it('returns the raw bytes unmodified', async () => {
+      mockPdfResponse();
+
+      const result = await fortnoxRequestPdf('invoices/1001/preview');
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.equals(PDF_BYTES)).toBe(true);
+    });
+
+    it('requests Accept: application/json — Fortnox rejects application/pdf with error 1000030', async () => {
+      mockPdfResponse();
+
+      await fortnoxRequestPdf('invoices/1001/preview');
+
+      const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Accept).toBe('application/json');
+      expect(headers.Authorization).toBe('Bearer mock-token');
+    });
+
+    it('raises a FortnoxApiError when Fortnox answers with a JSON error envelope', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () =>
+          Promise.resolve({ ErrorInformation: { message: 'Can not find invoice', code: 2000428 } }),
+      });
+
+      await expect(fortnoxRequestPdf('invoices/999999/preview')).rejects.toThrow(
+        /Can not find invoice/,
+      );
+    });
+
+    it('rejects a 200 that is not a PDF instead of writing an error page to disk', async () => {
+      const errorEnvelope = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'Invalid response type', code: 1000030 } }),
+      );
+      mockPdfResponse(errorEnvelope, 'application/json');
+
+      await expect(fortnoxRequestPdf('invoices/1001/preview')).rejects.toThrow(
+        /Invalid response type/,
+      );
+    });
+
+    // The content-type header is not evidence: validate the actual bytes, so a
+    // mislabelled error page can never be saved under a .pdf name.
+    it('rejects a non-PDF body even when it is labelled application/pdf', async () => {
+      const errorEnvelope = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'Invalid response type', code: 1000030 } }),
+      );
+      mockPdfResponse(errorEnvelope, 'application/pdf');
+
+      await expect(fortnoxRequestPdf('invoices/1001/preview')).rejects.toThrow(
+        /Invalid response type/,
+      );
+    });
+
+    it('rejects an HTML error page served as application/octet-stream', async () => {
+      mockPdfResponse(
+        Buffer.from('<html><body>502 Bad Gateway</body></html>'),
+        'application/octet-stream',
+      );
+
+      await expect(fortnoxRequestPdf('invoices/1001/preview')).rejects.toThrow(/not a PDF/i);
+    });
+
+    it('accepts real PDF bytes regardless of an unhelpful content-type', async () => {
+      mockPdfResponse(PDF_BYTES, 'application/octet-stream');
+
+      const result = await fortnoxRequestPdf('invoices/1001/preview');
+      expect(result.equals(PDF_BYTES)).toBe(true);
+    });
+
+    it('retries a transient 500 on the non-mutating preview endpoint', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ ErrorInformation: { message: 'boom', code: 1 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/pdf' }),
+          arrayBuffer: () =>
+            Promise.resolve(
+              PDF_BYTES.buffer.slice(
+                PDF_BYTES.byteOffset,
+                PDF_BYTES.byteOffset + PDF_BYTES.byteLength,
+              ),
+            ),
+        });
+
+      const result = await fortnoxRequestPdf('invoices/1001/preview');
+
+      expect(result.equals(PDF_BYTES)).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/fortnox-client-pdf.test.ts
+++ b/tests/fortnox-client-pdf.test.ts
@@ -6,7 +6,7 @@ vi.mock('../src/auth.js', () => ({
   getResolvedProfile: vi.fn().mockReturnValue('default'),
 }));
 
-const PDF_BYTES = Buffer.from('%PDF-1.4\nbinary\x00\x01bytes');
+const PDF_BYTES = Buffer.from('%PDF-1.4\nbinary\x00\x01bytes\n%%EOF\n');
 
 function mockPdfResponse(bytes: Buffer = PDF_BYTES, contentType = 'application/pdf') {
   global.fetch = vi.fn().mockResolvedValue({

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   fortnoxRequest,
+  fortnoxRequestBinary,
   FortnoxApiError,
   FortnoxRequestTimeoutError,
 } from '../src/fortnox-client.js';
@@ -356,5 +357,92 @@ describe('fortnox-client', () => {
     const headers = init.headers as Record<string, string>;
     expect(headers['Content-Type']).toBeUndefined();
     expect(headers.Authorization).toBe('Bearer mock-token');
+  });
+
+  describe('fortnoxRequestBinary', () => {
+    const PDF_BYTES = Buffer.from('%PDF-1.4\nbinary\x00\x01bytes');
+
+    function mockPdfResponse(bytes: Buffer = PDF_BYTES, contentType = 'application/pdf') {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': contentType }),
+        arrayBuffer: () =>
+          Promise.resolve(
+            bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+          ),
+      });
+    }
+
+    it('returns the raw bytes unmodified', async () => {
+      mockPdfResponse();
+
+      const result = await fortnoxRequestBinary('invoices/1001/preview');
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.equals(PDF_BYTES)).toBe(true);
+    });
+
+    it('requests Accept: application/json — Fortnox rejects application/pdf with error 1000030', async () => {
+      mockPdfResponse();
+
+      await fortnoxRequestBinary('invoices/1001/preview');
+
+      const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Accept).toBe('application/json');
+      expect(headers.Authorization).toBe('Bearer mock-token');
+    });
+
+    it('raises a FortnoxApiError when Fortnox answers with a JSON error envelope', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () =>
+          Promise.resolve({ ErrorInformation: { message: 'Can not find invoice', code: 2000428 } }),
+      });
+
+      await expect(fortnoxRequestBinary('invoices/999999/preview')).rejects.toThrow(
+        /Can not find invoice/,
+      );
+    });
+
+    it('rejects a 200 that is not a PDF instead of writing an error page to disk', async () => {
+      const errorEnvelope = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'Invalid response type', code: 1000030 } }),
+      );
+      mockPdfResponse(errorEnvelope, 'application/json');
+
+      await expect(fortnoxRequestBinary('invoices/1001/preview')).rejects.toThrow(
+        /Invalid response type/,
+      );
+    });
+
+    it('retries a transient 500 and returns the bytes from the successful attempt', async () => {
+      const pdfBody = PDF_BYTES;
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ ErrorInformation: { message: 'boom', code: 1 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/pdf' }),
+          arrayBuffer: () =>
+            Promise.resolve(
+              pdfBody.buffer.slice(pdfBody.byteOffset, pdfBody.byteOffset + pdfBody.byteLength),
+            ),
+        });
+
+      const result = await fortnoxRequestBinary('invoices/1001/preview');
+
+      expect(result.equals(PDF_BYTES)).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   fortnoxRequest,
-  fortnoxRequestBinary,
   FortnoxApiError,
   FortnoxRequestTimeoutError,
 } from '../src/fortnox-client.js';
@@ -357,92 +356,5 @@ describe('fortnox-client', () => {
     const headers = init.headers as Record<string, string>;
     expect(headers['Content-Type']).toBeUndefined();
     expect(headers.Authorization).toBe('Bearer mock-token');
-  });
-
-  describe('fortnoxRequestBinary', () => {
-    const PDF_BYTES = Buffer.from('%PDF-1.4\nbinary\x00\x01bytes');
-
-    function mockPdfResponse(bytes: Buffer = PDF_BYTES, contentType = 'application/pdf') {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: new Headers({ 'content-type': contentType }),
-        arrayBuffer: () =>
-          Promise.resolve(
-            bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
-          ),
-      });
-    }
-
-    it('returns the raw bytes unmodified', async () => {
-      mockPdfResponse();
-
-      const result = await fortnoxRequestBinary('invoices/1001/preview');
-
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect(result.equals(PDF_BYTES)).toBe(true);
-    });
-
-    it('requests Accept: application/json — Fortnox rejects application/pdf with error 1000030', async () => {
-      mockPdfResponse();
-
-      await fortnoxRequestBinary('invoices/1001/preview');
-
-      const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
-      const headers = init.headers as Record<string, string>;
-      expect(headers.Accept).toBe('application/json');
-      expect(headers.Authorization).toBe('Bearer mock-token');
-    });
-
-    it('raises a FortnoxApiError when Fortnox answers with a JSON error envelope', async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        headers: new Headers({ 'content-type': 'application/json' }),
-        json: () =>
-          Promise.resolve({ ErrorInformation: { message: 'Can not find invoice', code: 2000428 } }),
-      });
-
-      await expect(fortnoxRequestBinary('invoices/999999/preview')).rejects.toThrow(
-        /Can not find invoice/,
-      );
-    });
-
-    it('rejects a 200 that is not a PDF instead of writing an error page to disk', async () => {
-      const errorEnvelope = Buffer.from(
-        JSON.stringify({ ErrorInformation: { message: 'Invalid response type', code: 1000030 } }),
-      );
-      mockPdfResponse(errorEnvelope, 'application/json');
-
-      await expect(fortnoxRequestBinary('invoices/1001/preview')).rejects.toThrow(
-        /Invalid response type/,
-      );
-    });
-
-    it('retries a transient 500 and returns the bytes from the successful attempt', async () => {
-      const pdfBody = PDF_BYTES;
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          headers: new Headers({ 'content-type': 'application/json' }),
-          json: () => Promise.resolve({ ErrorInformation: { message: 'boom', code: 1 } }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          headers: new Headers({ 'content-type': 'application/pdf' }),
-          arrayBuffer: () =>
-            Promise.resolve(
-              pdfBody.buffer.slice(pdfBody.byteOffset, pdfBody.byteOffset + pdfBody.byteLength),
-            ),
-        });
-
-      const result = await fortnoxRequestBinary('invoices/1001/preview');
-
-      expect(result.equals(PDF_BYTES)).toBe(true);
-      expect(global.fetch).toHaveBeenCalledTimes(2);
-    });
   });
 });

--- a/tests/live/invoices.live.test.ts
+++ b/tests/live/invoices.live.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { credentialsAvailable, setupLiveClientServer, getText } from './setup.js';
 
 let hasCredentials = false;
@@ -63,5 +66,61 @@ describe('live: fortnox_list_invoices', () => {
 
     const text = getText(result);
     expect(text.length).toBeGreaterThan(0);
+  });
+});
+
+describe('live: fortnox_invoice_pdf', () => {
+  it('downloads a real PDF without changing the invoice', async () => {
+    if (!hasCredentials) {
+      console.log('SKIP: No Fortnox credentials found — skipping live invoice PDF test.');
+      return;
+    }
+
+    const { client } = await setupLiveClientServer();
+
+    // Pick a real invoice from the account rather than hardcoding a number.
+    const list = await client.callTool({
+      name: 'fortnox_list_invoices',
+      arguments: { limit: 1, includeRaw: true },
+    });
+    const raw = getText(list).split('Raw JSON:\n')[1];
+    if (!raw) {
+      console.log('SKIP: No invoices in this account — skipping live invoice PDF test.');
+      return;
+    }
+    const invoices = (
+      JSON.parse(raw) as { Invoices?: { DocumentNumber: string; Sent?: boolean }[] }
+    ).Invoices;
+    if (!invoices?.length) {
+      console.log('SKIP: No invoices in this account — skipping live invoice PDF test.');
+      return;
+    }
+    const { DocumentNumber, Sent: sentBefore } = invoices[0]!;
+
+    const target = join(tmpdir(), `noxctl-live-invoice-${DocumentNumber}.pdf`);
+    try {
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: DocumentNumber, outputPath: target },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      // A real PDF, not an error envelope that merely got saved with a .pdf name.
+      const bytes = readFileSync(target);
+      expect(bytes.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+      expect(bytes.length).toBeGreaterThan(1000);
+
+      // The default /preview path must leave the invoice's Sent flag alone.
+      const after = await client.callTool({
+        name: 'fortnox_get_invoice',
+        arguments: { documentNumber: DocumentNumber, includeRaw: true },
+      });
+      const afterRaw = getText(after).split('Raw JSON:\n')[1];
+      const sentAfter = (JSON.parse(afterRaw!) as { Sent?: boolean }).Sent;
+      expect(sentAfter).toBe(sentBefore);
+    } finally {
+      rmSync(target, { force: true });
+    }
   });
 });

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -15,7 +15,7 @@ function mockFetch(response: unknown) {
   });
 }
 
-const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes');
+const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes\n%%EOF\n');
 
 function pdfResponse(bytes: Buffer = PDF_BYTES) {
   return {
@@ -257,6 +257,42 @@ describe('invoice operations', () => {
       expect(result.invoice.Sent).toBe(true);
       // No usable PDF came back, so none is offered to the caller.
       expect(result.pdf).toBeUndefined();
+    });
+
+    // A truncated PDF still starts with %PDF-, so the magic number alone is not
+    // enough: offering it to the caller would let a good saved copy be replaced
+    // by a broken one.
+    it('withholds a truncated print PDF rather than letting it replace a good copy', async () => {
+      const truncated = Buffer.from('%PDF-1.4\ninvoice bytes but cut off mid-str');
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(pdfResponse(truncated))
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(JSON.stringify({ Invoice: { DocumentNumber: '1001', Sent: true } })),
+          json: () => Promise.resolve({ Invoice: { DocumentNumber: '1001', Sent: true } }),
+        });
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      const result = await markInvoicePrinted('1001');
+
+      expect(result.invoice.Sent).toBe(true);
+      expect(result.pdf).toBeUndefined();
+    });
+
+    // Fortnox can answer 2xx with an error envelope. Unlike an unreadable body,
+    // that is positive evidence the print did NOT happen — so it must not be
+    // reported as a successful "marked as sent".
+    it('raises when /print answers 200 with a Fortnox error envelope', async () => {
+      const envelope = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'Kan inte skriva ut', code: 2000999 } }),
+      );
+      global.fetch = vi.fn().mockResolvedValue(pdfResponse(envelope));
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      await expect(markInvoicePrinted('1001')).rejects.toThrow(/Kan inte skriva ut/);
     });
 
     it('returns the printed PDF so callers can save the version that was marked sent', async () => {

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -160,6 +160,18 @@ describe('invoice operations', () => {
       expect(result.DocumentNumber).toBe('1001');
     });
 
+    // 'email' and 'einvoice' both deliver the invoice to the customer, so an
+    // unrecognised method must not quietly fall through to one of them.
+    it('refuses an unrecognised send method instead of defaulting to one', async () => {
+      mockFetch({ Invoice: { DocumentNumber: '1001' } });
+      const { sendInvoice } = await import('../../src/operations/invoices.js');
+
+      await expect(
+        sendInvoice('1001', 'sms' as unknown as Parameters<typeof sendInvoice>[1]),
+      ).rejects.toThrow(/Unsupported send method/);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('routes to einvoice endpoint', async () => {
       mockFetch({ Invoice: { DocumentNumber: '1001' } });
       const { sendInvoice } = await import('../../src/operations/invoices.js');

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -228,7 +228,44 @@ describe('invoice operations', () => {
 
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/print');
-      expect(result.Sent).toBe(true);
+      expect(result.invoice.Sent).toBe(true);
+    });
+
+    // Once /print answers 2xx, Fortnox has set Sent. Nothing after that point
+    // may throw on the caller's behalf — including validation of the PDF body,
+    // which this action does not even need.
+    it('still reports success when the printed body is not a readable PDF', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/pdf' }),
+          arrayBuffer: () => Promise.resolve(Buffer.from('truncated garbage').buffer),
+        })
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(JSON.stringify({ Invoice: { DocumentNumber: '1001', Sent: true } })),
+          json: () => Promise.resolve({ Invoice: { DocumentNumber: '1001', Sent: true } }),
+        });
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      const result = await markInvoicePrinted('1001');
+
+      expect(result.invoice.Sent).toBe(true);
+      // No usable PDF came back, so none is offered to the caller.
+      expect(result.pdf).toBeUndefined();
+    });
+
+    it('returns the printed PDF so callers can save the version that was marked sent', async () => {
+      mockPdfThenInvoice({ DocumentNumber: '1001', Sent: true });
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      const result = await markInvoicePrinted('1001');
+
+      expect(result.pdf?.equals(PDF_BYTES)).toBe(true);
     });
 
     // The print already succeeded at this point; failing the whole call would
@@ -248,10 +285,10 @@ describe('invoice operations', () => {
 
       const result = await markInvoicePrinted('1001');
 
-      expect(result.Sent).toBe(true);
-      expect(result.DocumentNumber).toBe('1001');
+      expect(result.invoice.Sent).toBe(true);
+      expect(result.invoice.DocumentNumber).toBe('1001');
       // The read-back failure must remain visible, not be silently swallowed.
-      expect(String(result.Note)).toMatch(/Boom/);
+      expect(String(result.invoice.Note)).toMatch(/Boom/);
     });
   });
 

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -278,6 +278,7 @@ describe('invoice operations', () => {
 
       const result = await markInvoicePrinted('1001');
 
+      expect(result.confirmed).toBe(true);
       expect(result.invoice.Sent).toBe(true);
       expect(result.pdf).toBeUndefined();
     });
@@ -321,8 +322,11 @@ describe('invoice operations', () => {
 
       const result = await markInvoicePrinted('1001');
 
-      expect(result.invoice.Sent).toBe(true);
+      // The print was accepted, so this is not an error...
       expect(result.invoice.DocumentNumber).toBe('1001');
+      // ...but the outcome was never confirmed, so it must NOT claim Sent.
+      expect(result.confirmed).toBe(false);
+      expect(result.invoice.Sent).toBeUndefined();
       // The read-back failure must remain visible, not be silently swallowed.
       expect(String(result.invoice.Note)).toMatch(/Boom/);
     });

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  // Needed by FortnoxApiError, which prefixes messages with the active profile.
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
 }));
 
 function mockFetch(response: unknown) {
@@ -196,14 +198,16 @@ describe('invoice operations', () => {
       expect(bytes.equals(PDF_BYTES)).toBe(true);
     });
 
-    it('uses /print when the caller opts into marking the invoice as sent', async () => {
+    // Downloading must never mutate. Marking the invoice as sent is a separate
+    // step (markInvoicePrinted) that callers run *after* the bytes are on disk.
+    it('never touches /print, even indirectly', async () => {
       mockPdf();
       const { getInvoicePdf } = await import('../../src/operations/invoices.js');
 
-      await getInvoicePdf('1001', { markSent: true });
+      await getInvoicePdf('1001');
 
-      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-      expect(calledUrl).toContain('invoices/1001/print');
+      const urls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
+      expect(urls.some((u) => u.includes('/print'))).toBe(false);
     });
 
     it('rejects a non-numeric document number before calling Fortnox', async () => {
@@ -212,6 +216,42 @@ describe('invoice operations', () => {
 
       await expect(getInvoicePdf('../../customers/1')).rejects.toThrow();
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('markInvoicePrinted', () => {
+    it('calls /print and flags it as a mutation so it is never auto-retried', async () => {
+      mockPdfThenInvoice({ DocumentNumber: '1001', Sent: true });
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      const result = await markInvoicePrinted('1001');
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('invoices/1001/print');
+      expect(result.Sent).toBe(true);
+    });
+
+    // The print already succeeded at this point; failing the whole call would
+    // recreate exactly the "successful action reported as a failure" ambiguity
+    // this code path exists to remove.
+    it('still reports success when the confirmation read-back fails', async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(pdfResponse())
+        .mockResolvedValue({
+          ok: false,
+          status: 500,
+          headers: new Headers(),
+          json: () => Promise.resolve({ ErrorInformation: { message: 'Boom', code: 0 } }),
+        });
+      const { markInvoicePrinted } = await import('../../src/operations/invoices.js');
+
+      const result = await markInvoicePrinted('1001');
+
+      expect(result.Sent).toBe(true);
+      expect(result.DocumentNumber).toBe('1001');
+      // The read-back failure must remain visible, not be silently swallowed.
+      expect(String(result.Note)).toMatch(/Boom/);
     });
   });
 

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -13,6 +13,38 @@ function mockFetch(response: unknown) {
   });
 }
 
+const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes');
+
+function pdfResponse(bytes: Buffer = PDF_BYTES) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/pdf' }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+    // Faithful to a real fetch Response: .text() is available and yields the
+    // PDF bytes decoded as text, which is what used to reach JSON.parse.
+    text: () => Promise.resolve(bytes.toString('utf-8')),
+  };
+}
+
+function mockPdf(bytes: Buffer = PDF_BYTES) {
+  global.fetch = vi.fn().mockResolvedValue(pdfResponse(bytes));
+}
+
+// /print returns the PDF; the follow-up GET reports the invoice's post-print state.
+function mockPdfThenInvoice(invoice: Record<string, unknown>) {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce(pdfResponse())
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ Invoice: invoice })),
+      json: () => Promise.resolve({ Invoice: invoice }),
+    });
+}
+
 describe('invoice operations', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -106,13 +138,26 @@ describe('invoice operations', () => {
     });
 
     it('routes to print endpoint', async () => {
-      mockFetch({ Invoice: { DocumentNumber: '1001' } });
+      mockPdfThenInvoice({ DocumentNumber: '1001', Sent: true });
       const { sendInvoice } = await import('../../src/operations/invoices.js');
 
       await sendInvoice('1001', 'print');
 
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/print');
+    });
+
+    // Regression: /print answers with application/pdf, not JSON. Parsing the PDF
+    // bytes as JSON threw a bare SyntaxError *after* Fortnox had already flagged
+    // the invoice as sent, so the caller saw a crash for an action that succeeded.
+    it('does not choke on the PDF body that /print returns, and reports the sent invoice', async () => {
+      mockPdfThenInvoice({ DocumentNumber: '1001', Sent: true });
+      const { sendInvoice } = await import('../../src/operations/invoices.js');
+
+      const result = await sendInvoice('1001', 'print');
+
+      expect(result.Sent).toBe(true);
+      expect(result.DocumentNumber).toBe('1001');
     });
 
     it('routes to einvoice endpoint', async () => {
@@ -123,6 +168,38 @@ describe('invoice operations', () => {
 
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/einvoice');
+    });
+  });
+
+  describe('getInvoicePdf', () => {
+    it('uses /preview by default so downloading a PDF does not flag the invoice as sent', async () => {
+      mockPdf();
+      const { getInvoicePdf } = await import('../../src/operations/invoices.js');
+
+      const bytes = await getInvoicePdf('1001');
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('invoices/1001/preview');
+      expect(calledUrl).not.toContain('/print');
+      expect(bytes.equals(PDF_BYTES)).toBe(true);
+    });
+
+    it('uses /print when the caller opts into marking the invoice as sent', async () => {
+      mockPdf();
+      const { getInvoicePdf } = await import('../../src/operations/invoices.js');
+
+      await getInvoicePdf('1001', { markSent: true });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('invoices/1001/print');
+    });
+
+    it('rejects a non-numeric document number before calling Fortnox', async () => {
+      mockPdf();
+      const { getInvoicePdf } = await import('../../src/operations/invoices.js');
+
+      await expect(getInvoicePdf('../../customers/1')).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -52,6 +52,21 @@ function mockPdfThenInvoice(invoice: Record<string, unknown>) {
     });
 }
 
+// Saving a PDF *and* marking it sent is three calls: /preview for the bytes,
+// /print for the mutation, then a read-back of the invoice.
+function mockPreviewPrintThenInvoice(invoice: Record<string, unknown>) {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce(pdfResponse())
+    .mockResolvedValueOnce(pdfResponse())
+    .mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ Invoice: invoice })),
+      json: () => Promise.resolve({ Invoice: invoice }),
+    });
+}
+
 async function setupClientServer() {
   const server = createServer();
   const client = new Client({ name: 'test-client', version: '1.0.0' });
@@ -329,6 +344,25 @@ describe('invoice tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(readFileSync(target).equals(PDF_BYTES)).toBe(true);
+      rmSync(target, { force: true });
+    });
+
+    // Asking for markSent is not evidence that it took effect. If Fortnox
+    // reports the invoice as still unsent, say so rather than confirming.
+    it('does not claim the invoice is sent when Fortnox reports otherwise', async () => {
+      // The markSent flow is three calls: /preview, /print, then the read-back.
+      mockPreviewPrintThenInvoice({ DocumentNumber: '1001', Sent: false });
+      const target = join(tmpdir(), `noxctl-test-unsent-${process.pid}.pdf`);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target, markSent: true, confirm: true },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).not.toContain('är nu markerad som skickad');
+      expect(text).toMatch(/Varning/);
       rmSync(target, { force: true });
     });
 

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -19,7 +19,7 @@ function mockFetch(response: unknown, ok = true, status = 200) {
   });
 }
 
-const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes');
+const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes\n%%EOF\n');
 
 function pdfResponse() {
   return {

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { readFileSync, rmSync } from 'node:fs';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from '../../src/index.js';
@@ -274,6 +274,40 @@ describe('invoice tools', () => {
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/preview');
       expect(result.isError).toBeFalsy();
+      rmSync(target, { force: true });
+    });
+
+    // Tool arguments are agent-generated and can be prompt-injection influenced,
+    // so a stray path must not silently truncate an existing file.
+    it('refuses to clobber an existing file unless overwrite is set', async () => {
+      mockPdf();
+      const target = join(tmpdir(), `noxctl-test-existing-${process.pid}.pdf`);
+      writeFileSync(target, 'important pre-existing content');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(readFileSync(target, 'utf-8')).toBe('important pre-existing content');
+      rmSync(target, { force: true });
+    });
+
+    it('replaces an existing file when overwrite is explicitly set', async () => {
+      mockPdf();
+      const target = join(tmpdir(), `noxctl-test-overwrite-${process.pid}.pdf`);
+      writeFileSync(target, 'stale');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target, overwrite: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(readFileSync(target).equals(PDF_BYTES)).toBe(true);
       rmSync(target, { force: true });
     });
 

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from '../../src/index.js';
@@ -293,6 +293,27 @@ describe('invoice tools', () => {
       expect(result.isError).toBe(true);
       expect(readFileSync(target, 'utf-8')).toBe('important pre-existing content');
       rmSync(target, { force: true });
+    });
+
+    // `w` follows symlinks, so an agent-supplied path pointing at a symlink
+    // could truncate whatever it targets. overwrite must not enable that.
+    it('refuses to write through a symlink even with overwrite set', async () => {
+      mockPdf();
+      const dir = mkdtempSync(join(tmpdir(), 'noxctl-symlink-test-'));
+      const realFile = join(dir, 'real.txt');
+      const link = join(dir, 'link.pdf');
+      writeFileSync(realFile, 'SECRET ORIGINAL');
+      symlinkSync(realFile, link);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: link, overwrite: true },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(readFileSync(realFile, 'utf-8')).toBe('SECRET ORIGINAL');
+      rmSync(dir, { recursive: true, force: true });
     });
 
     it('replaces an existing file when overwrite is explicitly set', async () => {

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createServer } from '../../src/index.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -14,6 +17,39 @@ function mockFetch(response: unknown, ok = true, status = 200) {
     text: () => Promise.resolve(JSON.stringify(response)),
     json: () => Promise.resolve(response),
   });
+}
+
+const PDF_BYTES = Buffer.from('%PDF-1.4\ninvoice bytes');
+
+function pdfResponse() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/pdf' }),
+    arrayBuffer: () =>
+      Promise.resolve(
+        PDF_BYTES.buffer.slice(PDF_BYTES.byteOffset, PDF_BYTES.byteOffset + PDF_BYTES.byteLength),
+      ),
+    text: () => Promise.resolve(PDF_BYTES.toString('utf-8')),
+  };
+}
+
+// The print/preview endpoints answer with application/pdf, not JSON.
+function mockPdf() {
+  global.fetch = vi.fn().mockResolvedValue(pdfResponse());
+}
+
+// /print returns the PDF; the follow-up GET reports the post-print invoice.
+function mockPdfThenInvoice(invoice: Record<string, unknown>) {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce(pdfResponse())
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ Invoice: invoice })),
+      json: () => Promise.resolve({ Invoice: invoice }),
+    });
 }
 
 async function setupClientServer() {
@@ -178,16 +214,18 @@ describe('invoice tools', () => {
     });
 
     it('sends invoice via print', async () => {
-      mockFetch({ Invoice: { DocumentNumber: '1001' } });
+      mockPdfThenInvoice({ DocumentNumber: '1001', Sent: true });
 
       const { client } = await setupClientServer();
-      await client.callTool({
+      const result = await client.callTool({
         name: 'fortnox_send_invoice',
         arguments: { documentNumber: '1001', method: 'print', confirm: true },
       });
 
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/print');
+      // The PDF body must not surface as an error to the caller.
+      expect(result.isError).toBeFalsy();
     });
 
     it('sends invoice via e-invoice', async () => {
@@ -201,6 +239,68 @@ describe('invoice tools', () => {
 
       const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(calledUrl).toContain('invoices/1001/einvoice');
+    });
+  });
+
+  describe('fortnox_invoice_pdf', () => {
+    it('saves the PDF and returns the path rather than the bytes', async () => {
+      mockPdf();
+      const target = join(tmpdir(), `noxctl-test-${process.pid}.pdf`);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain(target);
+      expect(readFileSync(target).equals(PDF_BYTES)).toBe(true);
+      // The PDF itself must never be inlined into the tool response.
+      expect(text).not.toContain('%PDF');
+      rmSync(target, { force: true });
+    });
+
+    it('uses /preview so a plain download needs no confirmation and does not mark the invoice sent', async () => {
+      mockPdf();
+      const target = join(tmpdir(), `noxctl-test-preview-${process.pid}.pdf`);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target },
+      });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('invoices/1001/preview');
+      expect(result.isError).toBeFalsy();
+      rmSync(target, { force: true });
+    });
+
+    it('requires confirmation for markSent because it mutates the invoice', async () => {
+      mockPdf();
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', markSent: true },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not call Fortnox on dryRun', async () => {
+      mockPdf();
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', dryRun: true },
+      });
+
+      expect((result.content as { type: string; text: string }[])[0].text).toContain('Dry run');
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #66.

## What

`noxctl invoices pdf <documentNumber>` and the `fortnox_invoice_pdf` MCP tool download an invoice as a PDF. Adds `fortnoxRequestBinary` to the client so binary responses reuse the existing rate limiting, retry, timeout and error mapping rather than growing a second request path.

```bash
noxctl invoices pdf 28                          # -> invoice-28.pdf
noxctl invoices pdf 28 --file ~/Desktop/f.pdf
noxctl invoices pdf 28 --file - > faktura.pdf
noxctl invoices pdf 28 --mark-sent --yes        # also flags it as sent
```

## Two deliberate deviations from the ticket

**1. Defaults to `/preview`, not `/print`.** The OpenAPI spec is explicit that `/print` "sets property Sent to TRUE" while `/preview` does not, and both return the same PDF. Both use cases in the ticket were *get the PDF to attach to an email* — where silently flagging an invoice as sent is a real accounting side effect. `--mark-sent` opts into `/print`, and being a mutation it goes through the normal confirmation gate.

**2. The destination flag is `--file`, not `--output`.** `-o/--output` is already a global option for the output *format* (`json|table`). `--output <path>` was rejected by Commander at runtime — caught by live testing, not by unit tests.

## Also fixes a pre-existing crash

`invoices send --method print` (and `fortnox_send_invoice` with `method: "print"`) hit `/print`, which answers with `application/pdf`, and parsed it as JSON:

```
SyntaxError: Unexpected token '%', "%PDF-1.4..." is not valid JSON
```

This threw *after* Fortnox had already marked the invoice as sent — a successful action reported as a failure. The print path now reads the PDF response and re-reads the invoice to report its true post-print state. The existing test passed only because its mock returned JSON, which real Fortnox never does there; the mock is now faithful.

## The Accept-header quirk

Accept stays `application/json` on the PDF endpoints. Fortnox rejects `Accept: application/pdf` with `{"error":1,"message":"Invalid response type","code":1000030}`. Commented at the source so it doesn't get "fixed" later.

`fortnoxRequestBinary` also refuses a 200 whose content-type isn't a PDF, surfacing the Fortnox error message instead of writing a JSON error envelope to disk under a `.pdf` name.

## Verification

- **739 unit tests passing** (was 722), lint, Prettier, and `tsc` clean.
- **Live against the real Fortnox API** (read-only `/preview`): a regular invoice and a credit invoice both download as valid, correctly rendered PDFs (verified by rendering them, not just by `file`). On an unsent invoice, `Sent` stayed `false` across repeated downloads — confirming `/preview` has no side effect.
- New opt-in live test asserts the `%PDF-` magic bytes and that `Sent` is unchanged.
- **`--mark-sent` (`/print`) is covered by unit tests only.** It was not exercised live because it mutates production accounting data. Happy to run it against a specific invoice if you want live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)