### PR TITLE
fix: speed up financial reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-27
+
+### Fixed
+
+- **Income statements and balance sheets no longer fetch every voucher sequentially.** Voucher detail reads now use a five-worker pool while the shared Fortnox client continues to enforce the 25-request-per-5-second limit. This removes round-trip latency as the dominant per-voucher bottleneck for large financial years. Removed voucher rows (`Removed: true`) are also excluded from report totals because Fortnox has replaced those rows. Thanks to @MountRose76 for the report, measurements, diagnosis, and independent result comparison (#108).
+
 ## [0.7.2] - 2026-08-19
 
 ### Fixed

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,7 +8,7 @@
 
 - **#108 — slow financial reports.** Voucher detail reads now use a five-worker pool while the shared Fortnox client remains responsible for the 25-request/5-second rate limit. Six-detail regression coverage proves requests overlap and never exceed five in flight.
 - Financial reports now exclude voucher rows with `Removed: true`, matching the bookkeeping tool's existing contract that removed rows were replaced and must not be counted.
-- Red/green verification captured both defects: concurrency was exactly one before the fix, and a removed row inflated the fixture total from 3,500 to 13,500. `npm run verify` passes (73 files, 833 tests).
+- Red/green verification captured both defects: concurrency was exactly one before the fix, and a removed row inflated the fixture total from 3,500 to 13,500. `npm run check:release` passes for `0.7.3` (73 files, 833 tests, zero production vulnerabilities, package dry-run successful).
 
 ## Previous Session (2026-08-19)
 
@@ -30,20 +30,21 @@ Found and fixed without being reported:
 
 ## In Progress
 
-Issue #108 is committed locally as `2e8d56d`. The branch has not been pushed and no PR has been opened.
+Issue #108 and release candidate `0.7.3` are published for review in PR #109 from `fix/issue-108-report-voucher-concurrency`. Codex review and CI are the remaining merge gates.
 
 ## Blockers
 
-None for the local #108 fix.
+None for PR #109 or the planned `0.7.3` release.
 
 ## Next Steps
 
-1. Push `fix/issue-108-report-voucher-concurrency` and open a PR for #108 when explicitly requested.
-2. Triage open API-drift issue #107 independently of this user fix.
-3. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
-4. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
-5. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
-6. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
+1. Merge PR #109 after Codex review and all CI jobs pass, then tag and publish `v0.7.3` from the exact merge commit.
+2. Verify the npm package and GitHub release, then notify and credit @MountRose76 on issue #108.
+3. Triage open API-drift issue #107 independently of this user fix.
+4. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
+5. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
+6. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
+7. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
 
 ## Notes
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,16 @@
 # Project Status
 
-**Last session:** 2026-08-19
-**Branch:** `main` at `17aef1d` (synchronized with `origin/main`)
-**Published:** `v0.7.0`, `v0.7.1`, `v0.7.2` tagged and released on GitHub. **npm still serves `0.6.1`** — see Blockers.
+**Last session:** 2026-08-27
+**Branch:** `fix/issue-108-report-voucher-concurrency`, with implementation commit `2e8d56d`, based on `main` at `4807d3c`
+**Published:** `v0.7.2` on GitHub and `noxctl@0.7.2` on npm (registry verified 2026-08-27)
 
 ## Completed This Session
+
+- **#108 — slow financial reports.** Voucher detail reads now use a five-worker pool while the shared Fortnox client remains responsible for the 25-request/5-second rate limit. Six-detail regression coverage proves requests overlap and never exceed five in flight.
+- Financial reports now exclude voucher rows with `Removed: true`, matching the bookkeeping tool's existing contract that removed rows were replaced and must not be counted.
+- Red/green verification captured both defects: concurrency was exactly one before the fix, and a removed row inflated the fixture total from 3,500 to 13,500. `npm run verify` passes (73 files, 833 tests).
+
+## Previous Session (2026-08-19)
 
 Three externally reported issues fixed, plus both open Dependabot PRs, across six merged PRs.
 
@@ -24,23 +30,24 @@ Found and fixed without being reported:
 
 ## In Progress
 
-Nothing. Working tree clean, no open PRs.
+Issue #108 is committed locally as `2e8d56d`. The branch has not been pushed and no PR has been opened.
 
 ## Blockers
 
-- **`npm publish` has not run.** npm serves `0.6.1` as `latest` while GitHub advertises v0.7.2. It stops at the 2FA one-time password, which needs an interactive terminal — run `npm publish` from the repo root on `main`. A single publish ships all three releases, since 0.7.2 supersedes 0.7.0/0.7.1.
-- Rollback if needed: `npm dist-tag add noxctl@0.6.1 latest`, then `npm deprecate noxctl@0.7.2 "<reason>"`.
+None for the local #108 fix.
 
 ## Next Steps
 
-1. **Run `npm publish`** (see Blockers) — the only thing between this work and users.
-2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules. This is the highest-value remaining work.
-3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it. An `npm version` hook or release workflow removes the class.
-4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
-5. `#13` (bank transactions) remains blocked upstream. The 2026-08-17 spec added `/api/bank-process-*`, but those are company-formation/KYC onboarding, not transactions. Revisit only if the drift workflow reports a genuinely transactional bank path.
+1. Push `fix/issue-108-report-voucher-concurrency` and open a PR for #108 when explicitly requested.
+2. Triage open API-drift issue #107 independently of this user fix.
+3. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
+4. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
+5. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
+6. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
 
 ## Notes
 
 - Two rounds of Codex cross-model review (gpt-5.6-sol, high effort) ran on #97 and caught three real problems, including a terminal-escape regression introduced during the fix and a legacy-credential renewal bug that would have broken untouched installs on refresh. `LEGACY_SCOPES` exists because of that second finding — it is frozen history and must never be edited.
+- Issue #108 received a fresh local `qwen3-coder-next-80b` review after deterministic checks. Its proposed JavaScript data races and removed-row test gap were validated and declined: no code can interleave inside the synchronous index claim, and the removed fixture demonstrably failed before the exclusion.
 - Local `backup/pre-rewrite-*` branches must never be pushed publicly (pre-sanitization history).
 - @hedborg has filed three high-quality reports with root-cause analysis and tested patches, and has offered PRs each time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Magnus-Gille/noxctl",
     "source": "github"
   },
