### PR TITLE
release: 0.6.1 — ship the @hono/node-server security override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-21
+
 ### Internal
 
 - `@types/node` realigned to `^22` (was `^25.9.5`). The types should track the *minimum* supported Node, not the newest release — typing against a newer Node than `engines` allows lets TypeScript accept APIs that do not exist at runtime for users on the supported floor. The build and full suite pass unchanged on `@types/node@22`, confirming nothing depended on the newer typings. This supersedes the proposed bump to 26.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.6.0')
+  .version('0.6.1')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.6.0',
+    version: '0.6.1',
   });
 
   registerCustomerTools(server);


### PR DESCRIPTION
Cuts the 0.6.1 patch release, shipping what has accumulated on `main` since 0.6.0 (close-report pending item 2). No user-facing runtime change.

## Contents (promoted from `[Unreleased]`)

- **Security:** transitive `@hono/node-server` pinned to `^2.0.11` via `overrides`, clearing GHSA-frvp-7c67-39w9 (#76). noxctl was never exposed (stdio-only, hono never loaded), but the override keeps `npm audit` a meaningful gate.
- **Internal:** `@types/node` realigned to `^22` to match the supported Node floor; `lint-staged` 17 (dev-only) (#77).
- Docs merged since 0.6.0 ride along in the tag (#69, #75, #78, #79).

## Release mechanics

- Version bumped in all three literals — `package.json`, CLI `.version(...)`, MCP `serverInfo` — which `tests/cli.test.ts` asserts stay in agreement.
- `npm run check:release` passes locally: lint, format, build, 67 files / 759 tests, `npm audit --omit=dev` 0 vulnerabilities, and a 271-file `noxctl-0.6.1.tgz` dry-run.

After merge: tag `v0.6.1`, `npm publish` (interactive passkey flow per CONTRIBUTING.md), verify the registry shasum, then `gh release create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)