### PR TITLE
fix: fail closed on inaccessible credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,31 @@ Non-default sessions print a `[profile: <name>]` stderr banner on startup and pr
 
 If the active pointer becomes unreadable or corrupt and no explicit `--profile` flag or `NOXCTL_PROFILE` is set, `noxctl serve` **refuses to start** rather than silently falling back to `default`. This prevents a corrupted pointer from routing production MCP sessions to the wrong tenant. The CLI's `doctor` and `profile use` commands are exempt — they can still run against a broken pointer so you can repair it.
 
+### Credential recovery from sandboxes and automation
+
+Credential diagnostics use the same four states in `doctor`, `keychain status`,
+and MCP status: `available`, `missing`, `locked`, and `inaccessible`. Only
+`missing` means no registered profile or credential was found. `inaccessible`
+means noxctl cannot safely determine whether credentials exist in the current
+execution context; it will not recommend or start OAuth replacement from that
+state.
+
+Use this recovery flow when a sandboxed agent and your terminal disagree:
+
+```bash
+# Run these in a normal, unsandboxed terminal.
+noxctl keychain status
+noxctl keychain unlock                    # only when the dedicated keychain is locked
+noxctl --profile <name> doctor
+noxctl --profile <name> company info
+```
+
+Do not re-run `noxctl init` while the state is `locked` or `inaccessible`.
+Resolve access first, then retry with an explicit profile. An MCP server is
+pinned to the profile selected when that process starts; changing the active
+pointer does not retarget it. Restart the MCP server after correcting profile
+selection or unlocking credentials.
+
 ## YubiKey-locked keychain (macOS)
 
 By default, credentials live in your macOS **login keychain**, which unlocks automatically when you log in. That's convenient, but it means an AI agent (or anything running as you) can read the tokens without a per-session gesture from you.
@@ -608,7 +633,12 @@ Once authorized, the tokens are stored in the OS keychain. No env vars are neede
 
 **"Not authenticated. Run `noxctl init`"**
 
