### PR TITLE
docs: correct the stale test count and two wrong TODO entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ See `TODO.md` for the prioritized backlog and instructions for adding new resour
 
 ```bash
 npm run build       # TypeScript compile
-npm test            # Vitest (757 unit tests)
+npm test            # Vitest (759 unit tests)
 npm run test:live   # Live API tests (needs credentials)
 npm run lint        # ESLint
 npm run format      # Prettier

--- a/TODO.md
+++ b/TODO.md
@@ -36,8 +36,11 @@ Weekly GitHub Actions workflow (`api-drift.yml`) fetches the Fortnox OpenAPI spe
 11. ~~CLI `dashboard` command~~ ✅ Done
 12. Bilingual MCP descriptions (Swedish primary + English keywords)
 13. MCP capability resource
-14. Bank transactions (requires enabling Bank API scope)
-15. File attachments (underlag) — upload receipts, attach to vouchers
+14. Bank transactions — **blocked upstream, not a scope toggle.** A freshly fetched
+    Fortnox OpenAPI spec (2026-07-21, 233 paths) contains **zero** `/3/bank*`
+    endpoints; this is a separate Fortnox Bank/Finans product surface, so there is
+    nothing to implement against from the standard REST API. See issue #13.
+15. ~~File attachments (underlag) — upload receipts, attach to vouchers~~ ✅ Done (#37) — `noxctl vouchers attach`; live use needs the **archive** scope
 16. Live mutation test coverage — only read paths tested live
 
 ## Adding a New Resource


### PR DESCRIPTION
Small corrections found during the session-close doc review.

**`CLAUDE.md`** said 757 tests; the suite is at 759.

**`TODO.md` item 14** claimed bank transactions merely *"requires enabling Bank API scope"*. That's wrong, and it was repeating exactly the assumption issue #13 was retitled away from: a freshly fetched Fortnox spec (2026-07-21, 233 paths) contains **zero** `/3/bank*` endpoints. It's a separate Fortnox Bank/Finans product surface, not a toggle on the existing app — no amount of scope configuration unblocks it.

Left as a backlog item, but now honest about why it's blocked, so the next person doesn't go hunting for a setting that doesn't exist.

**`TODO.md` item 15** (file attachments) shipped in #37 and was still listed as outstanding.

Docs only.