### PR TITLE
docs: document invoices pdf in the CLAUDE.md CLI examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ noxctl invoices list
 noxctl invoices list --output json
 noxctl customers get 25
 
+# Invoice PDFs (read-only — uses /preview, does not mark the invoice as sent)
+noxctl invoices pdf 28                       # -> invoice-28.pdf
+noxctl invoices pdf 28 --file /tmp/f.pdf
+noxctl invoices pdf 28 --mark-sent --yes     # ALSO flags it as sent (mutation)
+
 # Writing data (prompts for confirmation on TTY; use --yes to skip)
 echo '{"InvoiceRows": [...]}' | noxctl invoices update 28 --input - --yes
 noxctl invoices send 28              # prompts: Continue? [y/N]


### PR DESCRIPTION
Adds the new `invoices pdf` command to the CLI-first examples in `CLAUDE.md`.

Those examples are what a Claude Code session reads before reaching for a workaround — and #66 was filed precisely because this gap got worked around by hand twice (importing `getValidToken` from `dist/auth.js` in a throwaway script). Worth having the command visible where that decision gets made.

Notes the `/preview` default (read-only, does not mark the invoice as sent) and flags `--mark-sent` as the mutation.

Docs only — no code change.