### PR TITLE
chore(deps): @modelcontextprotocol/sdk 1.30.0, drop the @hono/node-server override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 (supersedes Dependabot #89).
+- **Dropped the `@hono/node-server` override.** SDK 1.30.0 widens its dependency range to `^1.19.9 || ^2.0.5`, so npm now resolves 2.0.11 on its own — exactly the condition the 0.6.1 entry named for removing the pin. Verified: `npm ls @hono/node-server` still resolves 2.0.11 without the override, and `npm audit --omit=dev` reports 0 vulnerabilities, so GHSA-frvp-7c67-39w9 stays closed. The `fast-uri`, `hono` and `ip-address` overrides are unchanged.
+
+
 ## [0.7.0] - 2026-08-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,12 +257,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "noxctl",
   "version": "0.7.0",
   "mcpName": "io.github.magnus-gille/noxctl",
-  "description": "CLI and MCP server for Fortnox accounting — invoices, customers, bookkeeping, and VAT",
+  "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
   "type": "module",
   "bin": {
     "noxctl": "dist/cli.js"
@@ -62,7 +62,6 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
-    "@hono/node-server": "^2.0.11",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
     "ip-address": "10.3.1"


### PR DESCRIPTION
Supersedes #89, which was a lockfile-only bump against a pre-0.7.0 `main` and no longer merges cleanly.

## What changed

- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0. The declared range stays `^1.27.1`, matching this project's style of letting the range lag the lock.
- **Removed the `@hono/node-server` override.** SDK 1.30.0 widens its dependency to `^1.19.9 || ^2.0.5`, which is exactly the condition the 0.6.1 CHANGELOG named for dropping the pin added for GHSA-frvp-7c67-39w9.

## Verification that the advisory stays closed

```
$ npm ls @hono/node-server          # with the override removed
noxctl@0.7.0
└─┬ @modelcontextprotocol/sdk@1.30.0
  └── @hono/node-server@2.0.11

$ npm audit --omit=dev
found 0 vulnerabilities
```

npm resolves 2.0.11 on its own now, so the override was doing nothing. The `fast-uri`, `hono` and `ip-address` overrides are untouched.

`npm run check:release` passes: lint, Prettier, build, 829 tests, production audit, package dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)