### PR TITLE
chore(release): 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-19
+
 ### Fixed
 
 - **`fortnox_create_voucher` silently dropped per-row fields.** `VoucherRowSchema` declared only `Account`, `Debit`, `Credit` and `Description`, and the MCP SDK strips any argument a schema does not declare — so a per-line note passed as `TransactionInformation` never reached Fortnox, with no error and a voucher that booked fine minus the data. The schema now covers the full `VoucherRowSinglePayloadItem` set: `TransactionInformation`, `CostCenter`, `Project`, `Quantity` and `Removed`. `createVoucher()` already forwarded rows verbatim, so the schema was the only place fields were lost. Same root cause as the Supplier gap in #96; the test asserts the declared property list so it cannot drift again. Thanks to @hedborg (#101).
@@ -206,6 +208,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Table and JSON output modes (auto-detected by TTY, override with `-o`).
 - `noxctl doctor` / `fortnox_status` for setup validation.
 
+[0.7.2]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Magnus-Gille/noxctl/compare/v0.6.1...v0.7.0
 [0.4.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.4.0...v0.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Magnus-Gille/noxctl",
     "source": "github"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "noxctl",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.7.1')
+  .version('0.7.2')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.7.1',
+    version: '0.7.2',
   });
 
   registerCustomerTools(server);


### PR DESCRIPTION
Ships the #101 fix from #102: `fortnox_create_voucher` no longer silently drops `TransactionInformation`, `CostCenter`, `Project` and `Quantity` from voucher rows.

`npm run check:release` passes: lint, Prettier, build, 832 tests, production audit, package dry-run. 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)