### PR TITLE
docs: record v0.7.4 deployment

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status
 
 **Last session:** 2026-08-28
-**Branch:** `release/0.7.4` (local release preparation)
-**Published:** `v0.7.3` on GitHub and `noxctl@0.7.3` on npm (both verified 2026-08-27)
+**Branch:** `docs/release-0.7.4-handoff`
+**Published:** `v0.7.4` on GitHub and `noxctl@0.7.4` on npm (both verified 2026-08-28)
 
 ## Completed This Session
 
@@ -11,6 +11,8 @@
 - Verified GitHub Markdown rendering, local links/anchors, package metadata and dry-run contents, lint, TypeScript formatting, build, and all 833 tests across 73 files.
 - Published PR #112 and updated the GitHub About description, npm homepage, and ten discovery topics. The refreshed public Open Graph metadata now uses the broader CLI/MCP positioning.
 - Codex review found and fixed two documentation issues before PR #112 merged as `6be163c60856da775b05470a0100b0af65adae8c`: an over-broad `npx` instruction and a brittle hard-coded test count.
+- Prepared and reviewed release PR #114, then merged it as `db369322955cae863ac1a372fa8cba6cb67c3712`. The release gate passed with 833 tests across 73 files, zero production vulnerabilities, and a successful package dry run.
+- Published `noxctl@0.7.4` to npm and created the matching GitHub release. npm `latest` resolves to `0.7.4`; the registry SHA-1 `6180f1632a31f5ee3e29e921e5b09bfd0b592e19` matches the reviewed tarball, and a clean install reports `0.7.4`.
 
 ## Previous Session (2026-08-27)
 
@@ -41,7 +43,7 @@ Found and fixed without being reported:
 
 ## In Progress
 
-The GitHub front-page refresh is live on `main`. Patch release 0.7.4 is being prepared so the new README and canonical package discovery metadata also reach npm; the local release gate passes with 833 tests and zero production vulnerabilities.
+No active release work. The GitHub front-page refresh and `noxctl@0.7.4` are live.
 
 ## Blockers
 
@@ -49,11 +51,10 @@ None.
 
 ## Next Steps
 
-1. Open and merge the protected 0.7.4 release PR, then request exact-SHA confirmation before tagging and publishing to npm.
-2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
-3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
-4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
-5. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
+1. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
+2. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
+3. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
+4. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- record the verified npm and GitHub v0.7.4 deployment
- capture the exact release commit and registry artifact hash
- remove completed release work from the active next steps

## Verification

- npm registry reports `latest` as `0.7.4`
- registry SHA-1 matches the reviewed tarball
- clean install reports `noxctl --version` as `0.7.4`
- GitHub release tag resolves to `db369322955cae863ac1a372fa8cba6cb67c3712`
- `git diff --cached --check` passed before commit