### PR TITLE
feat: complete supplier invoice row schema

### DIFF
--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -31,10 +31,10 @@
     },
     {
       "id": "supplier-invoice-row",
-      "declaredPropertyCount": 4,
+      "declaredPropertyCount": 19,
       "specificationPropertyCount": 18,
-      "missingPropertyCount": 15,
-      "stateHash": "da75598bb1e7623170ae1b6ce0ff6096a55df3055d765ce8445a9c0d96f6283a"
+      "missingPropertyCount": 0,
+      "stateHash": "25c363c59fda47579aaf27c77e21c3af3fa7c239d23a2a0d01a18533c2e65d3f"
     },
     {
       "id": "voucher-row",

--- a/src/tools/supplier-invoices.ts
+++ b/src/tools/supplier-invoices.ts
@@ -14,10 +14,50 @@ import {
 } from '../tool-output.js';
 
 const SupplierInvoiceRowSchema = z.strictObject({
-  Account: z.number().describe('Kontonummer'),
+  Account: z.number().int().min(1000).max(9999).describe('Kontonummer (1000–9999)'),
+  AccountDescription: z.string().optional().describe('Kontobeskrivning'),
+  ArticleNumber: z.string().optional().describe('Artikelnummer'),
+  Code: z
+    .enum([
+      'TOT',
+      'VAT',
+      'FRT',
+      'AFE',
+      'ROV',
+      'CND',
+      'CNC',
+      'PRD',
+      'PRC',
+      'SRD',
+      'SRC',
+      'PRE',
+      'GWB',
+      'ACC',
+    ])
+    .optional()
+    .describe('Radkod enligt Fortnox'),
+  CostCenter: z.string().nullable().optional().describe('Kostnadsställe'),
   Debit: z.number().optional().describe('Debetbelopp'),
+  DebitCurrency: z.number().optional().describe('Debetbelopp i fakturans valuta'),
   Credit: z.number().optional().describe('Kreditbelopp'),
-  Description: z.string().optional().describe('Beskrivning'),
+  CreditCurrency: z.number().optional().describe('Kreditbelopp i fakturans valuta'),
+  Description: z
+    .string()
+    .optional()
+    .describe('Äldre kompatibilitetsfält för beskrivning; använd ItemDescription'),
+  ItemDescription: z.string().optional().describe('Artikel- eller radbeskrivning'),
+  Price: z.number().optional().describe('Pris per enhet'),
+  Project: z.string().optional().describe('Projektnummer'),
+  Quantity: z.number().int().optional().describe('Antal'),
+  StockLocationCode: z.string().optional().describe('Lagerplatskod'),
+  StockPointCode: z.string().optional().describe('Lagerställekod'),
+  Total: z.number().nullable().optional().describe('Radens totalbelopp'),
+  TransactionInformation: z
+    .string()
+    .max(100)
+    .optional()
+    .describe('Transaktionsinformation (max 100 tecken)'),
+  Unit: z.string().optional().describe('Enhet'),
 });
 
 export function registerSupplierInvoiceTools(
@@ -94,7 +134,7 @@ export function registerSupplierInvoiceTools(
       SupplierInvoiceRows: z
         .array(SupplierInvoiceRowSchema)
         .optional()
-        .describe('Fakturarader med konto, debet och kredit'),
+        .describe('Fakturarader med kontering, belopp och valfri artikel-/lagerinformation'),
       confirm: z.boolean().optional().describe('Bekräfta att leverantörsfakturan ska skapas'),
       dryRun: z
         .boolean()

--- a/tests/tools/supplier-invoices.test.ts
+++ b/tests/tools/supplier-invoices.test.ts
@@ -110,6 +110,89 @@ describe('supplier invoice tools', () => {
       expect(body.SupplierInvoice.SupplierNumber).toBe('5');
     });
 
+    it('advertises and preserves the complete supplier invoice row payload', async () => {
+      mockFetch({
+        SupplierInvoice: { GivenNumber: 10, SupplierNumber: '5', Total: 1000 },
+      });
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const createTool = tools.find((tool) => tool.name === 'fortnox_create_supplier_invoice');
+      const input = createTool?.inputSchema as {
+        properties: {
+          SupplierInvoiceRows: {
+            items: { properties: Record<string, { enum?: string[] }> };
+          };
+        };
+      };
+      const rowProperties = input.properties.SupplierInvoiceRows.items.properties;
+
+      expect(Object.keys(rowProperties)).toHaveLength(19);
+      expect(rowProperties.Code?.enum).toHaveLength(14);
+      expect(rowProperties.Code?.enum).toContain('TOT');
+      expect(rowProperties.Code?.enum).toContain('ACC');
+
+      const row = {
+        Account: 5410,
+        AccountDescription: 'Förbrukningsinventarier',
+        ArticleNumber: 'LAPTOP',
+        Code: 'ACC',
+        CostCenter: null,
+        Credit: 0,
+        CreditCurrency: 0,
+        Debit: 1000,
+        DebitCurrency: 1000,
+        Description: 'Bakåtkompatibel beskrivning',
+        ItemDescription: 'Laptop',
+        Price: 1000,
+        Project: 'P1',
+        Quantity: 1,
+        StockLocationCode: 'STH',
+        StockPointCode: 'A1',
+        Total: null,
+        TransactionInformation: 'Laptopinköp',
+        Unit: 'st',
+      };
+
+      const result = await client.callTool({
+        name: 'fortnox_create_supplier_invoice',
+        arguments: {
+          SupplierNumber: '5',
+          SupplierInvoiceRows: [row],
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.SupplierInvoice.SupplierInvoiceRows[0]).toEqual(row);
+    });
+
+    it.each([
+      ['an unknown row code', { Account: 5410, Code: 'UNKNOWN' }],
+      ['an out-of-range account', { Account: 999 }],
+      ['a fractional quantity', { Account: 5410, Quantity: 1.5 }],
+      [
+        'overlong transaction information',
+        { Account: 5410, TransactionInformation: 'x'.repeat(101) },
+      ],
+    ])('rejects %s before making a Fortnox request', async (_case, row) => {
+      mockFetch({ SupplierInvoice: {} });
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_create_supplier_invoice',
+        arguments: {
+          SupplierNumber: '5',
+          SupplierInvoiceRows: [row],
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
     it('requires confirmation', async () => {
       mockFetch({ SupplierInvoice: {} });
       const { client } = await setupClientServer();


### PR DESCRIPTION
## Summary

- expand strict supplier-invoice row discovery from four fields to the complete
  current Fortnox request-component coverage
- preserve the existing optional legacy `Description` field while guiding callers to
  `ItemDescription`
- enforce the documented row-code enum, account range, integer quantity,
  transaction-information length, and nullable fields
- prove every supported value survives MCP validation into the Fortnox POST payload
- refresh the privacy-safe audit baseline from 15 missing supplier-invoice fields to 0

## Verification

- focused red/green supplier-invoice tests — 13 passing
- `npm run verify` — 78 files, 886 tests
- `npm run audit:schemas` — `supplier-invoice-row` reports `missing=0`; baseline matches
- `npm run check:release` — 0 production vulnerabilities; embedded consumer and
  package dry-run passed
- native Codex diff review — stale discovery description fixed
- independent M5 review (`qwen3-coder-next-80b`) — grounded enum test gap fixed;
  ungrounded nullable/field-mapping claims validated and declined

## Scope

This is the first implementation slice of #131. The umbrella remains open for invoice,
offer, and order rows. The full local OpenAPI cache is git-ignored and is not part of
this PR. No release is included.

Part of #131
