### PR TITLE
fix: reject unknown MCP tool arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { setResolvedProfile } from './auth.js';
 import { DEFAULT_PROFILE, InvalidProfileNameError } from './profile-name.js';
@@ -32,6 +32,7 @@ import { registerSalaryTransactionTools } from './tools/salarytransactions.js';
 import { registerAttendanceTransactionTools } from './tools/attendancetransactions.js';
 import { registerAbsenceTransactionTools } from './tools/absencetransactions.js';
 import { registerScheduleTimeTools } from './tools/scheduletimes.js';
+import { createStrictMcpServer } from './strict-mcp-server.js';
 
 export interface CreateServerOptions {
   /** Host-authorized transport for exactly one tenant context. */
@@ -39,7 +40,7 @@ export interface CreateServerOptions {
 }
 
 export function createServer(options: CreateServerOptions = {}): McpServer {
-  const server = new McpServer({
+  const server = createStrictMcpServer({
     name: 'fortnox-mcp',
     version: '0.7.4',
   });

--- a/src/strict-mcp-server.ts
+++ b/src/strict-mcp-server.ts
@@ -1,0 +1,54 @@
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+type ToolShape = Record<string, z.ZodType>;
+
+function isToolShape(value: unknown): value is ToolShape {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return Object.values(value).every(
+    (field) =>
+      typeof field === 'object' &&
+      field !== null &&
+      'safeParse' in field &&
+      typeof field.safeParse === 'function',
+  );
+}
+
+/**
+ * Create the repository's MCP server with fail-closed top-level tool inputs.
+ *
+ * Tool modules still use the SDK's legacy `tool(name, description, shape,
+ * callback)` registration form. The SDK normally turns that raw shape into a
+ * stripping Zod object, so misspelled or unsupported keys disappear before the
+ * callback sees them. This compatibility boundary preserves the existing tool
+ * modules while registering the same shapes as strict objects instead.
+ *
+ * The narrow overload is deliberate: every noxctl tool follows this convention,
+ * and a future registration style must choose its object policy explicitly
+ * rather than silently falling back to the SDK default.
+ */
+export function createStrictMcpServer(serverInfo: Implementation): McpServer {
+  const server = new McpServer(serverInfo);
+
+  server.tool = ((name: string, description: string, shape: ToolShape, callback: unknown) => {
+    if (typeof description !== 'string' || !isToolShape(shape) || typeof callback !== 'function') {
+      throw new Error(
+        `Tool ${name} must use tool(name, description, ZodRawShape, callback) so input strictness is explicit.`,
+      );
+    }
+
+    const inputSchema = z.strictObject(shape);
+    return server.registerTool(
+      name,
+      { description, inputSchema },
+      callback as ToolCallback<typeof inputSchema>,
+    ) as RegisteredTool;
+  }) as McpServer['tool'];
+
+  return server;
+}

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -21,7 +21,7 @@ import {
 // TransactionInformation simply vanished and the voucher booked without it
 // (#101). createVoucher() forwards rows verbatim, so this schema is the only
 // place fields were being lost.
-const VoucherRowSchema = z.object({
+const VoucherRowSchema = z.strictObject({
   Account: z.number().describe('Kontonummer'),
   Debit: z.number().optional().describe('Debetbelopp'),
   Credit: z.number().optional().describe('Kreditbelopp'),

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -20,7 +20,7 @@ import {
   requireConfirmation,
 } from '../tool-output.js';
 
-const InvoiceRowSchema = z.object({
+const InvoiceRowSchema = z.strictObject({
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
   Description: z.string().describe('Beskrivning'),
   DeliveredQuantity: z.number().describe('Antal'),
@@ -182,7 +182,7 @@ export function registerInvoiceTools(
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       InvoiceRows: z
         .array(
-          z.object({
+          z.strictObject({
             ArticleNumber: z.string().optional().describe('Artikelnummer'),
             Description: z.string().optional().describe('Beskrivning'),
             DeliveredQuantity: z.number().optional().describe('Antal'),

--- a/src/tools/offers.ts
+++ b/src/tools/offers.ts
@@ -10,7 +10,7 @@ import {
   requireConfirmation,
 } from '../tool-output.js';
 
-const OfferRowSchema = z.object({
+const OfferRowSchema = z.strictObject({
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
   Description: z.string().describe('Beskrivning'),
   DeliveredQuantity: z.number().describe('Antal'),
@@ -116,7 +116,7 @@ export function registerOfferTools(
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       OfferRows: z
         .array(
-          z.object({
+          z.strictObject({
             ArticleNumber: z.string().optional().describe('Artikelnummer'),
             Description: z.string().optional().describe('Beskrivning'),
             DeliveredQuantity: z.number().optional().describe('Antal'),

--- a/src/tools/orders.ts
+++ b/src/tools/orders.ts
@@ -10,7 +10,7 @@ import {
   requireConfirmation,
 } from '../tool-output.js';
 
-const OrderRowSchema = z.object({
+const OrderRowSchema = z.strictObject({
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
   Description: z.string().describe('Beskrivning'),
   DeliveredQuantity: z.number().describe('Antal'),
@@ -106,7 +106,7 @@ export function registerOrderTools(
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       OrderRows: z
         .array(
-          z.object({
+          z.strictObject({
             ArticleNumber: z.string().optional().describe('Artikelnummer'),
             Description: z.string().optional().describe('Beskrivning'),
             DeliveredQuantity: z.number().optional().describe('Antal'),

--- a/src/tools/supplier-invoices.ts
+++ b/src/tools/supplier-invoices.ts
@@ -13,7 +13,7 @@ import {
   requireConfirmation,
 } from '../tool-output.js';
 
-const SupplierInvoiceRowSchema = z.object({
+const SupplierInvoiceRowSchema = z.strictObject({
   Account: z.number().describe('Kontonummer'),
   Debit: z.number().optional().describe('Debetbelopp'),
   Credit: z.number().optional().describe('Kreditbelopp'),

--- a/tests/strict-mcp-inputs.test.ts
+++ b/tests/strict-mcp-inputs.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/index.js';
+import { createStrictMcpServer } from '../src/strict-mcp-server.js';
+
+vi.mock('../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'strict-input-test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+function textOf(result: Awaited<ReturnType<Client['callTool']>>): string {
+  return (result.content as { type: string; text: string }[])[0]?.text ?? '';
+}
+
+describe('strict MCP tool inputs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fails fast if a future tool bypasses the repository registration convention', () => {
+    const server = createStrictMcpServer({ name: 'test-server', version: '1.0.0' });
+
+    expect(() => server.tool('unsupported-overload', () => ({ content: [] }))).toThrow(
+      /must use tool\(name, description, ZodRawShape, callback\)/,
+    );
+  });
+
+  it('rejects an unknown top-level mutation argument before calling Fortnox', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_create_supplier',
+      arguments: {
+        Name: 'Testleverantör AB',
+        confirm: true,
+        YourReferense: 'felstavat fältnamn',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('YourReferense');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown nested mutation argument before calling Fortnox', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_create_voucher',
+      arguments: {
+        Description: 'Test',
+        TransactionDate: '2026-08-29',
+        VoucherRows: [
+          { Account: 6110, Debit: 100, TransactionInfo: 'felstavat fältnamn' },
+          { Account: 1930, Credit: 100 },
+        ],
+        confirm: true,
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('TransactionInfo');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('advertises closed schemas for every top-level tool input', async () => {
+    const { client } = await setupClientServer();
+    const { tools } = await client.listTools();
+
+    expect(tools.length).toBeGreaterThan(100);
+    for (const tool of tools) {
+      expect(tool.inputSchema.additionalProperties, tool.name).toBe(false);
+    }
+  });
+
+  it('advertises closed schemas for every structured financial-document row', async () => {
+    const { client } = await setupClientServer();
+    const { tools } = await client.listTools();
+    const structuredRows = [
+      ['fortnox_create_invoice', 'InvoiceRows'],
+      ['fortnox_update_invoice', 'InvoiceRows'],
+      ['fortnox_create_supplier_invoice', 'SupplierInvoiceRows'],
+      ['fortnox_create_offer', 'OfferRows'],
+      ['fortnox_update_offer', 'OfferRows'],
+      ['fortnox_create_order', 'OrderRows'],
+      ['fortnox_update_order', 'OrderRows'],
+      ['fortnox_create_voucher', 'VoucherRows'],
+    ] as const;
+
+    for (const [toolName, rowProperty] of structuredRows) {
+      const tool = tools.find((candidate) => candidate.name === toolName)!;
+      const schema = tool.inputSchema as {
+        properties: Record<string, { items?: { additionalProperties?: boolean } }>;
+      };
+      expect(schema.properties[rowProperty].items?.additionalProperties, toolName).toBe(false);
+    }
+  });
+
+  it('preserves additional fields in the intentional contract-row passthrough', async () => {
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_create_contract',
+      arguments: {
+        CustomerNumber: '25',
+        InvoiceRows: [
+          {
+            ArticleNumber: '10',
+            DeliveredQuantity: 1,
+            Price: 500,
+            FutureFortnoxField: 'bevaras',
+          },
+        ],
+        dryRun: true,
+      },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain('"FutureFortnoxField": "bevaras"');
+  });
+});


### PR DESCRIPTION
## Summary

- register every existing raw-shape MCP tool input as a strict top-level Zod object
- make structured invoice, supplier-invoice, offer, order, and voucher rows strict
- preserve the explicit passthrough contracts used for open Fortnox payloads
- add regression coverage for top-level and nested unknown arguments, schema discovery, passthrough behavior, and future registration overloads

## Why

The MCP SDK's default object parsing silently stripped undeclared keys. That was the shared failure mode behind #96 and #101: a mutation could succeed after dropping data the caller believed had been sent. Unknown keys now fail validation before any Fortnox request and name the offending field in the error.

## Verification

- red phase: the new top-level and nested tests both reached a mocked Fortnox POST after silently removing the unknown field
- `npm run verify` — 77 files, 873 tests
- `npm audit --omit=dev` — 0 production vulnerabilities
- packed `noxctl/embedded` runtime and type consumer
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

## Review

- M5 `qwen3-coder-next-80b` performed a bounded design review and an independent final diff review
- adopted: explicit regression coverage for unsupported registration overloads
- declined with evidence: a claimed type-only runtime import bug (`McpServer` is only a return type in `index.ts`, while the runtime class is imported by the factory); build and packed-consumer checks pass
- declined: wrapping `registerTool` would broaden the policy beyond the repository's documented legacy registration boundary and is unnecessary while all discovered tools are covered by the schema test

## Scope

No OpenAPI redistribution, hosted runtime, provider expansion, version bump, release, deployment, branch deletion, or npm publication.

Closes #127
