### PR TITLE
fix(deps): override @hono/node-server to clear GHSA-frvp-7c67-39w9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Security
+
+- Pinned the transitive `@hono/node-server` to `^2.0.11` via `overrides`, clearing GHSA-frvp-7c67-39w9 (moderate: path traversal in `serve-static` on Windows via an encoded backslash). It reaches us through `@modelcontextprotocol/sdk`, whose declared range `^1.19.9` cannot pick up the fix in 2.0.5.
+
+  **noxctl was never exposed:** the server runs only over `StdioServerTransport` and never imports hono, starts an HTTP server, or calls `serveStatic`. The override is nonetheless worth having so `npm audit` stays a meaningful gate rather than a permanently-red one, and it is safe for the same reason the advisory was unexploitable — the code is never loaded. Remove it once the SDK moves to `@hono/node-server` 2.x.
+
+  The alternative npm proposed, `npm audit fix --force`, would have downgraded the SDK to 1.24.3 — a breaking change to a core dependency to fix an unreachable vulnerability.
+
 ## [0.6.0] - 2026-07-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -172,12 +172,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "noxctl",
   "version": "0.6.0",
   "mcpName": "io.github.magnus-gille/noxctl",
-  "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
+  "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
   "type": "module",
   "bin": {
     "noxctl": "dist/cli.js"
@@ -60,5 +60,8 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
     "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.11"
   }
 }


### PR DESCRIPTION
**Unblocks CI.** A new moderate advisory landed against `@hono/node-server <2.0.5` and it fails the required `npm audit --omit=dev` gate, so it is currently blocking *every* open PR — including the two docs-only ones.

## noxctl was never exposed

The MCP server runs only over `StdioServerTransport`. We never import hono, never start an HTTP server, and never call `serveStatic`. The advisory additionally requires Windows. The vulnerable code is not reachable in this package.

## Why an override

It arrives via `@modelcontextprotocol/sdk`, whose declared range `^1.19.9` **cannot** reach the fix in 2.0.5 — that's a major bump. So the options were:

| Option | Verdict |
|---|---|
| `npm audit fix --force` | Downgrades the SDK to **1.24.3** — a breaking change to a core dependency, to fix an unreachable vulnerability. No. |
| Wait for upstream | CI stays red indefinitely, blocking unrelated work. |
| `--audit-level=high` | Silences all future moderate advisories too. Guts the gate. |
| **`overrides` to `^2.0.11`** | Actually removes the vulnerable code. Chosen. |

## The honest trade-off

The override goes **outside the SDK's declared range**, so we ship a combination upstream doesn't test. That's acceptable here for precisely the same reason the CVE doesn't apply — the code is never loaded. If anyone later adopts the SDK's HTTP transport, this needs revisiting.

**Remove the override once the SDK moves to `@hono/node-server` 2.x.** Noted in the changelog so it isn't forgotten.

## Verification

- `npm audit --omit=dev` — **0 vulnerabilities** (was 2 moderate)
- **759 tests** pass, build and lint clean
- Live MCP `initialize` + `tools/list` handshake still returns **105 tools**, confirming the SDK is unaffected by the swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)