### PR TITLE
feat: complete offer row schema

### DIFF
--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -10,10 +10,10 @@
     },
     {
       "id": "offer-row",
-      "declaredPropertyCount": 8,
+      "declaredPropertyCount": 20,
       "specificationPropertyCount": 19,
-      "missingPropertyCount": 12,
-      "stateHash": "60562fc9976fddccdbe0e99844a63ed092b77f225728aeed40350d61793bd7f9"
+      "missingPropertyCount": 0,
+      "stateHash": "ad10515787a657a7ca9f5bec5cd49d33e34e2861c5aa31da0925e05e86e54f96"
     },
     {
       "id": "order-row",

--- a/src/tools/offers.ts
+++ b/src/tools/offers.ts
@@ -11,14 +11,53 @@ import {
 } from '../tool-output.js';
 
 const OfferRowSchema = z.strictObject({
+  AccountNumber: z.number().int().optional().describe('Kontonummer'),
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
-  Description: z.string().describe('Beskrivning'),
-  DeliveredQuantity: z.number().describe('Antal'),
+  ContributionPercent: z.string().optional().describe('Täckningsgrad i procent'),
+  ContributionValue: z.string().optional().describe('Täckningsbidrag'),
+  CostCenter: z.string().nullable().optional().describe('Kostnadsställe'),
+  Description: z.string().max(255).describe('Beskrivning (max 255 tecken)'),
+  DeliveredQuantity: z.number().describe('Antal (kompatibilitetsfält)'),
+  Discount: z.number().optional().describe('Rabattvärde'),
+  DiscountType: z.enum(['AMOUNT', 'PERCENT']).optional().describe('Rabatttyp'),
+  HouseWork: z.boolean().optional().describe('Markera raden som husarbete (ROT/RUT)'),
+  HouseWorkHoursToReport: z
+    .number()
+    .int()
+    .min(0)
+    .max(999)
+    .nullable()
+    .optional()
+    .describe('Timmar att rapportera för husarbete (0–999)'),
+  HouseWorkType: z
+    .enum([
+      'CONSTRUCTION',
+      'ELECTRICITY',
+      'GLASSMETALWORK',
+      'GROUNDDRAINAGEWORK',
+      'MASONRY',
+      'PAINTINGWALLPAPERING',
+      'HVAC',
+      'CLEANING',
+      'TEXTILECLOTHING',
+      'COOKING',
+      'SNOWPLOWING',
+      'GARDENING',
+      'BABYSITTING',
+      'OTHERCARE',
+      'TUTORING',
+      'OTHERCOSTS',
+    ])
+    .optional()
+    .describe('Typ av husarbete'),
   Price: z.number().describe('Pris per enhet (exkl. moms)'),
-  AccountNumber: z.number().optional().describe('Kontonummer (default: 3001)'),
-  VAT: z.number().optional().describe('Momssats i procent (default: 25)'),
-  Unit: z.string().optional().describe('Enhet (t.ex. "st", "tim")'),
-  Discount: z.number().optional().describe('Rabatt i procent'),
+  Project: z.string().optional().describe('Projektnummer'),
+  Quantity: z.string().optional().describe('Antal enligt Fortnox offertradskontrakt'),
+  RowId: z.number().int().optional().describe('Rad-id'),
+  Total: z.number().nullable().optional().describe('Radsumma'),
+  Unit: z.string().max(20).optional().describe('Enhet (max 20 tecken)'),
+  VAT: z.number().int().optional().describe('Momssats i procent (default: 25)'),
+  VATCode: z.string().optional().describe('Momskod'),
 });
 
 const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be numeric');
@@ -115,18 +154,7 @@ export function registerOfferTools(
       documentNumber: DocumentNumberSchema.describe('Offertnummer att uppdatera'),
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       OfferRows: z
-        .array(
-          z.strictObject({
-            ArticleNumber: z.string().optional().describe('Artikelnummer'),
-            Description: z.string().optional().describe('Beskrivning'),
-            DeliveredQuantity: z.number().optional().describe('Antal'),
-            Price: z.number().optional().describe('Pris per enhet (exkl. moms)'),
-            AccountNumber: z.number().optional().describe('Kontonummer'),
-            VAT: z.number().optional().describe('Momssats i procent'),
-            Unit: z.string().optional().describe('Enhet'),
-            Discount: z.number().optional().describe('Rabatt i procent'),
-          }),
-        )
+        .array(OfferRowSchema.partial())
         .optional()
         .describe('Offertrader (ersätter alla befintliga rader)'),
       ExpireDate: z.string().optional().describe('Utgångsdatum (YYYY-MM-DD)'),

--- a/tests/tools/offers.test.ts
+++ b/tests/tools/offers.test.ts
@@ -98,6 +98,114 @@ describe('offer tools', () => {
       const body = JSON.parse(fetchCall[1].body);
       expect(body.Offer.CustomerNumber).toBe('42');
     });
+
+    it('advertises and preserves complete offer rows for create and update', async () => {
+      mockFetch({ Offer: { DocumentNumber: '2', CustomerNumber: '42' } });
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const createTool = tools.find((tool) => tool.name === 'fortnox_create_offer');
+      const updateTool = tools.find((tool) => tool.name === 'fortnox_update_offer');
+      type RowProperties = Record<string, { enum?: string[] }>;
+      type OfferToolInput = {
+        properties: {
+          OfferRows: {
+            items: {
+              properties: RowProperties;
+              additionalProperties?: boolean;
+              required?: string[];
+            };
+          };
+        };
+      };
+      const createRows = (createTool?.inputSchema as OfferToolInput).properties.OfferRows.items;
+      const updateRows = (updateTool?.inputSchema as OfferToolInput).properties.OfferRows.items;
+
+      expect(Object.keys(createRows.properties)).toHaveLength(20);
+      expect(Object.keys(updateRows.properties)).toHaveLength(20);
+      expect(createRows.additionalProperties).toBe(false);
+      expect(updateRows.additionalProperties).toBe(false);
+      expect(createRows.required).toEqual(
+        expect.arrayContaining(['Description', 'DeliveredQuantity', 'Price']),
+      );
+      expect(updateRows.required ?? []).toEqual([]);
+      expect(createRows.properties.DiscountType?.enum).toEqual(['AMOUNT', 'PERCENT']);
+      expect(createRows.properties.HouseWorkType?.enum).toHaveLength(16);
+      expect(createRows.properties.HouseWorkType?.enum).toContain('CONSTRUCTION');
+      expect(createRows.properties.HouseWorkType?.enum).toContain('TUTORING');
+      expect(createRows.properties.HouseWorkType?.enum).toContain('OTHERCOSTS');
+
+      const row = {
+        AccountNumber: 3001,
+        ArticleNumber: 'CONSULTING',
+        ContributionPercent: '40.0',
+        ContributionValue: '480.0',
+        CostCenter: null,
+        Description: 'Teknisk rådgivning',
+        DeliveredQuantity: 2.5,
+        Discount: 10,
+        DiscountType: 'PERCENT',
+        HouseWork: true,
+        HouseWorkHoursToReport: null,
+        HouseWorkType: 'TUTORING',
+        Price: 1200,
+        Project: 'P1',
+        Quantity: '2.5',
+        RowId: 7,
+        Total: null,
+        Unit: 'tim',
+        VAT: 25,
+        VATCode: 'SE25',
+      };
+
+      const created = await client.callTool({
+        name: 'fortnox_create_offer',
+        arguments: { CustomerNumber: '42', OfferRows: [row], confirm: true },
+      });
+      const updated = await client.callTool({
+        name: 'fortnox_update_offer',
+        arguments: { documentNumber: '2', OfferRows: [row], confirm: true },
+      });
+
+      expect(created.isError).not.toBe(true);
+      expect(updated.isError).not.toBe(true);
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(JSON.parse(calls[0][1].body).Offer.OfferRows[0]).toEqual(row);
+      expect(JSON.parse(calls[1][1].body).Offer.OfferRows[0]).toEqual(row);
+    });
+
+    it.each([
+      ['a fractional account number', { AccountNumber: 3001.5 }],
+      ['an overlong description', { Description: 'x'.repeat(256) }],
+      ['an unknown discount type', { DiscountType: 'UNKNOWN' }],
+      ['too many house-work hours', { HouseWorkHoursToReport: 1000 }],
+      ['an unknown house-work type', { HouseWorkType: 'UNKNOWN' }],
+      ['a numeric quantity', { Quantity: 2.5 }],
+      ['a fractional row id', { RowId: 1.5 }],
+      ['an overlong unit', { Unit: 'x'.repeat(21) }],
+      ['a fractional VAT percentage', { VAT: 25.5 }],
+    ])('rejects %s before making an offer request', async (_case, invalidFields) => {
+      mockFetch({ Offer: {} });
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_create_offer',
+        arguments: {
+          CustomerNumber: '42',
+          OfferRows: [
+            {
+              Description: 'Test',
+              DeliveredQuantity: 1,
+              Price: 100,
+              ...invalidFields,
+            },
+          ],
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
   });
 
   describe('fortnox_create_invoice_from_offer', () => {


### PR DESCRIPTION
## Summary

- declare every field in the current Fortnox offer-row request component
- preserve the legacy `DeliveredQuantity` create/update contract while adding `Quantity`
- share one strict schema between create and partial update rows
- refresh the privacy-safe schema-audit baseline from 12 missing fields to zero
- add discovery, constraint, nullability, strictness, and POST/PUT payload regression coverage

Part of #131. The umbrella issue remains open for order rows.

## Verification

- `npm test -- tests/tools/offers.test.ts` (16 tests)
- `npm run verify` (906 tests)
- `npm run audit:schemas` (`offer-row`: missing=0)
- release gate: 0 production vulnerabilities, embedded consumer passed, npm pack dry-run passed
- native Codex review: no blocking findings after strengthening partial-update discovery coverage
- independent M5 review (`qwen3-coder-next-80b`): no blocking findings

No release is included.
