### PR TITLE
docs: refresh repository front page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ keychain-backed tests.
 > installs noxctl.
 
 ```bash
-git clone https://github.com/Magnus-Gille/fortnox-mcp.git
-cd fortnox-mcp
+git clone https://github.com/Magnus-Gille/noxctl.git
+cd noxctl
 npm install
 npm run build
 ```
@@ -35,7 +35,7 @@ npm run build
 Common scripts:
 
 ```bash
-npm test              # Vitest — 832 unit tests
+npm test              # Vitest — 833 unit tests
 npm run test:watch    # Vitest in watch mode
 npm run test:live     # Live Fortnox tests (requires credentials — opt-in)
 npm run lint          # ESLint (typescript-eslint)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ npm run build
 Common scripts:
 
 ```bash
-npm test              # Vitest — 833 unit tests
+npm test              # Vitest unit suite
 npm run test:watch    # Vitest in watch mode
 npm run test:live     # Live Fortnox tests (requires credentials — opt-in)
 npm run lint          # ESLint (typescript-eslint)

--- a/README.md
+++ b/README.md
@@ -1,31 +1,66 @@
 # noxctl
 
-Command-line interface (CLI) and Model Context Protocol (MCP) server for Fortnox — manage invoices, customers, bookkeeping, and VAT (Value Added Tax) from the terminal or from AI (Artificial Intelligence) agents like Claude Code.
+[![CI](https://github.com/Magnus-Gille/noxctl/actions/workflows/ci.yml/badge.svg)](https://github.com/Magnus-Gille/noxctl/actions/workflows/ci.yml) [![npm](https://img.shields.io/npm/v/noxctl?logo=npm)](https://www.npmjs.com/package/noxctl) [![Node.js](https://img.shields.io/node/v/noxctl?logo=node.js)](https://www.npmjs.com/package/noxctl) [![License: MIT](https://img.shields.io/github/license/Magnus-Gille/noxctl)](LICENSE)
 
-```
+**Fortnox from the terminal — or from an MCP-compatible AI assistant.**
+
+noxctl is a command-line interface (CLI) and Model Context Protocol (MCP) server for
+invoices, customers, suppliers, bookkeeping, VAT, payroll, and more. Fortnox operations
+share the same CLI and MCP command surface, so you can use noxctl interactively, in
+scripts, or through tools such as Claude Code.
+
+You bring your own Fortnox developer app. Credentials stay in your operating system's
+secure store, and requests go directly from your machine to the Fortnox API — there is
+no shared credential and no backend operated by this project.
+
+> [!IMPORTANT]
+> noxctl is an independent, **unofficial** open-source project. It is **not affiliated
+> with, endorsed by, or certified by Fortnox AB.** You remain responsible for reviewing
+> every operation and complying with applicable terms and accounting, tax, payroll, and
+> privacy rules. See the full [Disclaimer](#disclaimer).
+
+## Why noxctl?
+
+- **One interface, two ways to work:** Fortnox operations are available from both the
+  CLI and MCP; local setup and profile utilities stay in the CLI.
+- **Safe writes by default:** mutations prompt for confirmation, fail closed when piped,
+  and support `--dry-run` / `dryRun` previews.
+- **Built for automation:** human-readable tables in a terminal and stable JSON when
+  piped or requested explicitly.
+- **Local credential control:** OAuth credentials are stored in macOS Keychain, Linux
+  Secret Service, or a DPAPI-protected Windows store.
+- **Multiple companies:** named profiles keep Fortnox tenants separate.
+
+## Quick start
+
+You need Node.js 22.12+, a Fortnox account with API access, and your own Fortnox
+developer app. Linux also requires `secret-tool` for secure credential storage.
+
+```bash
+npm install --global noxctl
 noxctl init                          # interactive setup wizard
-noxctl company info                  # verify connection
+noxctl company info                  # verify the connection
+```
+
+Then explore from the terminal:
+
+```bash
 noxctl customers list                # list customers
 noxctl invoices list --filter unpaid # unpaid invoices
 noxctl -o json invoices list | jq .  # JSON output for scripting/AI
 ```
 
-## Status
+Prefer not to install globally? Replace `noxctl` in any command with `npx noxctl`.
 
-noxctl is an independent, **unofficial** open-source project. It is **not affiliated with, endorsed by, or certified by Fortnox AB.**
-
-Use it with your own Fortnox account and developer credentials. **It is provided "as is", with no warranty and no liability — the author takes no responsibility for anything you do with it; you use it entirely at your own risk and are responsible for complying with Fortnox terms, Swedish bookkeeping/tax/payroll rules, and your own privacy obligations.** See the full [Disclaimer](#disclaimer).
-
-## Prerequisites
-
-- **Node.js** 22.12+
-- **Fortnox account** with API (Application Programming Interface) access
-- **Your own Fortnox developer app** with the required scopes enabled
-- **Linux only:** `secret-tool` available for secure credential storage
-
-Fortnox product plans, API activation requirements, and integration licensing can change. Verify the current Fortnox requirements before publishing or relying on this setup for business-critical work.
+**Documentation:** [full setup](#setup) · [profiles](#profiles-multi-tenant) ·
+[commands and MCP tools](#tools) · [mutation safety](#mutation-safety) ·
+[troubleshooting](#troubleshooting) · [contributing](CONTRIBUTING.md)
 
 ## Setup
+
+Fortnox product plans, API activation requirements, and integration licensing can
+change. Verify the current Fortnox requirements before publishing or relying on this
+setup for business-critical work.
 
 ### How it connects to Fortnox
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ noxctl invoices list --filter unpaid # unpaid invoices
 noxctl -o json invoices list | jq .  # JSON output for scripting/AI
 ```
 
-Prefer not to install globally? Replace `noxctl` in any command with `npx noxctl`.
+Prefer not to install globally? Skip the install command and run CLI commands as `npx noxctl <command>` instead.
 
 **Documentation:** [full setup](#setup) · [profiles](#profiles-multi-tenant) ·
 [commands and MCP tools](#tools) · [mutation safety](#mutation-safety) ·

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you think you have found a security issue in noxctl, please report it privately
 so it can be investigated and fixed before public disclosure.
 
-- **Preferred:** open a [private security advisory](https://github.com/Magnus-Gille/fortnox-mcp/security/advisories/new) on GitHub.
+- **Preferred:** open a [private security advisory](https://github.com/Magnus-Gille/noxctl/security/advisories/new) on GitHub.
 - **Email:** `magnus.gille@outlook.com` with the subject `noxctl security`.
 
 Please include:

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,16 @@
 # Project Status
 
-**Last session:** 2026-08-27
-**Branch:** `main` contains release commit `34ebf874c97f887111c428974f13effa95f7f4b2`
+**Last session:** 2026-08-28
+**Branch:** `docs/refresh-readme-front-page` (local, not published)
 **Published:** `v0.7.3` on GitHub and `noxctl@0.7.3` on npm (both verified 2026-08-27)
 
 ## Completed This Session
+
+- Refreshed the README opening for first-time visitors: trust model, native GitHub badges/callout, accurate value summary, global-install and `npx` quick starts, and navigation into the long-form reference.
+- Corrected stale pre-rename clone and private-security-advisory links, and added canonical repository/bugs/homepage plus discovery keywords to npm package metadata.
+- Verified GitHub Markdown rendering, local links/anchors, package metadata and dry-run contents, lint, TypeScript formatting, build, and all 833 tests across 73 files. The public Open Graph preview is clean but still uses the old Claude-specific GitHub About description until that repository metadata is updated.
+
+## Previous Session (2026-08-27)
 
 - **#108 — slow financial reports.** Voucher detail reads now use a five-worker pool while the shared Fortnox client remains responsible for the 25-request/5-second rate limit. Six-detail regression coverage proves requests overlap and never exceed five in flight.
 - Financial reports now exclude voucher rows with `Removed: true`, matching the bookkeeping tool's existing contract that removed rows were replaced and must not be counted.
@@ -33,7 +39,7 @@ Found and fixed without being reported:
 
 ## In Progress
 
-Nothing. Issue #108 is closed and `0.7.3` is released.
+The README/front-page refresh is complete locally. Publishing requires an owner-approved push/PR plus an explicit GitHub About metadata update (description, npm homepage, and topics).
 
 ## Blockers
 
@@ -41,10 +47,11 @@ None.
 
 ## Next Steps
 
-1. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
-2. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
-3. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
-4. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
+1. Publish `docs/refresh-readme-front-page` through a pull request and update the GitHub About description/homepage/topics after explicit owner approval.
+2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
+3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
+4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
+5. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
 
 ## Notes
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,14 +1,15 @@
 # Project Status
 
 **Last session:** 2026-08-28
-**Branch:** `docs/refresh-readme-front-page` (local, not published)
+**Branch:** `docs/refresh-readme-front-page` (published as PR #112)
 **Published:** `v0.7.3` on GitHub and `noxctl@0.7.3` on npm (both verified 2026-08-27)
 
 ## Completed This Session
 
-- Refreshed the README opening for first-time visitors: trust model, native GitHub badges/callout, accurate value summary, global-install and `npx` quick starts, and navigation into the long-form reference.
+- Refreshed the README opening for first-time visitors: trust model, badges and a GitHub-native callout, accurate value summary, global-install and `npx` quick starts, and navigation into the long-form reference.
 - Corrected stale pre-rename clone and private-security-advisory links, and added canonical repository/bugs/homepage plus discovery keywords to npm package metadata.
-- Verified GitHub Markdown rendering, local links/anchors, package metadata and dry-run contents, lint, TypeScript formatting, build, and all 833 tests across 73 files. The public Open Graph preview is clean but still uses the old Claude-specific GitHub About description until that repository metadata is updated.
+- Verified GitHub Markdown rendering, local links/anchors, package metadata and dry-run contents, lint, TypeScript formatting, build, and all 833 tests across 73 files.
+- Published PR #112 and updated the GitHub About description, npm homepage, and ten discovery topics. The refreshed public Open Graph metadata now uses the broader CLI/MCP positioning.
 
 ## Previous Session (2026-08-27)
 
@@ -39,7 +40,7 @@ Found and fixed without being reported:
 
 ## In Progress
 
-The README/front-page refresh is complete locally. Publishing requires an owner-approved push/PR plus an explicit GitHub About metadata update (description, npm homepage, and topics).
+PR #112 is open for the README/front-page refresh. The GitHub About metadata is live; merge only after required CI passes on the final PR head.
 
 ## Blockers
 
@@ -47,7 +48,7 @@ None.
 
 ## Next Steps
 
-1. Publish `docs/refresh-readme-front-page` through a pull request and update the GitHub About description/homepage/topics after explicit owner approval.
+1. Review and merge PR #112 after required CI passes; no automatic merge is configured.
 2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
 3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
 4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "noxctl",
   "version": "0.7.3",
   "mcpName": "io.github.magnus-gille/noxctl",
-  "description": "CLI and MCP server for Fortnox accounting \u2014 invoices, customers, bookkeeping, and VAT",
+  "description": "CLI and MCP server for Fortnox \u2014 invoices, bookkeeping, VAT, payroll, and automation",
   "type": "module",
   "bin": {
     "noxctl": "dist/cli.js"
@@ -27,7 +27,10 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "fortnox",
+    "cli",
+    "automation",
     "accounting",
     "invoicing",
     "bookkeeping",
@@ -35,6 +38,14 @@
   ],
   "author": "Magnus Gille",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Magnus-Gille/noxctl.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Magnus-Gille/noxctl/issues"
+  },
+  "homepage": "https://github.com/Magnus-Gille/noxctl#readme",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary

- give first-time visitors a concise product overview, trust model, quick start, and navigation
- add CI, npm, Node.js, and license badges plus a GitHub-native unofficial-project callout
- fix stale pre-rename contributor and security links
- add canonical npm repository, issues, homepage, and discovery metadata

## Verification

- npm run verify: 73 test files and 833 tests passed
- GitHub Markdown rendering checked
- local Markdown links and anchors checked
- npm package dry-run checked
- independent local review passed