### PR TITLE
docs: refresh the stale TODO.md Current State block, ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules/
 dist/
 __pycache__/

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,13 @@
 
 ## Current State
 
-- Published to npm as `noxctl@0.3.0`
-- 23 operations modules: invoices, customers, suppliers, articles, vouchers, accounts, financial reports, tax, company, invoice payments, supplier invoice payments, offers, orders, projects, cost centers, tax reductions (ROT/RUT), price lists, prices, employees, salary transactions, attendance transactions, absence transactions, schedule times
+- Published to npm as `noxctl@0.6.0` (2026-07-21)
+- Invoice PDF export: `noxctl invoices pdf` / `fortnox_invoice_pdf`
+- Requires Node.js >=22.12.0; uses Commander 15
+- 26 operations modules: invoices, customers, suppliers, supplier invoices, articles, vouchers, accounts, financial reports, financial years/locked period, tax, company, invoice payments, supplier invoice payments, offers, orders, contracts, projects, cost centers, tax reductions (ROT/RUT), price lists, analytics, employees, salary transactions, attendance transactions, absence transactions, schedule times
 - Full sales pipeline: offer → order → invoice → payment
 - Payroll (Lön): employees + salary/attendance/absence transactions + schedule times (opt-in `salary` scope via `init --with-salary`)
-- 716 unit tests
+- 759 unit tests across 67 files
 
 ## API Drift Detection
 


### PR DESCRIPTION
Follow-up to #78, which corrected two backlog entries but missed the Current State header at the top of TODO.md — it still described 0.3.0.

- Published version: `noxctl@0.3.0` → `0.6.0` (2026-07-21), noting invoice PDF export, the Node >=22.12.0 floor, and commander 15
- Test count: 716 → 759 (across 67 files), matching CHANGELOG.md and CLAUDE.md
- Operations modules: 23 → 26, with the one-line list reconciled against `src/operations/` (adds supplier invoices, financial years/locked period, contracts, analytics)
- `.DS_Store` added to `.gitignore` — it was never ignored and sat untracked in every `git status`

Docs/config only; no runtime change. Facts cross-checked against `package.json`, `CHANGELOG.md`, and the `src/operations/` listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)