### PR TITLE
CI: migrate actions to Node 24 runtime

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -13,7 +13,8 @@ jobs:
   check-api-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # v5.1.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       - name: Check for API changes
         id: diff
@@ -48,7 +49,8 @@ jobs:
 
       - name: Open issue on API change
         if: steps.diff.outputs.changed == 'true'
-        uses: actions/github-script@v7
+        # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           DIFF_SUMMARY: ${{ steps.diff.outputs.summary }}
         with:
@@ -74,7 +76,8 @@ jobs:
 
       - name: Open issue on fetch error
         if: steps.diff.outputs.error == 'true'
-        uses: actions/github-script@v7
+        # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           DIFF_SUMMARY: ${{ steps.diff.outputs.summary }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
         node-version: [22, 24]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # v5.1.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      # v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
Closes #81

## Summary
- migrate checkout, setup-node, and both github-script invocations to maintained Node 24-native releases
- pin all five workflow action invocations to immutable full commit SHAs with human-readable version comments
- preserve workflow triggers, permissions, jobs, and the Node 22/24 test matrix

## Verification
- official upstream action manifests at every pinned SHA declare runs.using: node24
- static inventory check: all five invocations are accounted for, immutable-pinned, and version-commented
- npm run lint
- npm run build
- npm test (67 files, 759 tests)
- npm run format:check
- npm audit --omit=dev (0 vulnerabilities)
- npm pack --dry-run --ignore-scripts (271 files)
- bounded M5 mellum review returned exact PASS with deterministic verifier; ledger fc5f5c01-670b-43fd-9705-5d8fbf3089d2