-Credentials are missing or were not saved. Re-run the setup step. On macOS, check that Keychain Access is not blocking the `security` command. On Linux, ensure `secret-tool` is installed (`sudo apt install libsecret-tools`).
+This message is emitted only when the credential state is `missing`. Re-run the
+setup step. If the message instead says `locked` or `inaccessible`, do not
+replace the credentials: follow the
+[sandbox/automation recovery flow](#credential-recovery-from-sandboxes-and-automation).
+On Linux, an inaccessible store can also mean that `secret-tool` is unavailable
+(`sudo apt install libsecret-tools`).
 
 **403 Forbidden from Fortnox API**
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,29 @@
 # Project Status
 
-**Last session:** 2026-08-28
-**Branch:** `feat/122-embedded-api` (stacked on `feat/119-tenant-client` → `feat/120-client-bound-operations` → `feat/121-tenant-bound-mcp`)
+**Last session:** 2026-08-29
+**Branch:** `fix/117-keychain-recovery`
 **Published:** `v0.7.4` on GitHub and `noxctl@0.7.4` on npm (both verified 2026-08-28)
 
 ## Completed This Session
+
+- Implemented #117's fail-closed credential recovery model. Auth, CLI doctor,
+  `keychain status`, profile selection, init, and MCP status now share the
+  explicit states `available`, `missing`, `locked`, and `inaccessible`.
+- A registered profile whose credential lookup returns no item is treated as
+  `inaccessible`, so sandbox/keychain ambiguity can no longer lead directly to
+  OAuth replacement. Recovery output identifies the effective profile and
+  source and explains that running MCP processes remain pinned to their startup
+  profile.
+- Hardened macOS dedicated-keychain inspection, Linux `secret-tool` exit-state
+  handling, and Windows DPAPI file/access detection without falling back to a
+  less protected credential store. Added the short sandbox/YubiKey recovery
+  flow to README.
+- Red/green coverage now exercises available, missing, locked, inaccessible,
+  malformed, registered-but-unreadable, Linux, Windows, macOS dedicated-keychain,
+  fail-closed init, doctor, keychain-status, and profile-source cases. Full
+  verification passes with 866 tests across 76 files, zero production
+  vulnerabilities, a passing packed embedded consumer, and a successful npm
+  package dry run.
 
 - Created hosted-product epic #118 and implementation tickets #119–#122 for the public reusable core; the private OAuth/session/token-vault/billing/operations host remains intentionally outside this repository.
 - Added isolated per-tenant Fortnox clients, transport-bound operation factories across all resource families, tenant-bound MCP server construction, and the supported `noxctl/embedded` package entry point while preserving local CLI/stdio behavior.
@@ -48,7 +67,8 @@ Found and fixed without being reported:
 
 ## In Progress
 
-The public hosted-core implementation and its review history are tracked in PR #123. GitHub is authoritative for its current merge state. This work does not include an npm release, deployment, or production-host publication.
+Issue #117 is implemented and verified locally on `fix/117-keychain-recovery`.
+It has not been pushed and no pull request or release has been created.
 
 ## Blockers
 
@@ -56,11 +76,12 @@ No public-core code blocker is known. The private hosted product still depends o
 
 ## Next Steps
 
-1. Start the private `noxctl-cloud` repository only after Fortnox has answered the partner/App Market, OAuth, commercial, and data-processing questions recorded in epic #118.
-2. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
-3. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
-4. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
-5. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
+1. Review and publish `fix/117-keychain-recovery` as a pull request; no release is bundled with this change.
+2. Start the private `noxctl-cloud` repository only after Fortnox has answered the partner/App Market, OAuth, commercial, and data-processing questions recorded in epic #118.
+3. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
+4. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.
+5. Confirm against a live account whether Fortnox really overwrites voucher-row `Description` with the account's registered name. Adopted from @hedborg's report but **not independently verified** — verifying needs a real voucher mutation. The docs currently say "normally".
+6. `#13` (bank transactions) remains blocked upstream. Revisit only if the drift workflow reports a genuinely transactional bank path.
 
 ## Notes
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -67,8 +67,8 @@ Found and fixed without being reported:
 
 ## In Progress
 
-Issue #117 is implemented and verified locally on `fix/117-keychain-recovery`.
-It has not been pushed and no pull request or release has been created.
+Issue #117 is implemented and verified on `fix/117-keychain-recovery` and is
+published for review in PR #124. No release has been created.
 
 ## Blockers
 
@@ -76,7 +76,7 @@ No public-core code blocker is known. The private hosted product still depends o
 
 ## Next Steps
 
-1. Review and publish `fix/117-keychain-recovery` as a pull request; no release is bundled with this change.
+1. Review and merge PR #124 after its required checks pass; no release is bundled with this change.
 2. Start the private `noxctl-cloud` repository only after Fortnox has answered the partner/App Market, OAuth, commercial, and data-processing questions recorded in epic #118.
 3. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
 4. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -20,8 +20,11 @@
   flow to README.
 - Red/green coverage now exercises available, missing, locked, inaccessible,
   malformed, registered-but-unreadable, Linux, Windows, macOS dedicated-keychain,
-  fail-closed init, doctor, keychain-status, and profile-source cases. Full
-  verification passes with 866 tests across 76 files, zero production
+  fail-closed init, doctor, keychain-status, and profile-source cases.
+- PR #124 review found and fixed two recovery gaps before merge: a sandbox-hidden
+  dedicated keychain could still fall back to the login keychain, and
+  `keychain status` omitted the shared credential state on non-macOS platforms.
+  The post-review gate passes with 867 tests across 76 files, zero production
   vulnerabilities, a passing packed embedded consumer, and a successful npm
   package dry run.
 
@@ -67,8 +70,8 @@ Found and fixed without being reported:
 
 ## In Progress
 
-Issue #117 is implemented and verified on `fix/117-keychain-recovery` and is
-published for review in PR #124. No release has been created.
+Issue #117 is implemented and verified on `fix/117-keychain-recovery` in PR
+#124. No release has been created.
 
 ## Blockers
 
@@ -76,7 +79,7 @@ No public-core code blocker is known. The private hosted product still depends o
 
 ## Next Steps
 
-1. Review and merge PR #124 after its required checks pass; no release is bundled with this change.
+1. Decide when to release the merged #117 fix; no release is bundled with PR #124.
 2. Start the private `noxctl-cloud` repository only after Fortnox has answered the partner/App Market, OAuth, commercial, and data-processing questions recorded in epic #118.
 3. **Close the schema-drift bug class.** #96 and #101 were the same defect: a hand-maintained Zod schema drifting from the Fortnox spec, with the MCP SDK silently discarding undeclared arguments. A test diffing each write tool's declared schema against the cached OpenAPI payload schema would catch the next one across all 27 resource modules.
 4. **Automate the version bump.** Five files carry the version (`package.json`, `package-lock.json`, `src/cli.ts`, `src/index.ts`, `server.json`); `server.json` had silently drifted three releases behind because nothing checks it.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,10 +1,20 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { loadCredentialBlob, saveCredentialBlob, type LoadSource } from './credentials-store.js';
+import {
+  CredentialStoreAccessError,
+  loadCredentialBlob,
+  saveCredentialBlob,
+  type LoadSource,
+} from './credentials-store.js';
 import { KeychainLockedError } from './keychain-target.js';
 import { DEFAULT_PROFILE, validateProfileName } from './profile-name.js';
-import { migrateLegacyIfNeeded, readProfileIndex, upsertProfile } from './profiles.js';
+import {
+  migrateLegacyIfNeeded,
+  readProfileIndex,
+  upsertProfile,
+  type ProfileSource,
+} from './profiles.js';
 
 const FORTNOX_AUTH_URL = 'https://apps.fortnox.se/oauth-v1/auth';
 const FORTNOX_TOKEN_URL = 'https://apps.fortnox.se/oauth-v1/token';
@@ -103,6 +113,7 @@ export interface FortnoxAppConfig {
 // instance would share this state. Revisit if the MCP SDK grows request-local
 // context that handlers can read.
 let resolvedProfile: string = DEFAULT_PROFILE;
+let resolvedProfileSource: ProfileSource = 'default';
 
 // Token endpoints may rotate refresh tokens, so concurrent requests for the
 // same profile must share one refresh and one credential-store write. Profile
@@ -114,12 +125,17 @@ const tokenRefreshes = new Map<string, Promise<string>>();
 // saveCredentials to decide whether to dual-write during the 0.2.x window.
 let legacyObservedForDefault = false;
 
-export function setResolvedProfile(name: string): void {
+export function setResolvedProfile(name: string, source: ProfileSource = 'default'): void {
   resolvedProfile = validateProfileName(name);
+  resolvedProfileSource = source;
 }
 
 export function getResolvedProfile(): string {
   return resolvedProfile;
+}
+
+export function getResolvedProfileSource(): ProfileSource {
+  return resolvedProfileSource;
 }
 
 // Test-only: reset module-level observation state between cases.
@@ -129,6 +145,46 @@ export function __resetLegacyObservedForDefault(): void {
 
 function profileOrResolved(profile?: string): string {
   return profile ?? resolvedProfile;
+}
+
+function sourceForProfile(profile: string): ProfileSource | 'explicit' {
+  return profile.toLowerCase() === resolvedProfile.toLowerCase()
+    ? resolvedProfileSource
+    : 'explicit';
+}
+
+function credentialContext(profile: string): string {
+  return `profile "${profile}" (source: ${sourceForProfile(profile)})`;
+}
+
+function inaccessibleRecovery(profile: string): string {
+  return (
+    `Run \`noxctl keychain status\` and, if needed, \`noxctl keychain unlock\` in an ` +
+    `unsandboxed terminal, then retry with \`--profile ${profile}\`. An already-running MCP ` +
+    `server remains pinned to the profile selected at startup; changing the active profile ` +
+    `pointer will not retarget it, so restart that MCP process after correcting the profile.`
+  );
+}
+
+export type CredentialState = 'available' | 'missing' | 'locked' | 'inaccessible';
+
+export interface CredentialInspection {
+  state: CredentialState;
+  profile: string;
+  source: ProfileSource | 'explicit';
+  credentials: FortnoxCredentials | null;
+  detail: string;
+}
+
+export class CredentialAccessError extends Error {
+  constructor(
+    public readonly profile: string,
+    public readonly source: ProfileSource | 'explicit',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CredentialAccessError';
+  }
 }
 
 function isDefaultProfile(name: string): boolean {
@@ -148,16 +204,31 @@ function legacySlotExists(source: LoadSource): boolean {
   );
 }
 
-export async function loadCredentials(profile?: string): Promise<FortnoxCredentials | null> {
+export async function inspectCredentials(profile?: string): Promise<CredentialInspection> {
   const target = profileOrResolved(profile);
+  const source = sourceForProfile(target);
   let result: { blob: string | null; source: LoadSource; legacyBlob: string | null };
   try {
     result = await loadCredentialBlob(target);
   } catch (err) {
-    // A locked dedicated keychain must surface, not look like "no credentials" —
-    // the caller tells the user to run `noxctl keychain unlock` (tap YubiKey).
-    if (err instanceof KeychainLockedError) throw err;
-    return null;
+    if (err instanceof KeychainLockedError) {
+      return {
+        state: 'locked',
+        profile: target,
+        source,
+        credentials: null,
+        detail: `Credential state: locked for ${credentialContext(target)} — ${err.message}`,
+      };
+    }
+    const reason =
+      err instanceof CredentialStoreAccessError || err instanceof Error ? err.message : String(err);
+    return {
+      state: 'inaccessible',
+      profile: target,
+      source,
+      credentials: null,
+      detail: `Credential state: inaccessible for ${credentialContext(target)} — ${reason}. ${inaccessibleRecovery(target)}`,
+    };
   }
 
   if (isDefaultProfile(target) && legacySlotExists(result.source)) {
@@ -166,15 +237,81 @@ export async function loadCredentials(profile?: string): Promise<FortnoxCredenti
     // the raw legacy blob — not result.blob, which may be the new slot if
     // pickHigher preferred it and would lose legacy-only metadata on drift.
     // A failure here must not break auth — Chunk D's `doctor` will surface it.
-    await migrateLegacyIfNeeded(result.legacyBlob);
+    try {
+      await migrateLegacyIfNeeded(result.legacyBlob);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        state: 'inaccessible',
+        profile: target,
+        source,
+        credentials: null,
+        detail: `Credential state: inaccessible for ${credentialContext(target)} — legacy profile metadata could not be inspected (${reason}). ${inaccessibleRecovery(target)}`,
+      };
+    }
   }
 
-  if (!result.blob) return null;
-  try {
-    return JSON.parse(result.blob) as FortnoxCredentials;
-  } catch {
-    return null;
+  if (!result.blob) {
+    let registered = false;
+    try {
+      const index = await readProfileIndex();
+      registered = index.profiles.some(
+        (entry) => entry.name.toLowerCase() === target.toLowerCase(),
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        state: 'inaccessible',
+        profile: target,
+        source,
+        credentials: null,
+        detail: `Credential state: inaccessible for ${credentialContext(target)} — the profile index could not be read (${reason}). ${inaccessibleRecovery(target)}`,
+      };
+    }
+    if (registered) {
+      return {
+        state: 'inaccessible',
+        profile: target,
+        source,
+        credentials: null,
+        detail: `Credential state: inaccessible for ${credentialContext(target)} — the registered profile exists, but credential lookup returned no item in this execution context. ${inaccessibleRecovery(target)}`,
+      };
+    }
+    return {
+      state: 'missing',
+      profile: target,
+      source,
+      credentials: null,
+      detail: `Credential state: missing for ${credentialContext(target)}. Run ${
+        isDefaultProfile(target) ? '`noxctl init`' : `\`noxctl init --profile ${target}\``
+      } to connect your Fortnox account.`,
+    };
   }
+  try {
+    return {
+      state: 'available',
+      profile: target,
+      source,
+      credentials: JSON.parse(result.blob) as FortnoxCredentials,
+      detail: `Credential state: available for ${credentialContext(target)}`,
+    };
+  } catch {
+    return {
+      state: 'inaccessible',
+      profile: target,
+      source,
+      credentials: null,
+      detail: `Credential state: inaccessible for ${credentialContext(target)} — the stored credential blob could not be parsed. ${inaccessibleRecovery(target)}`,
+    };
+  }
+}
+
+export async function loadCredentials(profile?: string): Promise<FortnoxCredentials | null> {
+  const inspected = await inspectCredentials(profile);
+  if (inspected.state === 'available') return inspected.credentials;
+  if (inspected.state === 'missing') return null;
+  if (inspected.state === 'locked') throw new KeychainLockedError(inspected.detail);
+  throw new CredentialAccessError(inspected.profile, inspected.source, inspected.detail);
 }
 
 export async function saveCredentials(creds: FortnoxCredentials, profile?: string): Promise<void> {
@@ -317,7 +454,7 @@ export async function getValidToken(profile?: string): Promise<string> {
       ? '`noxctl init`'
       : `\`noxctl init --profile ${target}\``;
     throw new Error(
-      `${profileTag(target)}Not authenticated. Run ${initCmd} to connect your Fortnox account.`,
+      `[profile: ${target}, source: ${sourceForProfile(target)}] Not authenticated. Run ${initCmd} to connect your Fortnox account.`,
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -986,6 +986,16 @@ keychain
     console.log(
       `  Platform          ${process.platform}${onDarwin ? '' : ' (dedicated keychain is macOS-only)'}`,
     );
+
+    const { inspectCredentials } = await import('./auth.js');
+    const inspection = await inspectCredentials();
+    console.log(
+      `  Credential state  ${inspection.state} — profile "${inspection.profile}" (source: ${inspection.source})`,
+    );
+    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+      console.log(`\n  ${inspection.detail}`);
+    }
+
     if (!onDarwin) return;
 
     const activePath = kt.activeKeychainPath();
@@ -1006,15 +1016,6 @@ keychain
       if (mismatch) console.log(`\n  ${mismatch}`);
     }
 
-    const { inspectCredentials } = await import('./auth.js');
-    const inspection = await inspectCredentials();
-    console.log(
-      `  Credential state  ${inspection.state} — profile "${inspection.profile}" (source: ${inspection.source})`,
-    );
-    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
-      console.log(`\n  ${inspection.detail}`);
-    }
-
     if (activePath && lockState === 'locked') {
       console.log('\n  Locked — run `noxctl keychain unlock` (tap your YubiKey).');
     }
@@ -1026,11 +1027,16 @@ keychain
   .action(async () => {
     requireDarwin();
     const kt = await import('./keychain-target.js');
-    const kcPath = kt.activeKeychainPath() ?? kt.dedicatedKeychainPath();
+    const activePath = kt.activeKeychainPath();
+    const kcPath = activePath ?? kt.dedicatedKeychainPath();
 
     const state = kt.keychainLockState(kcPath);
     if (state === 'missing') {
-      console.error('No dedicated keychain found. Run `noxctl keychain init` first.');
+      console.error(
+        activePath
+          ? `The configured keychain at ${kcPath} is inaccessible. Retry from an unsandboxed terminal; do not re-run noxctl keychain init.`
+          : 'No dedicated keychain found. Run `noxctl keychain init` first.',
+      );
       process.exit(1);
     }
     if (state === 'unlocked') {
@@ -1074,9 +1080,14 @@ keychain
   .action(async () => {
     requireDarwin();
     const kt = await import('./keychain-target.js');
-    const kcPath = kt.activeKeychainPath() ?? kt.dedicatedKeychainPath();
+    const activePath = kt.activeKeychainPath();
+    const kcPath = activePath ?? kt.dedicatedKeychainPath();
     if (kt.keychainLockState(kcPath) === 'missing') {
-      console.error('No dedicated keychain found.');
+      console.error(
+        activePath
+          ? `The configured keychain at ${kcPath} is inaccessible. Retry from an unsandboxed terminal.`
+          : 'No dedicated keychain found.',
+      );
       process.exit(1);
     }
     kt.lockKeychain(kcPath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -201,7 +201,7 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     throw err;
   }
 
-  setResolvedProfile(resolvedProfileInfo.name);
+  setResolvedProfile(resolvedProfileInfo.name, resolvedProfileInfo.source);
 
   // Banner ownership: MCP `serve` prints its own banner in bindStartupProfile
   // so host logs (Claude Desktop) always see it. Suppress here to avoid a
@@ -323,7 +323,7 @@ program
     'Also request the offer/order scopes — requires the Order licence on the Fortnox company',
   )
   .action(async (initOpts: { profile?: string; withSalary?: boolean; withOrders?: boolean }) => {
-    const { loadCredentials, runOAuthSetup, SCOPES, SALARY_SCOPE, ORDER_SCOPES } =
+    const { inspectCredentials, runOAuthSetup, SCOPES, SALARY_SCOPE, ORDER_SCOPES } =
       await import('./auth.js');
     const { validateProfileName } = await import('./profile-name.js');
 
@@ -349,12 +349,16 @@ program
     // (verification via getCompanyInfo, runOAuthSetup's internal saveCredentials
     // call chain) targets the profile being initialized — not a stale pointer.
     if (targetProfile.toLowerCase() !== resolvedProfileInfo.name.toLowerCase()) {
-      setResolvedProfile(targetProfile);
+      setResolvedProfile(targetProfile, 'flag');
       resolvedProfileInfo = { name: targetProfile, source: 'flag' };
     }
 
     // Step 1: Check if already configured
-    const existing = await loadCredentials(targetProfile);
+    const inspection = await inspectCredentials(targetProfile);
+    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+      fail(inspection.detail);
+    }
+    const existing = inspection.credentials;
     if (existing) {
       console.log('Existing credentials found.');
 
@@ -709,9 +713,12 @@ profile
       process.exit(2);
     }
 
-    const { loadCredentials } = await import('./auth.js');
-    const creds = await loadCredentials(validated);
-    if (!creds) {
+    const { inspectCredentials } = await import('./auth.js');
+    const inspection = await inspectCredentials(validated);
+    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+      fail(inspection.detail);
+    }
+    if (inspection.state === 'missing') {
       console.error(
         `No credentials found for profile "${validated}". Run \`noxctl init --profile ${validated}\` first.`,
       );
@@ -763,7 +770,7 @@ program
   .command('doctor')
   .description('Check setup: credentials, token, API connectivity, and scopes')
   .action(async () => {
-    const { loadCredentials } = await import('./auth.js');
+    const { inspectCredentials } = await import('./auth.js');
     let ok = true;
 
     function pass(label: string, detail?: string) {
@@ -802,6 +809,11 @@ program
         const state = kt.keychainLockState(activePath);
         if (state === 'locked') {
           fail('Dedicated keychain', 'locked — run `noxctl keychain unlock` (tap your YubiKey)');
+        } else if (state === 'missing') {
+          fail(
+            'Dedicated keychain',
+            `configured but inaccessible at ${activePath} — inspect it from an unsandboxed terminal`,
+          );
         } else {
           pass('Dedicated keychain', `active, ${state} (${activePath})`);
         }
@@ -845,23 +857,17 @@ program
       // best-effort diagnostic — don't block doctor on filesystem issues
     }
 
-    // 3. Credentials exist
-    let creds: Awaited<ReturnType<typeof loadCredentials>>;
-    try {
-      creds = await loadCredentials();
-    } catch (err) {
-      const { KeychainLockedError } = await import('./keychain-target.js');
-      if (err instanceof KeychainLockedError) {
-        fail('Credentials', err.message);
-        console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
-        return;
-      }
-      throw err;
+    // 3. Credential state
+    const inspection = await inspectCredentials();
+    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+      fail('Credentials', `${inspection.state} — ${inspection.detail}`);
+      console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
+      return;
     }
-    if (!creds) {
+    if (inspection.state === 'missing') {
       fail(
         'Credentials',
-        `not found for profile "${resolvedProfileInfo.name}" — run \`noxctl init${
+        `missing — not found for profile "${resolvedProfileInfo.name}" — run \`noxctl init${
           resolvedProfileInfo.name === DEFAULT_PROFILE
             ? ''
             : ` --profile ${resolvedProfileInfo.name}`
@@ -870,6 +876,7 @@ program
       console.log(`\n${ok ? 'All checks passed.' : 'Some checks failed.'}`);
       return;
     }
+    const creds = inspection.credentials!;
     pass('Credentials', 'found');
     if (creds.company_name) {
       pass('Company (cached)', creds.company_name);
@@ -997,6 +1004,15 @@ keychain
     if (enrolledSerial) {
       const mismatch = kt.diagnoseSerialMismatch(enrolledSerial, kt.listYubikeySerials());
       if (mismatch) console.log(`\n  ${mismatch}`);
+    }
+
+    const { inspectCredentials } = await import('./auth.js');
+    const inspection = await inspectCredentials();
+    console.log(
+      `  Credential state  ${inspection.state} — profile "${inspection.profile}" (source: ${inspection.source})`,
+    );
+    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+      console.log(`\n  ${inspection.detail}`);
     }
 
     if (activePath && lockState === 'locked') {

--- a/src/credentials-store.ts
+++ b/src/credentials-store.ts
@@ -11,7 +11,7 @@ import {
   validateProfileName,
 } from './profile-name.js';
 import { configDir } from './config-paths.js';
-import { activeKeychainPath, readDedicatedSecret } from './keychain-target.js';
+import { activeKeychainPath, KeychainAccessError, readDedicatedSecret } from './keychain-target.js';
 
 function legacyCredentialsFile(): string {
   return path.join(configDir(), 'credentials.json');
@@ -20,6 +20,40 @@ function legacyWindowsCredentialsFile(): string {
   return path.join(configDir(), 'credentials.dpapi');
 }
 const SERVICE_NAME = 'fortnox-mcp';
+
+export class CredentialStoreAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialStoreAccessError';
+  }
+}
+
+function commandFailureDetail(err: unknown): string {
+  if (typeof err !== 'object' || err === null) return String(err);
+  const e = err as {
+    message?: string;
+    stderr?: Buffer | string;
+    code?: string;
+    status?: number;
+  };
+  const stderr = e.stderr?.toString().trim();
+  return stderr || e.message || e.code || `exit ${e.status ?? 'unknown'}`;
+}
+
+function isMissingSecretError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { message?: string; stderr?: Buffer | string; status?: number };
+  const detail = `${e.message ?? ''}\n${e.stderr?.toString() ?? ''}`;
+  return (
+    e.status === 44 || /not found|could not be found|no keychain item|no matching/i.test(detail)
+  );
+}
+
+function isEmptyExitOne(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { stderr?: Buffer | string; status?: number };
+  return e.status === 1 && !(e.stderr?.toString().trim() ?? '');
+}
 
 function normalizeProfile(profile: string): { normalized: string; isDefault: boolean } {
   const validated = validateProfileName(profile).toLowerCase();
@@ -116,17 +150,29 @@ function loadMacSecret(account: string): string | null {
   // A locked keychain throws KeychainLockedError (propagated so the caller can
   // tell the user to run `noxctl keychain unlock`), not a silent null.
   const dedicated = activeKeychainPath();
-  if (dedicated) return readDedicatedSecret(account, dedicated);
+  if (dedicated) {
+    try {
+      return readDedicatedSecret(account, dedicated);
+    } catch (err) {
+      if (err instanceof KeychainAccessError) {
+        throw new CredentialStoreAccessError(err.message);
+      }
+      throw err;
+    }
+  }
 
   try {
     const raw = execFileSync(
       'security',
       ['find-generic-password', '-a', account, '-s', SERVICE_NAME, '-w'],
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
     ).trim();
     return decodeHexIfNeeded(raw);
-  } catch {
-    return null;
+  } catch (err) {
+    if (isMissingSecretError(err)) return null;
+    throw new CredentialStoreAccessError(
+      `macOS Keychain could not be inspected (${commandFailureDetail(err)})`,
+    );
   }
 }
 
@@ -221,8 +267,14 @@ function loadLinuxSecret(account: string): string | null {
     return execFileSync('secret-tool', ['lookup', 'service', SERVICE_NAME, 'account', account], {
       encoding: 'utf-8',
     }).trim();
-  } catch {
-    return null;
+  } catch (err) {
+    // `secret-tool lookup` uses exit 1 with no stderr when no matching item
+    // exists. Transport/session failures include diagnostic stderr (and a
+    // missing binary reports ENOENT), so those remain inaccessible.
+    if (isMissingSecretError(err) || isEmptyExitOne(err)) return null;
+    throw new CredentialStoreAccessError(
+      `Linux Secret Service could not be inspected (${commandFailureDetail(err)})`,
+    );
   }
 }
 
@@ -235,6 +287,7 @@ function saveLinuxSecret(account: string, secret: string): void {
 }
 
 function loadWindowsSecret(file: string): string | null {
+  if (!fsSync.existsSync(file)) return null;
   try {
     return execFileSync(
       'powershell',
@@ -254,8 +307,10 @@ function loadWindowsSecret(file: string): string | null {
       ],
       { encoding: 'utf-8' },
     ).trim();
-  } catch {
-    return null;
+  } catch (err) {
+    throw new CredentialStoreAccessError(
+      `Windows DPAPI credential store could not be inspected (${commandFailureDetail(err)})`,
+    );
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { setResolvedProfile } from './auth.js';
 import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
-import { readActivePointerOutcome, resolveProfile } from './profiles.js';
+import { readActivePointerOutcome, resolveProfile, type ResolvedProfile } from './profiles.js';
 import type { FortnoxTransport } from './fortnox-client.js';
 import { createFortnoxOperations, defaultFortnoxOperations } from './operations/index.js';
 import { registerCustomerTools } from './tools/customers.js';
@@ -109,7 +109,7 @@ export class StartupProfileError extends Error {
 // preAction precedence minus the flag (no Commander context at direct-run
 // entry). Pointer faults fail closed when no env override is present —
 // silently binding to `default` could route requests to the wrong tenant.
-export async function resolveStartupProfile(): Promise<string> {
+async function resolveStartupProfileInfo(): Promise<ResolvedProfile> {
   const env = process.env['NOXCTL_PROFILE'] ?? undefined;
   const outcome = await readActivePointerOutcome({ timeoutMs: 2000 });
 
@@ -137,7 +137,7 @@ export async function resolveStartupProfile(): Promise<string> {
 
   const pointer = outcome.kind === 'valid' ? outcome.name : null;
   try {
-    return resolveProfile({ env, pointer }).name;
+    return resolveProfile({ env, pointer });
   } catch (err) {
     if (err instanceof InvalidProfileNameError) {
       throw new StartupProfileError('invalid-env', err.message);
@@ -146,11 +146,18 @@ export async function resolveStartupProfile(): Promise<string> {
   }
 }
 
+export async function resolveStartupProfile(): Promise<string> {
+  return (await resolveStartupProfileInfo()).name;
+}
+
 // Extracted from startMcpServer so tests can exercise profile binding without
 // spinning up the stdio transport (which blocks on stdin).
 export async function bindStartupProfile(options: StartMcpServerOptions = {}): Promise<string> {
-  const profile = options.profile ?? (await resolveStartupProfile());
-  setResolvedProfile(profile);
+  const info = options.profile
+    ? { name: options.profile, source: 'flag' as const }
+    : await resolveStartupProfileInfo();
+  const profile = info.name;
+  setResolvedProfile(profile, info.source);
   if (profile.toLowerCase() !== DEFAULT_PROFILE) {
     process.stderr.write(`[profile: ${profile}]\n`);
   }

--- a/src/keychain-target.ts
+++ b/src/keychain-target.ts
@@ -61,15 +61,18 @@ export function challengeFilePath(): string {
 
 // Resolve which keychain credential operations should target.
 //   1. NOXCTL_KEYCHAIN_PATH env override (used by tests and power users).
-//   2. darwin only: the dedicated keychain + its challenge file both exist.
+//   2. darwin only: the challenge file marks the dedicated keychain configured.
 //   3. otherwise null — caller falls back to the login keychain (legacy behavior).
-// The challenge file gates files-exist detection so a half-created keychain
-// (file present, never `init`-ed) doesn't silently divert reads.
+// The challenge file is the durable configuration marker. Once it exists we
+// must keep targeting the dedicated keychain even when the current execution
+// context cannot see the keychain file; falling back to the login keychain
+// would cross the configured protection boundary. A keychain file without a
+// challenge remains a half-created setup and does not divert reads.
 export function activeKeychainPath(): string | null {
   const override = process.env.NOXCTL_KEYCHAIN_PATH;
   if (override && override.trim()) return override;
   if (process.platform !== 'darwin') return null;
-  if (fsSync.existsSync(dedicatedKeychainPath()) && fsSync.existsSync(challengeFilePath())) {
+  if (fsSync.existsSync(challengeFilePath())) {
     return dedicatedKeychainPath();
   }
   return null;

--- a/src/keychain-target.ts
+++ b/src/keychain-target.ts
@@ -24,6 +24,18 @@ export class KeychainLockedError extends Error {
   }
 }
 
+// Thrown when the dedicated keychain is configured but cannot be inspected in
+// the current execution context (for example from a sandbox that cannot see
+// the user's keychain file). This is deliberately distinct from both a locked
+// keychain and an absent credential item: callers must fail closed rather than
+// recommend replacing credentials whose existence cannot be determined.
+export class KeychainAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KeychainAccessError';
+  }
+}
+
 // Thrown when a challenge-response operation fails — most often a missed touch
 // (ykman reports "Failed to write to the YubiKey" when the tap window lapses).
 export class ChallengeResponseError extends Error {
@@ -91,7 +103,7 @@ let kcPath = CommandLine.arguments[2]
 
 var kc: SecKeychain?
 let openStatus = SecKeychainOpen(kcPath, &kc)
-if openStatus != errSecSuccess || kc == nil { exit(3) }
+if openStatus != errSecSuccess || kc == nil { exit(4) }
 
 SecKeychainSetUserInteractionAllowed(false)
 
@@ -110,15 +122,25 @@ if status == errSecSuccess, let data = item as? Data {
   exit(0)
 }
 if status == errSecInteractionNotAllowed || status == errSecAuthFailed { exit(2) }
-exit(3)
+if status == errSecItemNotFound { exit(3) }
+exit(4)
 `;
   const scriptPath = path.join(os.tmpdir(), `noxctl-kcread-${process.pid}.swift`);
   try {
     fsSync.writeFileSync(scriptPath, swiftScript, { mode: 0o600 });
     const result = spawnSync('swift', [scriptPath, account, keychainPath], { encoding: 'utf-8' });
+    if (result.error) {
+      throw new KeychainAccessError(
+        `Fortnox keychain at ${keychainPath} could not be inspected (${result.error.message})`,
+      );
+    }
     if (result.status === 0) return decodeBase64(result.stdout);
     if (result.status === 2) throw new KeychainLockedError();
-    return null;
+    if (result.status === 3) return null;
+    const detail = (result.stderr || '').trim() || `helper exit ${result.status ?? 'unknown'}`;
+    throw new KeychainAccessError(
+      `Fortnox keychain at ${keychainPath} could not be inspected (${detail})`,
+    );
   } finally {
     try {
       fsSync.unlinkSync(scriptPath);

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -28,14 +28,15 @@ export function registerStatusTools(server: McpServer): void {
       }
 
       // 2. Credentials
-      const { loadCredentials } = await import('../auth.js');
-      const creds = await loadCredentials();
-      if (!creds) {
-        fail('Credentials', 'not found — run `noxctl init` to set up');
+      const { inspectCredentials } = await import('../auth.js');
+      const inspection = await inspectCredentials();
+      if (inspection.state !== 'available') {
+        fail('Credentials', `${inspection.state} — ${inspection.detail}`);
         lines.push('');
         lines.push(ok ? 'All checks passed.' : 'Some checks failed.');
         return textResponse(lines.join('\n'));
       }
+      const creds = inspection.credentials!;
       pass('Credentials', 'found');
 
       // 3. Client ID

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 const credentialStore = vi.hoisted(() => ({
   loadCredentialBlob: vi.fn(),
   saveCredentialBlob: vi.fn(),
+  CredentialStoreAccessError: class CredentialStoreAccessError extends Error {},
 }));
 
 const profilesModule = vi.hoisted(() => ({
@@ -18,6 +19,8 @@ import {
   browserOpenCommand,
   LEGACY_SCOPES,
   loadCredentials,
+  inspectCredentials,
+  CredentialAccessError,
   saveCredentials,
   exchangeCodeForTokens,
   refreshAccessToken,
@@ -31,6 +34,7 @@ import {
   SALARY_SCOPE,
   setResolvedProfile,
   getResolvedProfile,
+  getResolvedProfileSource,
   CREDENTIAL_SCHEMA_VERSION,
   __resetLegacyObservedForDefault,
   type FortnoxCredentials,
@@ -95,6 +99,16 @@ describe('auth', () => {
       );
       const creds = await loadCredentials();
       expect(creds).toEqual(mockCredentials);
+    });
+
+    it('throws when a registered profile cannot be read in the current execution context', async () => {
+      profilesModule.readProfileIndex.mockResolvedValueOnce({
+        schema_version: 1,
+        profiles: [{ name: 'work' }],
+      });
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+
+      await expect(loadCredentials('work')).rejects.toThrow(CredentialAccessError);
     });
 
     it('returns credentials with tenant_id when present', async () => {
@@ -222,8 +236,100 @@ describe('auth', () => {
     });
 
     it('setResolvedProfile updates the module state', () => {
-      setResolvedProfile('demo');
+      setResolvedProfile('demo', 'env');
       expect(getResolvedProfile()).toBe('demo');
+      expect(getResolvedProfileSource()).toBe('env');
+    });
+  });
+
+  describe('inspectCredentials', () => {
+    it('reports available when credentials parse successfully', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials)),
+      );
+
+      await expect(inspectCredentials('default')).resolves.toMatchObject({
+        state: 'available',
+        profile: 'default',
+        credentials: mockCredentials,
+      });
+    });
+
+    it('reports missing only when the profile is not registered', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+
+      await expect(inspectCredentials('fresh')).resolves.toMatchObject({
+        state: 'missing',
+        profile: 'fresh',
+        credentials: null,
+      });
+    });
+
+    it('reports inaccessible when a registered profile lookup returns no item', async () => {
+      profilesModule.readProfileIndex.mockResolvedValueOnce({
+        schema_version: 1,
+        profiles: [{ name: 'work' }],
+      });
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+
+      const result = await inspectCredentials('work');
+      expect(result).toMatchObject({ state: 'inaccessible', profile: 'work', credentials: null });
+      expect(result.detail).toContain('registered profile');
+      expect(result.detail).toContain('unsandboxed terminal');
+      expect(result.detail).toContain('already-running MCP server');
+    });
+
+    it('reports locked without recommending OAuth setup', async () => {
+      const { KeychainLockedError } = await import('../src/keychain-target.js');
+      credentialStore.loadCredentialBlob.mockRejectedValueOnce(new KeychainLockedError());
+
+      const result = await inspectCredentials('work');
+      expect(result.state).toBe('locked');
+      expect(result.detail).toContain('keychain unlock');
+      expect(result.detail).toContain('profile "work" (source: explicit)');
+      expect(result.detail).not.toContain('noxctl init');
+    });
+
+    it('reports inaccessible when the credential backend throws', async () => {
+      credentialStore.loadCredentialBlob.mockRejectedValueOnce(
+        new credentialStore.CredentialStoreAccessError('sandbox denied access'),
+      );
+
+      const result = await inspectCredentials('work');
+      expect(result.state).toBe('inaccessible');
+      expect(result.detail).toContain('sandbox denied access');
+      expect(result.detail).not.toContain('noxctl init');
+    });
+
+    it('reports inaccessible for a malformed credential blob', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult('{not-json'));
+
+      const result = await inspectCredentials('work');
+      expect(result.state).toBe('inaccessible');
+      expect(result.detail).toContain('could not be parsed');
+    });
+
+    it('reports legacy-index migration failures as inaccessible', async () => {
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(
+        blobResult(JSON.stringify(mockCredentials), 'legacy'),
+      );
+      profilesModule.migrateLegacyIfNeeded.mockRejectedValueOnce(new Error('index denied'));
+
+      const result = await inspectCredentials('default');
+      expect(result.state).toBe('inaccessible');
+      expect(result.detail).toContain('legacy profile metadata');
+      expect(result.detail).toContain('index denied');
+    });
+
+    it('includes the resolved profile source in access errors', async () => {
+      setResolvedProfile('work', 'pointer');
+      profilesModule.readProfileIndex.mockResolvedValueOnce({
+        schema_version: 1,
+        profiles: [{ name: 'work' }],
+      });
+      credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
+
+      await expect(loadCredentials()).rejects.toThrow(/profile "work" \(source: pointer\)/);
     });
   });
 
@@ -489,18 +595,18 @@ describe('auth', () => {
     it('tags the not-authenticated error with profile when non-default', async () => {
       credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
       await expect(getValidToken('staging')).rejects.toThrow(
-        /\[profile: staging\].*noxctl init --profile staging/,
+        /\[profile: staging, source: explicit\].*noxctl init --profile staging/,
       );
     });
 
-    it('omits the profile tag for the default profile', async () => {
+    it('names the default profile and its resolution source', async () => {
       credentialStore.loadCredentialBlob.mockResolvedValueOnce(blobResult(null));
       try {
         await getValidToken();
         expect.unreachable();
       } catch (err) {
         const message = (err as Error).message;
-        expect(message).not.toContain('[profile:');
+        expect(message).toContain('[profile: default, source: default]');
         expect(message).toContain('noxctl init');
       }
     });

--- a/tests/cli-profile.test.ts
+++ b/tests/cli-profile.test.ts
@@ -193,10 +193,15 @@ describe('profile list', () => {
 });
 
 describe('profile use', () => {
-  it('refuses to switch to a profile without credentials', () => {
+  it('refuses to switch when credentials are missing or the store is inaccessible', () => {
     const res = run(['profile', 'use', 'work']);
     expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain('No credentials found for profile "work"');
+    const message = res.stderr.trim().startsWith('{')
+      ? (JSON.parse(res.stderr) as { error: { message: string } }).error.message
+      : res.stderr;
+    expect(message).toMatch(
+      /No credentials found for profile "work"|Credential state: inaccessible for profile "work"/,
+    );
   });
 
   it('rejects an invalid profile name', () => {
@@ -241,18 +246,15 @@ describe('credential recovery safety', () => {
     expect(res.stdout).not.toContain('noxctl init --profile work');
   });
 
-  it.runIf(process.platform === 'darwin')(
-    'keychain status uses the same inaccessible vocabulary',
-    async () => {
-      await registerProfile('work');
+  it('keychain status uses the same inaccessible vocabulary on every platform', async () => {
+    await registerProfile('work');
 
-      const res = run(['--output', 'table', '--profile', 'work', 'keychain', 'status']);
-      expect(res.status).toBe(0);
-      expect(res.stdout).toContain('Credential state  inaccessible');
-      expect(res.stdout).toContain('profile "work" (source: flag)');
-      expect(res.stdout).toContain('unsandboxed terminal');
-    },
-  );
+    const res = run(['--output', 'table', '--profile', 'work', 'keychain', 'status']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('Credential state  inaccessible');
+    expect(res.stdout).toContain('profile "work" (source: flag)');
+    expect(res.stdout).toContain('unsandboxed terminal');
+  });
 });
 
 describe('stderr profile indicator', () => {

--- a/tests/cli-profile.test.ts
+++ b/tests/cli-profile.test.ts
@@ -206,6 +206,55 @@ describe('profile use', () => {
   });
 });
 
+describe('credential recovery safety', () => {
+  async function registerProfile(name: string): Promise<void> {
+    await fs.mkdir(cfgDir, { recursive: true });
+    await fs.writeFile(
+      profilesIndexFile,
+      JSON.stringify({
+        schema_version: 1,
+        profiles: [{ name, created_at: '2026-01-01T00:00:00.000Z', schema_version: 2 }],
+      }),
+    );
+  }
+
+  it('init fails closed before setup when a registered profile lookup is inconclusive', async () => {
+    await registerProfile('work');
+
+    const res = run(['--output', 'table', '--profile', 'work', 'init']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('Credential state: inaccessible');
+    expect(res.stderr).toContain('profile "work" (source: flag)');
+    expect(res.stderr).toContain('unsandboxed terminal');
+    expect(res.stdout).not.toContain('Welcome to noxctl init');
+    expect(res.stdout).not.toContain('replace your current credentials');
+  });
+
+  it('doctor uses the same inaccessible vocabulary and reports profile source', async () => {
+    await registerProfile('work');
+
+    const res = run(['--output', 'table', '--profile', 'work', 'doctor']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('Profile — work (source: flag)');
+    expect(res.stdout).toContain('Credentials — inaccessible');
+    expect(res.stdout).toContain('unsandboxed terminal');
+    expect(res.stdout).not.toContain('noxctl init --profile work');
+  });
+
+  it.runIf(process.platform === 'darwin')(
+    'keychain status uses the same inaccessible vocabulary',
+    async () => {
+      await registerProfile('work');
+
+      const res = run(['--output', 'table', '--profile', 'work', 'keychain', 'status']);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('Credential state  inaccessible');
+      expect(res.stdout).toContain('profile "work" (source: flag)');
+      expect(res.stdout).toContain('unsandboxed terminal');
+    },
+  );
+});
+
 describe('stderr profile indicator', () => {
   it('is absent in non-TTY output (test runs without a TTY)', () => {
     const res = run(['--profile', 'work', 'profile', 'current']);

--- a/tests/credentials-store.test.ts
+++ b/tests/credentials-store.test.ts
@@ -30,6 +30,7 @@ import {
   loadCredentialBlob,
   saveCredentialBlob,
   deleteCredentialBlob,
+  CredentialStoreAccessError,
 } from '../src/credentials-store.js';
 import {
   validateProfileName,
@@ -216,6 +217,18 @@ describe('loadCredentialBlob (darwin)', () => {
 
     const result = await loadCredentialBlob('default');
     expect(result).toEqual({ blob: null, source: null, legacyBlob: null });
+  });
+
+  it('surfaces unexpected macOS keychain failures as inaccessible', async () => {
+    childProcess.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('sandbox denied access'), {
+        code: 'EPERM',
+        status: 1,
+        stderr: 'Operation not permitted',
+      });
+    });
+
+    await expect(loadCredentialBlob('demo')).rejects.toThrow(CredentialStoreAccessError);
   });
 
   it('returns legacy blob with source=legacy when only legacy keychain entry exists', async () => {
@@ -488,6 +501,26 @@ describe('Linux secret-tool backend', () => {
     setPlatform('linux');
   });
 
+  it('treats exit 1 without stderr as an absent secret', async () => {
+    childProcess.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('Command failed'), { status: 1, stderr: '' });
+    });
+
+    await expect(loadCredentialBlob('demo')).resolves.toEqual({
+      blob: null,
+      source: null,
+      legacyBlob: null,
+    });
+  });
+
+  it('surfaces a missing secret-tool binary as inaccessible', async () => {
+    childProcess.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('spawn secret-tool ENOENT'), { code: 'ENOENT' });
+    });
+
+    await expect(loadCredentialBlob('demo')).rejects.toThrow(CredentialStoreAccessError);
+  });
+
   it('uses account=profile:<name> for non-default profiles', async () => {
     childProcess.execFileSync.mockReturnValue('');
     await loadCredentialBlob('demo');
@@ -533,6 +566,26 @@ describe('Linux secret-tool backend', () => {
 describe('Windows DPAPI backend', () => {
   beforeEach(() => {
     setPlatform('win32');
+    fsSync.default.existsSync.mockReturnValue(true);
+  });
+
+  it('reports missing without invoking PowerShell when the DPAPI file is absent', async () => {
+    fsSync.default.existsSync.mockReturnValue(false);
+
+    await expect(loadCredentialBlob('demo')).resolves.toEqual({
+      blob: null,
+      source: null,
+      legacyBlob: null,
+    });
+    expect(childProcess.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces PowerShell failures for an existing DPAPI file as inaccessible', async () => {
+    childProcess.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ProtectedData failed'), { status: 1, stderr: 'denied' });
+    });
+
+    await expect(loadCredentialBlob('demo')).rejects.toThrow(CredentialStoreAccessError);
   });
 
   it('uses credentials.<name>.dpapi for non-default profiles', async () => {
@@ -660,6 +713,11 @@ describe('dedicated-keychain mode (darwin)', () => {
   it('throws KeychainLockedError when the dedicated keychain is locked', async () => {
     childProcess.spawnSync.mockReturnValue({ status: 2, stdout: '', stderr: '' });
     await expect(loadCredentialBlob('default')).rejects.toThrow(KeychainLockedError);
+  });
+
+  it('surfaces a configured but unreadable dedicated keychain as inaccessible', async () => {
+    childProcess.spawnSync.mockReturnValue({ status: 4, stdout: '', stderr: 'open failed' });
+    await expect(loadCredentialBlob('default')).rejects.toThrow(CredentialStoreAccessError);
   });
 
   it('save targets the dedicated keychain via Swift argv and kSecUseKeychain', async () => {

--- a/tests/keychain-target.test.ts
+++ b/tests/keychain-target.test.ts
@@ -20,6 +20,7 @@ vi.mock('node:fs', () => fsSync);
 
 import {
   KeychainLockedError,
+  KeychainAccessError,
   ChallengeResponseError,
   dedicatedKeychainPath,
   loginKeychainPath,
@@ -272,6 +273,13 @@ describe('readDedicatedSecret', () => {
   it('returns null on exit 3 (item absent)', () => {
     childProcess.spawnSync.mockReturnValue({ status: 3, stdout: '' });
     expect(readDedicatedSecret('profile:default', '/tmp/k.keychain-db')).toBeNull();
+  });
+
+  it('throws KeychainAccessError when the configured keychain cannot be opened', () => {
+    childProcess.spawnSync.mockReturnValue({ status: 4, stdout: '', stderr: 'open failed' });
+    expect(() => readDedicatedSecret('profile:default', '/tmp/k.keychain-db')).toThrow(
+      KeychainAccessError,
+    );
   });
 
   it('passes account and keychain path as argv (not interpolated)', () => {

--- a/tests/keychain-target.test.ts
+++ b/tests/keychain-target.test.ts
@@ -106,10 +106,17 @@ describe('activeKeychainPath precedence', () => {
     expect(isDedicatedModeActive()).toBe(false);
   });
 
-  it('returns the dedicated path on darwin only when both keychain and challenge files exist', () => {
+  it('returns the dedicated path on darwin when the challenge file marks it configured', () => {
     setPlatform('darwin');
     fsSync.default.existsSync.mockReturnValue(true);
     expect(activeKeychainPath()).toBe(dedicatedKeychainPath());
+  });
+
+  it('does not fall back when the configured keychain file is hidden by a sandbox', () => {
+    setPlatform('darwin');
+    fsSync.default.existsSync.mockImplementation((p: string) => p === challengeFilePath());
+    expect(activeKeychainPath()).toBe(dedicatedKeychainPath());
+    expect(isDedicatedModeActive()).toBe(true);
   });
 
   it('returns null on darwin when the challenge file is missing (half-created keychain)', () => {


### PR DESCRIPTION
## Summary

- add a shared credential-state model: available, missing, locked, and inaccessible
- fail closed before OAuth replacement when a registered profile or credential store cannot be inspected
- align CLI doctor, keychain status, profile selection, init, and MCP status diagnostics
- include effective profile/source and pinned-MCP recovery guidance
- harden macOS dedicated keychain, Linux secret-tool, and Windows DPAPI detection
- document sandbox and YubiKey recovery

## Verification

- `npm run verify` (866 tests across 76 files)
- `npm audit --omit=dev` (0 vulnerabilities)
- `node scripts/check-embedded-consumer.mjs`
- `npm pack --dry-run --ignore-scripts`
- independent `qwen3-coder-next-80b` review, with findings validated

Closes #117
