### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-19
+
 ### Changed
 
 - `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 (supersedes Dependabot #89).
@@ -194,6 +196,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Table and JSON output modes (auto-detected by TTY, override with `-o`).
 - `noxctl doctor` / `fortnox_status` for setup validation.
 
+[0.7.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Magnus-Gille/noxctl/compare/v0.6.1...v0.7.0
 [0.4.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.4.0...v0.4.1
 [0.2.0]: https://github.com/Magnus-Gille/noxctl/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [0.7.1] - 2026-08-19
 
+### Internal
+
+- Raised the CLI subprocess timeout in tests from 10s to 30s (and the Vitest per-test timeout to 45s, which has to exceed it). Spawning `node dist/cli.js` on a cold Windows CI runner regularly approached 10s, so these subprocess assertions flaked intermittently — the failure looked like an empty stderr rather than a timeout, which is unhelpfully misleading.
+
 ### Changed
 
 - `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 (supersedes Dependabot #89).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Magnus-Gille/noxctl",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "noxctl",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.7.0')
+  .version('0.7.1')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.7.0',
+    version: '0.7.1',
   });
 
   registerCustomerTools(server);

--- a/tests/cli-errors.test.ts
+++ b/tests/cli-errors.test.ts
@@ -7,6 +7,10 @@ import { errorEnvelope } from '../src/formatter.js';
 
 const CLI_PATH = path.resolve('dist/cli.js');
 
+// Windows CI runners spawn Node far slower than a warm local machine; 10s put
+// these subprocess assertions right at the edge and they flaked intermittently.
+const CLI_TIMEOUT_MS = 30_000;
+
 let tmpHome: string;
 
 function run(args: string[]): { stdout: string; stderr: string; status: number } {
@@ -19,7 +23,7 @@ function run(args: string[]): { stdout: string; stderr: string; status: number }
 
   const opts: ExecFileSyncOptions = {
     encoding: 'utf-8',
-    timeout: 10000,
+    timeout: CLI_TIMEOUT_MS,
     env: mergedEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   };

--- a/tests/cli-profile.test.ts
+++ b/tests/cli-profile.test.ts
@@ -6,6 +6,10 @@ import path from 'node:path';
 
 const CLI_PATH = path.resolve('dist/cli.js');
 
+// Windows CI runners spawn Node far slower than a warm local machine; 10s put
+// these subprocess assertions right at the edge and they flaked intermittently.
+const CLI_TIMEOUT_MS = 30_000;
+
 let tmpHome: string;
 let cfgDir: string;
 let activePointerFile: string;
@@ -25,7 +29,7 @@ function run(
 
   const opts: ExecFileSyncOptions = {
     encoding: 'utf-8',
-    timeout: 10000,
+    timeout: CLI_TIMEOUT_MS,
     env: mergedEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   };

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,7 +4,10 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const CLI_PATH = path.resolve('dist/cli.js');
-const execOpts: ExecFileSyncOptions = { encoding: 'utf-8', timeout: 10000 };
+// Windows CI runners spawn Node far slower than a warm local machine; 10s put
+// these subprocess assertions right at the edge and they flaked intermittently.
+const CLI_TIMEOUT_MS = 30_000;
+const execOpts: ExecFileSyncOptions = { encoding: 'utf-8', timeout: CLI_TIMEOUT_MS };
 
 describe('CLI smoke tests', () => {
   it('noxctl --help exits 0 and shows subcommands', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    testTimeout: 10_000,
+    // Must exceed the CLI subprocess timeout in the tests that spawn `node
+    // dist/cli.js`, or the test aborts before the subprocess reports anything.
+    testTimeout: 45_000,
     exclude: ['**/node_modules/**', '**/dist/**', 'tests/live/**'],
   },
 });


### PR DESCRIPTION
Patch release for the runtime dependency change in #98.

The only thing reaching the published package is `@modelcontextprotocol/sdk` 1.30.0 and the removal of the now-redundant `@hono/node-server` override. The dev-tooling bumps in #99 don't ship, so they ride along without warranting a release of their own.

`npm run check:release` passes: lint, Prettier, build, 829 tests, production audit, package dry-run. 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)