### PR TITLE
feat: complete invoice row schema

### DIFF
--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -3,10 +3,10 @@
   "records": [
     {
       "id": "invoice-row",
-      "declaredPropertyCount": 8,
+      "declaredPropertyCount": 18,
       "specificationPropertyCount": 18,
-      "missingPropertyCount": 10,
-      "stateHash": "e04c83af8dda43e69d4aeec0c041b72ae2f782e7587b4f6dd83870acf22a6bab"
+      "missingPropertyCount": 0,
+      "stateHash": "c88088ad9b7760e55821ad2ff4d22076a4efdc2e2a9a2419d7fe67bf62978a08"
     },
     {
       "id": "offer-row",

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -21,14 +21,61 @@ import {
 } from '../tool-output.js';
 
 const InvoiceRowSchema = z.strictObject({
+  AccountNumber: z.number().int().min(1000).max(9999).optional().describe('Kontonummer'),
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
-  Description: z.string().describe('Beskrivning'),
-  DeliveredQuantity: z.number().describe('Antal'),
+  Cost: z.number().min(-9_999_999_999).max(9_999_999_999).nullable().optional().describe('Kostnad'),
+  CostCenter: z.string().nullable().optional().describe('Kostnadsställe'),
+  DeliveredQuantity: z
+    .union([z.string(), z.number()])
+    .describe('Levererat antal (nummer eller decimalsträng)'),
+  Description: z.string().max(255).describe('Beskrivning (max 255 tecken)'),
+  Discount: z.number().optional().describe('Rabattvärde'),
+  DiscountType: z.enum(['AMOUNT', 'PERCENT']).optional().describe('Rabatttyp'),
+  HouseWork: z.boolean().optional().describe('Markera raden som husarbete (ROT/RUT)'),
+  HouseWorkHoursToReport: z
+    .number()
+    .int()
+    .min(0)
+    .max(999)
+    .nullable()
+    .optional()
+    .describe('Timmar att rapportera för husarbete (0–999)'),
+  HouseWorkType: z
+    .enum([
+      'CONSTRUCTION',
+      'ELECTRICITY',
+      'GLASSMETALWORK',
+      'GROUNDDRAINAGEWORK',
+      'MASONRY',
+      'PAINTINGWALLPAPERING',
+      'HVAC',
+      'MAJORAPPLIANCEREPAIR',
+      'MOVINGSERVICES',
+      'ITSERVICES',
+      'CLEANING',
+      'TEXTILECLOTHING',
+      'SNOWPLOWING',
+      'GARDENING',
+      'BABYSITTING',
+      'OTHERCARE',
+      'OTHERCOSTS',
+      'SOLARCELLS',
+      'STORAGESELFPRODUCEDELECTRICITY',
+      'CHARGINGSTATIONELECTRICVEHICLE',
+      'HOMEMAINTENANCE',
+      'FURNISHING',
+      'TRANSPORTATIONSERVICES',
+      'WASHINGANDCAREOFCLOTHING',
+    ])
+    .optional()
+    .describe('Typ av husarbete'),
   Price: z.number().describe('Pris per enhet (exkl. moms)'),
-  AccountNumber: z.number().optional().describe('Kontonummer (default: 3001)'),
-  VAT: z.number().optional().describe('Momssats i procent (default: 25)'),
-  Unit: z.string().optional().describe('Enhet (t.ex. "st", "tim")'),
-  Discount: z.number().optional().describe('Rabatt i procent'),
+  Project: z.string().optional().describe('Projektnummer'),
+  RowId: z.number().int().optional().describe('Rad-id'),
+  StockPointCode: z.string().optional().describe('Lagerställekod'),
+  Unit: z.string().max(20).optional().describe('Enhet (max 20 tecken)'),
+  VAT: z.number().int().optional().describe('Momssats i procent (default: 25)'),
+  VATCode: z.string().optional().describe('Momskod'),
 });
 
 const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be numeric');
@@ -181,18 +228,7 @@ export function registerInvoiceTools(
       documentNumber: DocumentNumberSchema.describe('Fakturanummer att uppdatera'),
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       InvoiceRows: z
-        .array(
-          z.strictObject({
-            ArticleNumber: z.string().optional().describe('Artikelnummer'),
-            Description: z.string().optional().describe('Beskrivning'),
-            DeliveredQuantity: z.number().optional().describe('Antal'),
-            Price: z.number().optional().describe('Pris per enhet (exkl. moms)'),
-            AccountNumber: z.number().optional().describe('Kontonummer'),
-            VAT: z.number().optional().describe('Momssats i procent'),
-            Unit: z.string().optional().describe('Enhet (t.ex. "st", "tim")'),
-            Discount: z.number().optional().describe('Rabatt i procent'),
-          }),
-        )
+        .array(InvoiceRowSchema.partial())
         .optional()
         .describe('Fakturarader (ersätter alla befintliga rader)'),
       DueDate: z.string().optional().describe('Förfallodatum (YYYY-MM-DD)'),

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -213,6 +213,100 @@ describe('invoice tools', () => {
       expect(body.Invoice.InvoiceRows[0].VAT).toBe(25);
       expect(body.Invoice.InvoiceRows[0].Unit).toBe('tim');
     });
+
+    it('advertises and preserves complete invoice rows for create and update', async () => {
+      mockFetch({ Invoice: { DocumentNumber: '1004', CustomerNumber: '42' } });
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const createTool = tools.find((tool) => tool.name === 'fortnox_create_invoice');
+      const updateTool = tools.find((tool) => tool.name === 'fortnox_update_invoice');
+      type RowProperties = Record<string, { enum?: string[] }>;
+      type InvoiceToolInput = {
+        properties: { InvoiceRows: { items: { properties: RowProperties } } };
+      };
+      const createProperties = (createTool?.inputSchema as InvoiceToolInput).properties.InvoiceRows
+        .items.properties;
+      const updateProperties = (updateTool?.inputSchema as InvoiceToolInput).properties.InvoiceRows
+        .items.properties;
+
+      expect(Object.keys(createProperties)).toHaveLength(18);
+      expect(Object.keys(updateProperties)).toHaveLength(18);
+      expect(createProperties.DiscountType?.enum).toEqual(['AMOUNT', 'PERCENT']);
+      expect(createProperties.HouseWorkType?.enum).toHaveLength(24);
+      expect(createProperties.HouseWorkType?.enum).toContain('CONSTRUCTION');
+      expect(createProperties.HouseWorkType?.enum).toContain('ITSERVICES');
+      expect(createProperties.HouseWorkType?.enum).toContain('WASHINGANDCAREOFCLOTHING');
+
+      const row = {
+        AccountNumber: 3001,
+        ArticleNumber: 'CONSULTING',
+        Cost: null,
+        CostCenter: null,
+        DeliveredQuantity: '2.5',
+        Description: 'Teknisk rådgivning',
+        Discount: 10,
+        DiscountType: 'PERCENT',
+        HouseWork: true,
+        HouseWorkHoursToReport: null,
+        HouseWorkType: 'ITSERVICES',
+        Price: 1200,
+        Project: 'P1',
+        RowId: 7,
+        StockPointCode: 'STH',
+        Unit: 'tim',
+        VAT: 25,
+        VATCode: 'SE25',
+      };
+
+      const created = await client.callTool({
+        name: 'fortnox_create_invoice',
+        arguments: { CustomerNumber: '42', InvoiceRows: [row], confirm: true },
+      });
+      const updated = await client.callTool({
+        name: 'fortnox_update_invoice',
+        arguments: { documentNumber: '1004', InvoiceRows: [row], confirm: true },
+      });
+
+      expect(created.isError).not.toBe(true);
+      expect(updated.isError).not.toBe(true);
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(JSON.parse(calls[0][1].body).Invoice.InvoiceRows[0]).toEqual(row);
+      expect(JSON.parse(calls[1][1].body).Invoice.InvoiceRows[0]).toEqual(row);
+    });
+
+    it.each([
+      ['an out-of-range account', { AccountNumber: 999 }],
+      ['an out-of-range cost', { Cost: 10_000_000_000 }],
+      ['an overlong description', { Description: 'x'.repeat(256) }],
+      ['an unknown discount type', { DiscountType: 'UNKNOWN' }],
+      ['too many house-work hours', { HouseWorkHoursToReport: 1000 }],
+      ['an unknown house-work type', { HouseWorkType: 'UNKNOWN' }],
+      ['a fractional row id', { RowId: 1.5 }],
+      ['an overlong unit', { Unit: 'x'.repeat(21) }],
+      ['a fractional VAT percentage', { VAT: 25.5 }],
+    ])('rejects %s before making an invoice request', async (_case, invalidFields) => {
+      mockFetch({ Invoice: {} });
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_create_invoice',
+        arguments: {
+          CustomerNumber: '42',
+          InvoiceRows: [
+            {
+              Description: 'Test',
+              DeliveredQuantity: 1,
+              Price: 100,
+              ...invalidFields,
+            },
+          ],
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
   });
 
   describe('fortnox_send_invoice', () => {


### PR DESCRIPTION
## Summary

- expand strict invoice-row discovery from eight fields to the complete current
  18-field Fortnox request-component coverage
- reuse one strict base schema for create and `partial()` update rows, eliminating
  future create/update drift
- preserve numeric `DeliveredQuantity` compatibility while accepting Fortnox's
  documented string representation without coercion
- enforce documented enums, integer/range, max-length, and nullable constraints
- prove a complete row survives both MCP create and update validation unchanged
- refresh the privacy-safe audit baseline from 10 missing invoice-row fields to 0

## Verification

- focused red/green invoice tests — 32 passing
- `npm run verify` — 78 files, 896 tests
- `npm run audit:schemas` — `invoice-row` reports `missing=0`; baseline matches
- `npm run check:release` — 0 production vulnerabilities; embedded consumer and
  package dry-run passed
- native Codex diff review — strict `partial()` behavior and create/update contract verified
- independent M5 review (`qwen3-coder-next-80b`) — no blocking findings; speculative
  residual claims checked against the local spec and payload tests

## Scope

This is the second implementation slice of #131. Supplier-invoice and invoice rows are
now complete; the umbrella remains open for offer and order rows. The full local
OpenAPI cache is git-ignored and is not part of this PR. No release is included.

Part of #131
