### PR TITLE
feat: add privacy-preserving schema audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,8 @@ npm test             # run tests
 npm run test:watch   # watch mode
 npm run lint         # ESLint with typescript-eslint
 npm run format       # format
+npm run check:api    # refresh the git-ignored OpenAPI cache and detect API drift
+npm run audit:schemas # compare selected MCP write schemas with the local cache
 ```
 
 ## Architecture

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,14 @@ package metadata, changelog, and README rather than as snapshots here.
 
 Weekly GitHub Actions workflow (`api-drift.yml`) fetches the Fortnox OpenAPI spec and compares it against the committed **fingerprint** (`api-spec/openapi-fingerprint.json` — opaque hashes only; the full spec is not stored in the repo, per Fortnox Developer Agreement cl. 6.1/6.3). Opens a GitHub issue labeled `api-drift` when endpoints/schemas change. Run locally with `npm run check:api`. Can also be triggered manually from the Actions tab.
 
+After fetching the local, git-ignored cache, run `npm run audit:schemas` to compare
+selected MCP write schemas with their OpenAPI payload components. Normal output and
+`api-spec/tool-schema-coverage.json` contain counts and opaque hashes only. Use
+`npm run audit:schemas -- --show-fields` for an explicit local diagnostic, and update
+the baseline with `npm run audit:schemas -- --update` only after reviewing an intended
+specification or tool-schema change. The coverage audit is deliberately local until
+its privacy boundary has been validated before CI integration.
+
 ## Roadmap
 
 ### Tier 2 — Usability

--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -1,0 +1,47 @@
+{
+  "formatVersion": 1,
+  "records": [
+    {
+      "id": "invoice-row",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 18,
+      "missingPropertyCount": 10,
+      "stateHash": "e04c83af8dda43e69d4aeec0c041b72ae2f782e7587b4f6dd83870acf22a6bab"
+    },
+    {
+      "id": "offer-row",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 19,
+      "missingPropertyCount": 12,
+      "stateHash": "60562fc9976fddccdbe0e99844a63ed092b77f225728aeed40350d61793bd7f9"
+    },
+    {
+      "id": "order-row",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 19,
+      "missingPropertyCount": 11,
+      "stateHash": "895148d406eb97c741d8a5b100df43cdd56c7302d81dc98a4a8574f7144c4c70"
+    },
+    {
+      "id": "supplier",
+      "declaredPropertyCount": 44,
+      "specificationPropertyCount": 41,
+      "missingPropertyCount": 0,
+      "stateHash": "22830034d8b00b23ddb2594bc76450751c81a3a16aaa50a7f44c20f82b62a545"
+    },
+    {
+      "id": "supplier-invoice-row",
+      "declaredPropertyCount": 4,
+      "specificationPropertyCount": 18,
+      "missingPropertyCount": 15,
+      "stateHash": "da75598bb1e7623170ae1b6ce0ff6096a55df3055d765ce8445a9c0d96f6283a"
+    },
+    {
+      "id": "voucher-row",
+      "declaredPropertyCount": 9,
+      "specificationPropertyCount": 9,
+      "missingPropertyCount": 0,
+      "stateHash": "d3d7fc08d35e0a5bdf4c2279bab5f5e2902cc070f2dff84e284e930e4a20d294"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "verify": "npm run lint && npm run format:check && npm run build && npm test",
     "check:release": "npm run verify && npm audit --omit=dev && node scripts/check-embedded-consumer.mjs && npm pack --dry-run --ignore-scripts",
     "check:api": "bash scripts/check-api-changes.sh",
+    "audit:schemas": "npm run build --silent && node scripts/audit-tool-schemas.mjs",
     "prepublishOnly": "npm run check:release",
     "prepare": "husky"
   },

--- a/scripts/audit-tool-schemas.mjs
+++ b/scripts/audit-tool-schemas.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../dist/index.js';
+import {
+  auditSchemaCoverage,
+  compareAuditBaselines,
+  formatAuditFields,
+  formatAuditSummary,
+  toAuditBaseline,
+} from '../dist/schema-audit.js';
+import { SCHEMA_AUDIT_MAPPINGS } from '../dist/schema-audit-mappings.js';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_DIR = path.dirname(SCRIPT_DIR);
+const DEFAULT_SPEC = path.join(REPO_DIR, 'api-spec', 'openapi.json');
+const DEFAULT_BASELINE = path.join(REPO_DIR, 'api-spec', 'tool-schema-coverage.json');
+
+function usage() {
+  return [
+    'Usage: node scripts/audit-tool-schemas.mjs [options]',
+    '',
+    'Options:',
+    '  --update             Replace the opaque baseline with the current result',
+    '  --show-fields        Print raw missing field names locally; never writes baseline',
+    '  --spec <path>        Read a different local OpenAPI document',
+    '  --baseline <path>    Read or update a different baseline',
+    '  --help               Show this help',
+    '',
+  ].join('\n');
+}
+
+function parseArgs(args) {
+  const options = {
+    update: false,
+    showFields: false,
+    specPath: DEFAULT_SPEC,
+    baselinePath: DEFAULT_BASELINE,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--update') options.update = true;
+    else if (arg === '--show-fields') options.showFields = true;
+    else if (arg === '--spec' || arg === '--baseline') {
+      const value = args[index + 1];
+      if (!value) throw new Error(`${arg} requires a path`);
+      if (arg === '--spec') options.specPath = path.resolve(value);
+      else options.baselinePath = path.resolve(value);
+      index += 1;
+    } else if (arg === '--help') {
+      process.stdout.write(usage());
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (options.update && options.showFields) {
+    throw new Error('--update and --show-fields cannot be combined');
+  }
+  return options;
+}
+
+async function readJson(filePath, description) {
+  let contents;
+  try {
+    contents = await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') throw new Error(`${description} not found at ${filePath}`);
+    throw new Error(`Could not read ${description} at ${filePath}: ${error.message}`);
+  }
+
+  try {
+    return JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`${description} is not valid JSON: ${error.message}`);
+  }
+}
+
+async function discoverTools() {
+  const server = createServer({
+    transport: async () => {
+      throw new Error('Schema discovery must not make Fortnox requests');
+    },
+  });
+  const client = new Client({ name: 'noxctl-schema-audit', version: '1' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const { tools } = await client.listTools();
+    return tools;
+  } finally {
+    await Promise.allSettled([client.close(), server.close()]);
+  }
+}
+
+async function writeJsonAtomically(filePath, value) {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    await rename(temporaryPath, filePath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [spec, tools] = await Promise.all([
+    readJson(options.specPath, 'OpenAPI specification'),
+    discoverTools(),
+  ]);
+  const results = auditSchemaCoverage(spec, tools, SCHEMA_AUDIT_MAPPINGS);
+  const current = toAuditBaseline(results);
+
+  if (options.showFields) {
+    process.stdout.write(formatAuditFields(results));
+    return;
+  }
+
+  if (options.update) {
+    await writeJsonAtomically(options.baselinePath, current);
+    process.stdout.write(formatAuditSummary(results));
+    return;
+  }
+
+  const expected = await readJson(options.baselinePath, 'Schema-audit baseline');
+  const comparison = compareAuditBaselines(expected, current);
+  process.stdout.write(formatAuditSummary(results, comparison));
+  if (!comparison.matches) {
+    process.stderr.write(`Changed mappings: ${comparison.changedMappingIds.join(', ')}\n`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`Schema audit failed: ${error.message}\n`);
+  process.exitCode = 2;
+});

--- a/src/schema-audit-mappings.ts
+++ b/src/schema-audit-mappings.ts
@@ -1,0 +1,46 @@
+import type { SchemaAuditMapping } from './schema-audit.js';
+
+/**
+ * First-wave write-schema coverage mappings.
+ *
+ * Component names are already part of the committed opaque API fingerprint. The
+ * OpenAPI document and its property names remain in the git-ignored local cache.
+ */
+export const SCHEMA_AUDIT_MAPPINGS: readonly SchemaAuditMapping[] = [
+  {
+    id: 'invoice-row',
+    toolName: 'fortnox_create_invoice',
+    toolSchemaPointer: '/properties/InvoiceRows/items',
+    specSchemaName: 'fortnox_Kf_InvoiceRowSinglePayloadItem',
+  },
+  {
+    id: 'offer-row',
+    toolName: 'fortnox_create_offer',
+    toolSchemaPointer: '/properties/OfferRows/items',
+    specSchemaName: 'fortnox_Offer_OfferRowSinglePayloadItem',
+  },
+  {
+    id: 'order-row',
+    toolName: 'fortnox_create_order',
+    toolSchemaPointer: '/properties/OrderRows/items',
+    specSchemaName: 'fortnox_Order_OrderRowSinglePayloadItem',
+  },
+  {
+    id: 'supplier',
+    toolName: 'fortnox_create_supplier',
+    toolSchemaPointer: '',
+    specSchemaName: 'fortnox_Lf_SupplierSinglePayloadItem',
+  },
+  {
+    id: 'supplier-invoice-row',
+    toolName: 'fortnox_create_supplier_invoice',
+    toolSchemaPointer: '/properties/SupplierInvoiceRows/items',
+    specSchemaName: 'fortnox_Lf_SupplierInvoiceRowSinglePayloadItem',
+  },
+  {
+    id: 'voucher-row',
+    toolName: 'fortnox_create_voucher',
+    toolSchemaPointer: '/properties/VoucherRows/items',
+    specSchemaName: 'fortnox_Bf_VoucherRowSinglePayloadItem',
+  },
+];

--- a/src/schema-audit.ts
+++ b/src/schema-audit.ts
@@ -1,0 +1,216 @@
+import { createHash } from 'node:crypto';
+
+const HASH_DOMAIN = 'noxctl-openapi-tool-schema-audit/v1';
+
+type JsonObject = Record<string, unknown>;
+
+export interface DiscoveredToolSchema {
+  name: string;
+  inputSchema: JsonObject;
+}
+
+export interface SchemaAuditMapping {
+  /** Stable public identifier used in logs and the opaque baseline. */
+  id: string;
+  toolName: string;
+  /** JSON Pointer from the tool's inputSchema to the object being compared. */
+  toolSchemaPointer: string;
+  /** Component name under components.schemas in the local OpenAPI cache. */
+  specSchemaName: string;
+  ignoredProperties?: readonly string[];
+}
+
+export interface SchemaAuditResult {
+  id: string;
+  declaredPropertyCount: number;
+  specificationPropertyCount: number;
+  ignoredProperties: string[];
+  missingProperties: string[];
+  stateHash: string;
+}
+
+export interface SchemaAuditBaselineRecord {
+  id: string;
+  declaredPropertyCount: number;
+  specificationPropertyCount: number;
+  missingPropertyCount: number;
+  stateHash: string;
+}
+
+export interface SchemaAuditBaseline {
+  formatVersion: 1;
+  records: SchemaAuditBaselineRecord[];
+}
+
+export interface SchemaAuditComparison {
+  matches: boolean;
+  changedMappingIds: string[];
+}
+
+function asObject(value: unknown, description: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${description} is not an object`);
+  }
+  return value as JsonObject;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function decodePointerSegment(segment: string): string {
+  return segment.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function resolvePointer(root: unknown, pointer: string, description: string): unknown {
+  if (pointer === '') return root;
+  if (!pointer.startsWith('/')) {
+    throw new Error(`${description} pointer must be empty or start with "/"`);
+  }
+
+  let current = root;
+  for (const encodedSegment of pointer.slice(1).split('/')) {
+    const segment = decodePointerSegment(encodedSegment);
+    const object = asObject(current, `${description} pointer parent`);
+    if (!Object.hasOwn(object, segment)) {
+      throw new Error(`${description} pointer not found`);
+    }
+    current = object[segment];
+  }
+  return current;
+}
+
+function sortedPropertyNames(schema: unknown, description: string): string[] {
+  const object = asObject(schema, description);
+  const properties = asObject(object['properties'], `${description} properties`);
+  return Object.keys(properties).sort(compareText);
+}
+
+function stateHash(mappingId: string, ignored: string[], missing: string[]): string {
+  const canonical = JSON.stringify({
+    domain: HASH_DOMAIN,
+    mappingId,
+    ignored,
+    missing,
+  });
+  return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+export function auditSchemaCoverage(
+  spec: unknown,
+  tools: readonly DiscoveredToolSchema[],
+  mappings: readonly SchemaAuditMapping[],
+): SchemaAuditResult[] {
+  const specObject = asObject(spec, 'OpenAPI document');
+  const components = asObject(specObject['components'], 'OpenAPI components');
+  const schemas = asObject(components['schemas'], 'OpenAPI component schemas');
+  const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+  const seenIds = new Set<string>();
+
+  const results = mappings.map((mapping) => {
+    if (seenIds.has(mapping.id)) {
+      throw new Error(`Duplicate schema-audit mapping id: ${mapping.id}`);
+    }
+    seenIds.add(mapping.id);
+
+    const tool = toolsByName.get(mapping.toolName);
+    if (!tool) throw new Error(`Mapped tool not found: ${mapping.id}`);
+
+    if (!Object.hasOwn(schemas, mapping.specSchemaName)) {
+      throw new Error(`Mapped OpenAPI schema not found: ${mapping.id}`);
+    }
+
+    const toolSchema = resolvePointer(
+      tool.inputSchema,
+      mapping.toolSchemaPointer,
+      `Tool schema for ${mapping.id}`,
+    );
+    const declared = sortedPropertyNames(toolSchema, `Tool schema for ${mapping.id}`);
+    const specification = sortedPropertyNames(
+      schemas[mapping.specSchemaName],
+      `OpenAPI schema for ${mapping.id}`,
+    );
+    const ignored = [...new Set(mapping.ignoredProperties ?? [])].sort(compareText);
+    const declaredSet = new Set(declared);
+    const ignoredSet = new Set(ignored);
+    const missing = specification.filter(
+      (property) => !declaredSet.has(property) && !ignoredSet.has(property),
+    );
+
+    return {
+      id: mapping.id,
+      declaredPropertyCount: declared.length,
+      specificationPropertyCount: specification.length,
+      ignoredProperties: ignored,
+      missingProperties: missing,
+      stateHash: stateHash(mapping.id, ignored, missing),
+    };
+  });
+
+  return results.sort((a, b) => compareText(a.id, b.id));
+}
+
+export function toAuditBaseline(results: readonly SchemaAuditResult[]): SchemaAuditBaseline {
+  return {
+    formatVersion: 1,
+    records: [...results]
+      .sort((a, b) => compareText(a.id, b.id))
+      .map((result) => ({
+        id: result.id,
+        declaredPropertyCount: result.declaredPropertyCount,
+        specificationPropertyCount: result.specificationPropertyCount,
+        missingPropertyCount: result.missingProperties.length,
+        stateHash: result.stateHash,
+      })),
+  };
+}
+
+function recordsById(baseline: SchemaAuditBaseline): Map<string, SchemaAuditBaselineRecord> {
+  return new Map(baseline.records.map((record) => [record.id, record]));
+}
+
+export function compareAuditBaselines(
+  expected: SchemaAuditBaseline,
+  current: SchemaAuditBaseline,
+): SchemaAuditComparison {
+  const expectedById = recordsById(expected);
+  const currentById = recordsById(current);
+  const ids = new Set([...expectedById.keys(), ...currentById.keys()]);
+  const changedMappingIds = [...ids]
+    .filter((id) => JSON.stringify(expectedById.get(id)) !== JSON.stringify(currentById.get(id)))
+    .sort(compareText);
+
+  return {
+    matches: expected.formatVersion === current.formatVersion && changedMappingIds.length === 0,
+    changedMappingIds:
+      expected.formatVersion === current.formatVersion
+        ? changedMappingIds
+        : ['$format', ...changedMappingIds],
+  };
+}
+
+export function formatAuditSummary(
+  results: readonly SchemaAuditResult[],
+  comparison?: SchemaAuditComparison,
+): string {
+  const status = comparison ? (comparison.matches ? 'ok' : 'drift') : 'generated';
+  const lines = [`Schema audit: ${status}`];
+  for (const result of [...results].sort((a, b) => compareText(a.id, b.id))) {
+    lines.push(
+      `${result.id}: declared=${result.declaredPropertyCount} spec=${result.specificationPropertyCount} missing=${result.missingProperties.length} state=${result.stateHash}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatAuditFields(results: readonly SchemaAuditResult[]): string {
+  const lines: string[] = [];
+  for (const result of [...results].sort((a, b) => compareText(a.id, b.id))) {
+    lines.push(`${result.id}:`);
+    // Property names originate in a fetched document. JSON quoting preserves
+    // their exact value while preventing terminal control-sequence injection.
+    lines.push(...result.missingProperties.map((property) => `  - ${JSON.stringify(property)}`));
+    if (result.missingProperties.length === 0) lines.push('  (none)');
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/tests/schema-audit.test.ts
+++ b/tests/schema-audit.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/index.js';
+import {
+  auditSchemaCoverage,
+  compareAuditBaselines,
+  formatAuditFields,
+  formatAuditSummary,
+  toAuditBaseline,
+  type SchemaAuditMapping,
+} from '../src/schema-audit.js';
+import { SCHEMA_AUDIT_MAPPINGS } from '../src/schema-audit-mappings.js';
+
+const mapping: SchemaAuditMapping = {
+  id: 'example-row',
+  toolName: 'fortnox_create_example',
+  toolSchemaPointer: '/properties/Rows/items',
+  specSchemaName: 'ExampleRow',
+  ignoredProperties: ['IgnoredByDesign'],
+};
+
+function syntheticInputs() {
+  return {
+    tools: [
+      {
+        name: 'fortnox_create_example',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            Rows: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  Present: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+    spec: {
+      components: {
+        schemas: {
+          ExampleRow: {
+            type: 'object',
+            properties: {
+              Present: { type: 'string' },
+              Missing: { type: 'number' },
+              IgnoredByDesign: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('OpenAPI tool-schema audit', () => {
+  it('finds missing properties and applies explicit ignores', () => {
+    const { spec, tools } = syntheticInputs();
+
+    const [result] = auditSchemaCoverage(spec, tools, [mapping]);
+
+    expect(result).toMatchObject({
+      id: 'example-row',
+      declaredPropertyCount: 1,
+      specificationPropertyCount: 3,
+      missingProperties: ['Missing'],
+    });
+  });
+
+  it('produces deterministic, domain-separated hashes that include mapping and ignores', () => {
+    const { spec, tools } = syntheticInputs();
+    const first = toAuditBaseline(auditSchemaCoverage(spec, tools, [mapping]));
+    const second = toAuditBaseline(auditSchemaCoverage(spec, tools, [mapping]));
+    const changedId = toAuditBaseline(
+      auditSchemaCoverage(spec, tools, [{ ...mapping, id: 'another-row' }]),
+    );
+    const changedIgnores = toAuditBaseline(
+      auditSchemaCoverage(spec, tools, [{ ...mapping, ignoredProperties: [] }]),
+    );
+
+    expect(second).toEqual(first);
+    expect(changedId.records[0]?.stateHash).not.toBe(first.records[0]?.stateHash);
+    expect(changedIgnores.records[0]?.stateHash).not.toBe(first.records[0]?.stateHash);
+    expect(JSON.stringify(first)).not.toContain('Missing');
+    expect(JSON.stringify(first)).not.toContain('IgnoredByDesign');
+    expect(JSON.stringify(first)).not.toContain('Present');
+  });
+
+  it('detects baseline drift without disclosing property names in normal output', () => {
+    const { spec, tools } = syntheticInputs();
+    const results = auditSchemaCoverage(spec, tools, [mapping]);
+    const current = toAuditBaseline(results);
+    const expected = structuredClone(current);
+    expected.records[0]!.missingPropertyCount = 2;
+
+    const comparison = compareAuditBaselines(expected, current);
+    const output = formatAuditSummary(results, comparison);
+
+    expect(comparison).toEqual({ matches: false, changedMappingIds: ['example-row'] });
+    expect(output).toContain('example-row');
+    expect(output).toContain('drift');
+    expect(output).not.toContain('Missing');
+    expect(output).not.toContain('IgnoredByDesign');
+    expect(output).not.toContain('Present');
+  });
+
+  it('reveals raw names only through the explicit field formatter', () => {
+    const { spec, tools } = syntheticInputs();
+    const results = auditSchemaCoverage(spec, tools, [mapping]);
+
+    expect(formatAuditFields(results)).toContain('Missing');
+  });
+
+  it('escapes control characters in explicit field diagnostics', () => {
+    const { spec, tools } = syntheticInputs();
+    const properties = spec.components.schemas.ExampleRow.properties;
+    Object.assign(properties, { '\u001b[31mDanger\u001b[0m\nField': { type: 'string' } });
+
+    const output = formatAuditFields(auditSchemaCoverage(spec, tools, [mapping]));
+
+    expect(output).not.toContain('\u001b');
+    expect(output).toContain('\\u001b[31mDanger\\u001b[0m\\nField');
+  });
+
+  it('fails closed when a tool, pointer, or OpenAPI component cannot be resolved', () => {
+    const { spec, tools } = syntheticInputs();
+
+    expect(() => auditSchemaCoverage(spec, [], [mapping])).toThrow(/tool.*not found/i);
+    expect(() =>
+      auditSchemaCoverage(spec, tools, [
+        { ...mapping, toolSchemaPointer: '/properties/Unknown/items' },
+      ]),
+    ).toThrow(/pointer.*not found/i);
+    expect(() =>
+      auditSchemaCoverage(spec, tools, [{ ...mapping, specSchemaName: 'Unknown' }]),
+    ).toThrow(/schema.*not found/i);
+  });
+
+  it('sorts mappings and properties for byte-stable baseline serialization', () => {
+    const { spec, tools } = syntheticInputs();
+    const other = { ...mapping, id: 'aaa-example-row' };
+    const baseline = toAuditBaseline(auditSchemaCoverage(spec, tools, [mapping, other]));
+
+    expect(baseline.formatVersion).toBe(1);
+    expect(baseline.records.map((record) => record.id)).toEqual(['aaa-example-row', 'example-row']);
+    expect(`${JSON.stringify(baseline, null, 2)}\n`).toBe(
+      `${JSON.stringify(toAuditBaseline(auditSchemaCoverage(spec, tools, [other, mapping])), null, 2)}\n`,
+    );
+  });
+
+  it('resolves every production mapping against the actual discovered MCP schemas', async () => {
+    const server = createServer({
+      transport: async () => {
+        throw new Error('Unexpected Fortnox request');
+      },
+    });
+    const client = new Client({ name: 'schema-audit-test', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+      const { tools } = await client.listTools();
+      const schemas = Object.fromEntries(
+        SCHEMA_AUDIT_MAPPINGS.map(({ specSchemaName }) => [
+          specSchemaName,
+          { type: 'object', properties: {} },
+        ]),
+      );
+
+      const results = auditSchemaCoverage(
+        { components: { schemas } },
+        tools,
+        SCHEMA_AUDIT_MAPPINGS,
+      );
+
+      expect(results).toHaveLength(6);
+      expect(results.every((result) => result.declaredPropertyCount > 0)).toBe(true);
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a local OpenAPI-to-MCP write-schema coverage audit for six high-risk mappings
- keep Fortnox property names out of normal output and the committed deterministic baseline
- provide explicit local `--show-fields` diagnostics and `--update` baseline refresh
- fail closed when tools, JSON pointers, components, or baseline state cannot be resolved
- document the local workflow without adding weekly CI integration yet

## Privacy boundary

The full `api-spec/openapi.json` remains git-ignored and is not part of this PR. Normal
and update output contains only stable mapping IDs, counts, and domain-separated SHA-256
state hashes. Raw property names are available only through the explicit local
`--show-fields` mode and are JSON-escaped before terminal output.

## Verification

- `npm run verify` — 78 files, 881 tests
- `npm run check:release` — 0 production vulnerabilities; packed embedded consumer and package dry-run passed
- real local cached-spec compare — baseline matched
- automated local leakage check — normal output contained no mapped OpenAPI property token
- native Codex diff review — terminal control-sequence finding fixed and regression-tested
- independent M5 review (`qwen3-coder-next-80b`) — residual findings validated; no remaining blocker

## Non-goals / follow-up

- no type, enum, requiredness, or conditional-field compatibility audit yet
- no weekly workflow integration until the privacy-safe output boundary is proven in use
- no automatic expansion of the known invoice/offer/order/supplier-invoice row gaps
- no release

Closes #129
