### PR TITLE
ci: add Action pin release provenance

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -13,8 +13,7 @@ jobs:
   check-api-spec:
     runs-on: ubuntu-latest
     steps:
-      # v5.1.0
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Check for API changes
         id: diff
@@ -49,8 +48,7 @@ jobs:
 
       - name: Open issue on API change
         if: steps.diff.outputs.changed == 'true'
-        # v8.0.0
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DIFF_SUMMARY: ${{ steps.diff.outputs.summary }}
         with:
@@ -76,8 +74,7 @@ jobs:
 
       - name: Open issue on fetch error
         if: steps.diff.outputs.error == 'true'
-        # v8.0.0
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DIFF_SUMMARY: ${{ steps.diff.outputs.summary }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,8 @@ jobs:
         node-version: [22, 24]
 
     steps:
-      # v5.1.0
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-      # v5.0.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
Closes #86.

Moves the existing semantic release tags onto the five immutable remote uses entries so Grimnir can verify them mechanically. No workflow trigger, permission, SHA, or behavior changed.

Verified against official upstream tags:
- actions/checkout v5.1.0 resolves to fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
- actions/setup-node v5.0.0 resolves to a0853c24544627f65ddf259abe73b1d18a591444
- actions/github-script v8.0.0 resolves to ed597411d8f924073f98dfc5c65a23a2325f34cd

Each exact tagged action.yml declares runs.using: node24 (approved).

Checks: npm run verify (68 files / 761 tests), npm audit --omit=dev (0 vulnerabilities), npm pack --dry-run --ignore-scripts, and diff validation confirming five same-line semantic provenance comments.

M5 bounded review was attempted via the local gateway (mellum) but returned HTTP 503, so no M5 result is claimed.