### PR TITLE
fix: voucher row schema silently dropped TransactionInformation, CostCenter, Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fortnox_create_voucher` silently dropped per-row fields.** `VoucherRowSchema` declared only `Account`, `Debit`, `Credit` and `Description`, and the MCP SDK strips any argument a schema does not declare — so a per-line note passed as `TransactionInformation` never reached Fortnox, with no error and a voucher that booked fine minus the data. The schema now covers the full `VoucherRowSinglePayloadItem` set: `TransactionInformation`, `CostCenter`, `Project`, `Quantity` and `Removed`. `createVoucher()` already forwarded rows verbatim, so the schema was the only place fields were lost. Same root cause as the Supplier gap in #96; the test asserts the declared property list so it cannot drift again. Thanks to @hedborg (#101).
+- Row-level `Description` now documents that Fortnox normally overwrites it with the account's own registered name, and points callers at `TransactionInformation` for per-line free text. **Not independently confirmed against a live account** — reported from real usage and adopted because the guidance is right either way: `TransactionInformation` is unambiguously the per-line free-text field.
+
+
 ## [0.7.1] - 2026-08-19
 
 ### Internal

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -21,11 +21,35 @@ import {
   textResponse,
 } from '../tool-output.js';
 
+// The full writable VoucherRow field set (Fortnox `VoucherRowSinglePayloadItem`).
+// The MCP SDK strips any key the schema does not declare, so an undeclared field
+// reaches neither Fortnox nor an error message — a per-line note passed as
+// TransactionInformation simply vanished and the voucher booked without it
+// (#101). createVoucher() forwards rows verbatim, so this schema is the only
+// place fields were being lost.
 const VoucherRowSchema = z.object({
   Account: z.number().describe('Kontonummer'),
   Debit: z.number().optional().describe('Debetbelopp'),
   Credit: z.number().optional().describe('Kreditbelopp'),
-  Description: z.string().optional().describe('Beskrivning'),
+  Description: z
+    .string()
+    .optional()
+    .describe(
+      'Radbeskrivning. OBS: Fortnox fyller normalt detta fält med kontots egen registrerade benämning, oavsett vad som skickas. Använd TransactionInformation för fritext per rad.',
+    ),
+  TransactionInformation: z
+    .string()
+    .optional()
+    .describe(
+      'Fritext för just denna rad (vem, vad, varför). Detta är det fria textfältet per rad — till skillnad från Description, som normalt speglar kontots egen benämning.',
+    ),
+  CostCenter: z.string().optional().describe('Kostnadsställe för denna rad'),
+  Project: z.string().optional().describe('Projektnummer för denna rad'),
+  Quantity: z.number().optional().describe('Antal (används av vissa kontotyper)'),
+  Removed: z
+    .boolean()
+    .optional()
+    .describe('Markerar raden som makulerad. Sätts normalt inte vid skapande.'),
 });
 
 const VoucherSeriesSchema = z

--- a/tests/tools/bookkeeping.test.ts
+++ b/tests/tools/bookkeeping.test.ts
@@ -129,6 +129,81 @@ describe('bookkeeping tools', () => {
     });
   });
 
+  // Issue #101: the MCP SDK strips any key the schema does not declare, so a
+  // per-line note passed as TransactionInformation vanished silently — the
+  // voucher booked fine with the data simply missing. Same root cause as the
+  // Supplier gap in #96, so assert the declared property list, not just a
+  // forwarded subset.
+  describe('voucher row schema covers the real row shape', () => {
+    const rowFields = [
+      'Account',
+      'Debit',
+      'Credit',
+      'Description',
+      'TransactionInformation',
+      'CostCenter',
+      'Project',
+      'Quantity',
+      'Removed',
+    ];
+
+    it('declares every writable VoucherRow field', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_create_voucher')!.inputSchema as {
+        properties: Record<string, { items?: { properties?: Record<string, unknown> } }>;
+      };
+      const declared = Object.keys(schema.properties.VoucherRows?.items?.properties ?? {});
+      for (const field of rowFields) {
+        expect(declared).toContain(field);
+      }
+    });
+
+    it('forwards per-row fields to Fortnox instead of dropping them', async () => {
+      mockFetch({ Voucher: { VoucherNumber: 1, VoucherSeries: 'A' } });
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_create_voucher',
+        arguments: {
+          Description: 'Test',
+          TransactionDate: '2026-03-01',
+          confirm: true,
+          VoucherRows: [
+            {
+              Account: 5460,
+              Debit: 194.32,
+              TransactionInformation: 'Kaffe till kontoret, faktura 1234',
+              CostCenter: '9050',
+              Project: '1002',
+              Quantity: 2,
+            },
+            { Account: 1930, Credit: 194.32 },
+          ],
+        },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const sent = JSON.parse(fetchCall[1].body as string).Voucher.VoucherRows[0];
+      expect(sent.TransactionInformation).toBe('Kaffe till kontoret, faktura 1234');
+      expect(sent.CostCenter).toBe('9050');
+      expect(sent.Project).toBe('1002');
+      expect(sent.Quantity).toBe(2);
+    });
+
+    it('steers callers to TransactionInformation for per-line free text', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_create_voucher')!.inputSchema as {
+        properties: Record<
+          string,
+          { items?: { properties?: Record<string, { description?: string }> } }
+        >;
+      };
+      const rowProps = schema.properties.VoucherRows?.items?.properties ?? {};
+      expect(rowProps.Description?.description).toMatch(/TransactionInformation/);
+    });
+  });
+
   describe('fortnox_attach_voucher_files', () => {
     it('returns isError when confirm is missing', async () => {
       mockFetch({});


### PR DESCRIPTION
Fixes #101, reported by @hedborg.

## The bug

`VoucherRowSchema` declared four of the nine writable `VoucherRow` fields. The MCP SDK strips any argument a schema doesn't declare, so `TransactionInformation` — Fortnox's actual per-line free-text field — never reached the API. No error; the voucher books correctly and the data you asked to record is simply absent.

`createVoucher()` forwards rows verbatim, so the tool schema was the only place they were being lost. This is the third instance of this root cause after #96, and the most dangerous one, because bookkeeping data goes missing without any signal.

## The fix

The schema now declares the full `VoucherRowSinglePayloadItem` set — adding `TransactionInformation`, `CostCenter`, `Project`, plus `Quantity` and `Removed`, which the reporter's suggested patch omitted. Taken from the OpenAPI spec rather than hand-picked, since a hand-maintained subset drifting is exactly what caused this.

Tests assert the tool's **declared schema property list**, not just a forwarded subset — a test that only sends values would still pass if a field were later dropped from the schema.

## On the `Description` question

The report notes that Fortnox overwrites row-level `Description` with the account's own registered name regardless of what you send, and flags it as unconfirmed. **I have not independently verified it** — that needs a real voucher mutation against a live account, which I won't do. I've adopted the documentation change anyway, because the guidance is correct either way: `TransactionInformation` is unambiguously the per-line free-text field, and `Description` is at best unreliable for that purpose.

Worth confirming against a live account before we state the overwrite behaviour more strongly than "normally".

## Verification

832 tests (up from 829); lint, Prettier, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)