-  "version": "0.7.2",
+  "version": "0.7.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "noxctl",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.7.2')
+  .version('0.7.3')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.7.2',
+    version: '0.7.3',
   });
 
   registerCustomerTools(server);

--- a/src/operations/financial-reports.ts
+++ b/src/operations/financial-reports.ts
@@ -16,7 +16,10 @@ interface VoucherRow {
   Account: number;
   Debit: number;
   Credit: number;
+  Removed?: boolean;
 }
+
+const VOUCHER_DETAIL_CONCURRENCY = 5;
 
 interface VouchersResponse {
   Vouchers: { VoucherRows?: VoucherRow[]; [key: string]: unknown }[];
@@ -151,19 +154,38 @@ async function fetchVoucherSums(
     page++;
   } while (page <= totalPages);
 
-  // Step 2: Fetch each voucher individually to get VoucherRows
+  // Step 2: Fetch voucher details concurrently. The shared client still owns
+  // rate limiting; this pool only keeps network latency from serialising reads.
   const yearParam = financialYear ? `?financialyear=${financialYear}` : '';
-  for (const v of vouchers) {
-    const detail = await fortnoxRequest<VoucherDetailResponse>(
-      `vouchers/${encodeURIComponent(v.series)}/${v.number}${yearParam}`,
-    );
-    for (const row of detail.Voucher.VoucherRows ?? []) {
-      const existing = sums.get(row.Account) ?? { debit: 0, credit: 0 };
-      existing.debit += row.Debit || 0;
-      existing.credit += row.Credit || 0;
-      sums.set(row.Account, existing);
+  let nextVoucherIndex = 0;
+  let failure: unknown;
+
+  async function worker(): Promise<void> {
+    while (failure === undefined) {
+      const voucherIndex = nextVoucherIndex++;
+      if (voucherIndex >= vouchers.length) return;
+      const voucher = vouchers[voucherIndex]!;
+
+      try {
+        const detail = await fortnoxRequest<VoucherDetailResponse>(
+          `vouchers/${encodeURIComponent(voucher.series)}/${voucher.number}${yearParam}`,
+        );
+        for (const row of detail.Voucher.VoucherRows ?? []) {
+          if (row.Removed === true) continue;
+          const existing = sums.get(row.Account) ?? { debit: 0, credit: 0 };
+          existing.debit += row.Debit || 0;
+          existing.credit += row.Credit || 0;
+          sums.set(row.Account, existing);
+        }
+      } catch (error) {
+        failure = error;
+      }
     }
   }
+
+  const workerCount = Math.min(VOUCHER_DETAIL_CONCURRENCY, vouchers.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (failure !== undefined) throw failure;
 
   return sums;
 }

--- a/tests/operations/financial-reports.test.ts
+++ b/tests/operations/financial-reports.test.ts
@@ -25,6 +25,53 @@ describe('financial reports operations', () => {
   });
 
   describe('getIncomeStatement', () => {
+    it('fetches voucher details with bounded concurrency', async () => {
+      let activeDetailRequests = 0;
+      let maxActiveDetailRequests = 0;
+
+      global.fetch = vi.fn().mockImplementation(async (input: string | URL | Request) => {
+        const url = String(input);
+        let response: unknown;
+
+        if (url.includes('/3/accounts')) {
+          response = {
+            Accounts: [{ Number: 3001, Description: 'Försäljning', BalanceBroughtForward: 0 }],
+            MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+          };
+        } else if (url.includes('/3/vouchers?')) {
+          response = {
+            Vouchers: Array.from({ length: 6 }, (_, index) => ({
+              VoucherSeries: 'A',
+              VoucherNumber: index + 1,
+            })),
+            MetaInformation: { '@TotalPages': 1, '@CurrentPage': 1 },
+          };
+        } else {
+          activeDetailRequests++;
+          maxActiveDetailRequests = Math.max(maxActiveDetailRequests, activeDetailRequests);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          activeDetailRequests--;
+          response = {
+            Voucher: { VoucherRows: [{ Account: 3001, Debit: 0, Credit: 100 }] },
+          };
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(response)),
+          json: () => Promise.resolve(response),
+        };
+      });
+
+      const { getIncomeStatement } = await import('../../src/operations/financial-reports.js');
+      const report = await getIncomeStatement();
+
+      expect(maxActiveDetailRequests).toBeGreaterThan(1);
+      expect(maxActiveDetailRequests).toBeLessThanOrEqual(5);
+      expect(report.netResult).toBe(-600);
+    });
+
     it('groups revenue and expense accounts correctly', async () => {
       // Call 1: accounts page 1 (with meta saying 1 page)
       // Call 2: vouchers list (returns 2 vouchers)
@@ -57,6 +104,7 @@ describe('financial reports operations', () => {
           Voucher: {
             VoucherRows: [
               { Account: 5410, Debit: 3000, Credit: 0 },
+              { Account: 5410, Debit: 10000, Credit: 0, Removed: true },
               { Account: 6570, Debit: 500, Credit: 0 },
               { Account: 1930, Debit: 0, Credit: 3500 },
             ],


### PR DESCRIPTION
## Summary

- fetch voucher details for income statements and balance sheets with a bounded five-worker pool
- keep the shared Fortnox client as the single rate-limit authority
- exclude `Removed: true` voucher rows from financial-report totals
- prepare patch release `0.7.3`

Thanks @MountRose76 for reporting the issue, measuring the sequential slowdown, identifying the fetch loop as the bottleneck, and independently comparing the resulting income-statement totals.

Closes #108.

## Verification

- red/green concurrency regression: maximum active detail requests was 1 before the fix and is bounded at 5 after it
- red/green removed-row regression: the fixture total was incorrectly 13,500 before the fix and is 3,500 after it
- `npm run check:release`
  - ESLint and Prettier
  - TypeScript build
  - 73 test files / 833 tests
  - 0 production vulnerabilities
  - `npm pack --dry-run --ignore-scripts` for `noxctl@0.7.3`

## Release

On merge, tag the exact merge commit as `v0.7.3`, publish `noxctl@0.7.3`, create the GitHub release from the credited changelog entry, and verify both npm and GitHub resolve to the same release.
