### PR TITLE
release: 0.5.0 — invoice PDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-21
+
 ### Added
 
 - **Invoice PDF export** (#66) — `noxctl invoices pdf <docNumber>` and the `fortnox_invoice_pdf` MCP tool download an invoice as a PDF. Writes to `--file <path>`, to stdout with `--file -`, or to `invoice-<docNumber>.pdf` by default (the destination is `--file` because `-o/--output` is globally the output *format*). The PDF always comes from Fortnox's `/preview` endpoint, which returns the document **without** marking the invoice as sent. `--mark-sent` additionally calls `/print` afterwards to set `Sent`, and therefore prompts for confirmation; the file is written first, so a failed write can never leave an invoice flagged as sent with no PDF to show for it. Works for credit invoices too.
@@ -16,6 +18,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `noxctl invoices send <docNumber> --method print` (and `fortnox_send_invoice` with `method: "print"`) crashed with `SyntaxError: Unexpected token '%'`. Fortnox's `/print` endpoint answers with the PDF document rather than JSON, and the response was being parsed as JSON — after Fortnox had already flagged the invoice as sent, so a successful action was reported as a failure. The print path now reads the PDF response correctly and re-reads the invoice to report its true post-print state, still reporting success (with a note) if only that read-back fails.
 - Fortnox exposes `/invoices/{n}/print` as a `GET` even though it sets `Sent`. Requests can now be flagged as mutations independently of their HTTP verb, so `/print` is no longer eligible for automatic retries and a `/print` timeout is correctly reported as an unknown outcome instead of "safe to retry".
+- When `--mark-sent` fails after the PDF has already been written, the error now reports the saved file's path and size instead of only the Fortnox error, so a successful download is not mistaken for a total failure.
+
+### Security
+
+- A saved PDF is validated by its `%PDF-` magic bytes rather than by the `Content-Type` header, so a JSON error envelope or an HTML error page returned with a 200 can never be written to disk under a `.pdf` name.
+- The `fortnox_invoice_pdf` MCP tool will not overwrite an existing file without an explicit `overwrite: true`, and will not write through a symbolic link in either mode (`O_EXCL`/`O_NOFOLLOW`, with an `lstat` fallback on Windows). Its arguments are model-generated, so a stray path must not be able to truncate an unrelated file.
+
+### Dependencies
+
+- Bumped the transitive `body-parser` to 2.3.0 (GHSA-v422-hmwv-36x6, low). Lockfile-only; no `package.json` range changed.
 
 ## [0.4.1] - 2026-07-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ See `TODO.md` for the prioritized backlog and instructions for adding new resour
 
 ```bash
 npm run build       # TypeScript compile
-npm test            # Vitest (716 unit tests)
+npm test            # Vitest (757 unit tests)
 npm run test:live   # Live API tests (needs credentials)
 npm run lint        # ESLint
 npm run format      # Prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1462,8 +1462,21 @@ Examples:
       const path = opts.file ?? `invoice-${documentNumber}.pdf`;
       writeFileSync(path, pdf);
 
-      // Only now that the PDF is safely on disk do we change Fortnox.
-      const printed = opts.markSent ? await markInvoicePrinted(documentNumber) : undefined;
+      // Only now that the PDF is safely on disk do we change Fortnox. If that
+      // fails, the download still succeeded — say so, or the user is left
+      // thinking the whole command achieved nothing.
+      let printed;
+      if (opts.markSent) {
+        try {
+          printed = await markInvoicePrinted(documentNumber);
+        } catch (err) {
+          throw new Error(
+            `Invoice ${documentNumber} saved to ${path} (${pdf.length} bytes), but marking it as sent failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
 
       // Prefer the document /print actually produced, so the saved copy matches
       // the version that was marked as sent. Best-effort: the /preview copy is

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.4.1')
+  .version('0.5.0')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -308,7 +308,20 @@ export function registerInvoiceTools(server: McpServer): void {
       writePdf(target, pdf, overwrite);
 
       // Only now that the PDF is safely on disk do we change anything in Fortnox.
-      const printed = markSent ? await markInvoicePrinted(documentNumber) : undefined;
+      // If that fails, the download still succeeded — say so, or the caller has
+      // no idea a usable file is sitting there.
+      let printed;
+      if (markSent) {
+        try {
+          printed = await markInvoicePrinted(documentNumber);
+        } catch (err) {
+          throw new Error(
+            `Faktura ${documentNumber} sparades som PDF: ${target} (${pdf.length} bytes), men kunde inte markeras som skickad: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
 
       // Prefer the document /print actually produced, so the saved copy matches
       // the version that was marked as sent. Best-effort: the /preview copy is

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const CLI_PATH = path.resolve('dist/cli.js');
@@ -325,5 +326,17 @@ describe('CLI smoke tests', () => {
     expect(() => {
       execFileSync('node', [CLI_PATH, 'nonexistent'], { ...execOpts, stdio: 'pipe' });
     }).toThrow();
+  });
+});
+
+describe('version consistency', () => {
+  // The CLI hardcodes its version string, so it can silently drift from
+  // package.json across releases — it already shipped one version behind once.
+  it('noxctl --version matches the package version', () => {
+    const pkg = JSON.parse(readFileSync(path.resolve('package.json'), 'utf-8')) as {
+      version: string;
+    };
+    const output = execFileSync('node', [CLI_PATH, '--version'], execOpts) as string;
+    expect(output.trim()).toBe(pkg.version);
   });
 });

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -8,6 +8,8 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  // Needed by FortnoxApiError, which prefixes messages with the active profile.
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
 }));
 
 function mockFetch(response: unknown, ok = true, status = 200) {
@@ -363,6 +365,39 @@ describe('invoice tools', () => {
       const text = (result.content as { type: string; text: string }[])[0].text;
       expect(text).not.toContain('är nu markerad som skickad');
       expect(text).toMatch(/Varning/);
+      rmSync(target, { force: true });
+    });
+
+    // Found live against the demo tenant: /preview succeeded and the PDF was
+    // written, then /print failed (missing bank details). The error must say the
+    // file was saved, or the user assumes the whole command achieved nothing.
+    it('reports the saved path when the PDF is written but marking it sent fails', async () => {
+      const target = join(tmpdir(), `noxctl-test-marksent-fail-${process.pid}.pdf`);
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(pdfResponse())
+        .mockResolvedValue({
+          ok: false,
+          status: 400,
+          headers: new Headers(),
+          json: () =>
+            Promise.resolve({
+              ErrorInformation: { message: 'Bankuppgifter saknas.', code: 2000570 },
+            }),
+        });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_invoice_pdf',
+        arguments: { documentNumber: '1001', outputPath: target, markSent: true, confirm: true },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain(target);
+      expect(text).toMatch(/Bankuppgifter saknas/);
+      // The PDF really is on disk despite the error.
+      expect(readFileSync(target).equals(PDF_BYTES)).toBe(true);
       rmSync(target, { force: true });
     });
 


### PR DESCRIPTION
Cuts `0.5.0`. Minor rather than patch: this adds user-facing surface (`noxctl invoices pdf`, the `fortnox_invoice_pdf` MCP tool) on top of the 0.4.1 line.

## Contents

- Promotes `[Unreleased]` to `[0.5.0]`, adding **Security** and **Dependencies** sections that were missing from the running notes.
- **`fix(invoices)`: report the saved PDF when `--mark-sent` fails.** Found by live-testing `--mark-sent` against the `demo` tenant: `/preview` succeeded and the PDF was written, then `/print` failed (that tenant has no bank details). The command surfaced only the Fortnox error, so the user had no idea a perfectly good PDF was already on disk. Both front-ends now report what was saved, where, and how large, alongside why marking failed.
- Bumps the CLI's **hardcoded** `--version` string, which had drifted a release behind `package.json`, and adds a test asserting the two agree so it can't silently ship stale again.
- Refreshes the stale test count in `CLAUDE.md`.

## On the live `--mark-sent` test

The write-before-mutate ordering behaved exactly as designed under a real failure: the PDF was written, `/print` failed, and `Sent` correctly stayed `false`. That is the invariant this feature was built around, now confirmed against a live tenant rather than only a mock.

The **success** path (`Sent` flipping `false → true`) is still unverified. The demo tenant returns `Bankuppgifter saknas` from `/print`, and `/3/settings/company` is GET-only, so the bank details have to be added once via the Fortnox UI (Register → Transaktionskonton). Happy to re-run and confirm the success path once that's done.

## Verification

`npm run check:release` passes: lint, Prettier, TypeScript build, **67 files / 758 tests**, `npm audit --omit=dev` clean, and a 271-file package dry-run producing `noxctl-0.5.0.tgz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)