### PR TITLE
chore(release): 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-28
+
+### Changed
+
+- Refreshed the repository front page for first-time visitors with a concise trust model, feature summary, quick start, status badges, and navigation into the full reference.
+- Added canonical npm repository, issue, homepage, and discovery metadata so package registries and tooling link back to the correct project surfaces.
+
+### Fixed
+
+- Corrected contributor clone instructions and the private security-advisory link that still used the repository's former `fortnox-mcp` name.
+
 ## [0.7.3] - 2026-08-27
 
 ### Fixed
@@ -214,6 +225,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Table and JSON output modes (auto-detected by TTY, override with `-o`).
 - `noxctl doctor` / `fortnox_status` for setup validation.
 
+[0.7.4]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Magnus-Gille/noxctl/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Magnus-Gille/noxctl/compare/v0.6.1...v0.7.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,11 @@ host rollout.
 
 1. Land everything on `main` and confirm CI is green.
 2. Promote `## [Unreleased]` to the new version in `CHANGELOG.md`.
-3. Bump the version in **three** places — they are separate literals and have
-   drifted before: `package.json`, `.version(...)` in `src/cli.ts`, and
-   `version:` in `src/index.ts` (the MCP server's `serverInfo`, which is what
-   connected clients see). `tests/cli.test.ts` asserts all three agree.
+3. Bump the version in **five files** — they are separate literals and have
+   drifted before: `package.json`, `package-lock.json`, `.version(...)` in
+   `src/cli.ts`, `version:` in `src/index.ts` (the MCP server's `serverInfo`),
+   and both version fields in `server.json`. `tests/cli.test.ts` asserts the
+   three code-facing versions agree; verify `server.json` separately.
 4. `npm run check:release` — lint, format, build, tests, production audit, and a
    package dry-run.
 5. Commit, open a PR, merge once CI passes.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Project Status
 
 **Last session:** 2026-08-28
-**Branch:** `docs/refresh-readme-front-page` (published as PR #112)
+**Branch:** `release/0.7.4` (local release preparation)
 **Published:** `v0.7.3` on GitHub and `noxctl@0.7.3` on npm (both verified 2026-08-27)
 
 ## Completed This Session
@@ -10,6 +10,7 @@
 - Corrected stale pre-rename clone and private-security-advisory links, and added canonical repository/bugs/homepage plus discovery keywords to npm package metadata.
 - Verified GitHub Markdown rendering, local links/anchors, package metadata and dry-run contents, lint, TypeScript formatting, build, and all 833 tests across 73 files.
 - Published PR #112 and updated the GitHub About description, npm homepage, and ten discovery topics. The refreshed public Open Graph metadata now uses the broader CLI/MCP positioning.
+- Codex review found and fixed two documentation issues before PR #112 merged as `6be163c60856da775b05470a0100b0af65adae8c`: an over-broad `npx` instruction and a brittle hard-coded test count.
 
 ## Previous Session (2026-08-27)
 
@@ -40,7 +41,7 @@ Found and fixed without being reported:
 
 ## In Progress
 
-PR #112 is open for the README/front-page refresh. The GitHub About metadata is live; merge only after required CI passes on the final PR head.
+The GitHub front-page refresh is live on `main`. Patch release 0.7.4 is being prepared so the new README and canonical package discovery metadata also reach npm; the local release gate passes with 833 tests and zero production vulnerabilities.
 
 ## Blockers
 
@@ -48,7 +49,7 @@ None.
 
 ## Next Steps
 
-1. Review and merge PR #112 after required CI passes; no automatic merge is configured.
+1. Open and merge the protected 0.7.4 release PR, then request exact-SHA confirmation before tagging and publishing to npm.
 2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
 3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
 4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noxctl",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noxctl",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noxctl",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "mcpName": "io.github.magnus-gille/noxctl",
   "description": "CLI and MCP server for Fortnox \u2014 invoices, bookkeeping, VAT, payroll, and automation",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Magnus-Gille/noxctl",
     "source": "github"
   },
-  "version": "0.7.3",
+  "version": "0.7.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "noxctl",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,7 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 program
   .name('noxctl')
   .description('CLI and MCP server for Fortnox accounting')
-  .version('0.7.3')
+  .version('0.7.4')
   .addOption(
     new Option('-o, --output <format>', 'Output format (default: table on TTY, json when piped)')
       .choices(['json', 'table'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { registerScheduleTimeTools } from './tools/scheduletimes.js';
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'fortnox-mcp',
-    version: '0.7.3',
+    version: '0.7.4',
   });
 
   registerCustomerTools(server);


### PR DESCRIPTION
## Summary

- prepare noxctl 0.7.4 so the merged README and canonical package discovery metadata reach npm
- update all six version literals across five release files
- add the 0.7.4 changelog entry and correct the maintainer release checklist

## Verification

- npm run check:release passed
- 73 test files and 833 tests passed
- npm audit --omit=dev: zero vulnerabilities
- npm pack dry-run: noxctl@0.7.4, 283 files
- all six release version literals verified as 0.7.4
- independent qwen35-122b-a10b review: PASS