### PR TITLE
feat: complete order row schema

### DIFF
--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -17,10 +17,10 @@
     },
     {
       "id": "order-row",
-      "declaredPropertyCount": 8,
+      "declaredPropertyCount": 19,
       "specificationPropertyCount": 19,
-      "missingPropertyCount": 11,
-      "stateHash": "895148d406eb97c741d8a5b100df43cdd56c7302d81dc98a4a8574f7144c4c70"
+      "missingPropertyCount": 0,
+      "stateHash": "9e47e77be6ba95abf03aa8b1b67ebfff4d661ab69471a05954fa034e9a8fed9c"
     },
     {
       "id": "supplier",

--- a/src/tools/orders.ts
+++ b/src/tools/orders.ts
@@ -11,14 +11,62 @@ import {
 } from '../tool-output.js';
 
 const OrderRowSchema = z.strictObject({
+  AccountNumber: z.number().int().optional().describe('Kontonummer'),
   ArticleNumber: z.string().optional().describe('Artikelnummer'),
-  Description: z.string().describe('Beskrivning'),
-  DeliveredQuantity: z.number().describe('Antal'),
+  Cost: z.number().min(-9_999_999_999).max(9_999_999_999).nullable().optional().describe('Kostnad'),
+  CostCenter: z.string().nullable().optional().describe('Kostnadsställe'),
+  DeliveredQuantity: z
+    .union([z.string(), z.number()])
+    .describe('Levererat antal (nummer eller decimalsträng)'),
+  Description: z.string().max(255).describe('Beskrivning (max 255 tecken)'),
+  Discount: z.number().optional().describe('Rabattvärde'),
+  DiscountType: z.enum(['AMOUNT', 'PERCENT']).optional().describe('Rabatttyp'),
+  HouseWork: z.boolean().optional().describe('Markera raden som husarbete (ROT/RUT)'),
+  HouseWorkHoursToReport: z
+    .number()
+    .int()
+    .min(0)
+    .max(999)
+    .nullable()
+    .optional()
+    .describe('Timmar att rapportera för husarbete (0–999)'),
+  HouseWorkType: z
+    .enum([
+      'CONSTRUCTION',
+      'ELECTRICITY',
+      'GLASSMETALWORK',
+      'GROUNDDRAINAGEWORK',
+      'MASONRY',
+      'PAINTINGWALLPAPERING',
+      'HVAC',
+      'MAJORAPPLIANCEREPAIR',
+      'MOVINGSERVICES',
+      'ITSERVICES',
+      'CLEANING',
+      'TEXTILECLOTHING',
+      'SNOWPLOWING',
+      'GARDENING',
+      'BABYSITTING',
+      'OTHERCARE',
+      'OTHERCOSTS',
+      'SOLARCELLS',
+      'STORAGESELFPRODUCEDELECTRICITY',
+      'CHARGINGSTATIONELECTRICVEHICLE',
+      'HOMEMAINTENANCE',
+      'FURNISHING',
+      'TRANSPORTATIONSERVICES',
+      'WASHINGANDCAREOFCLOTHING',
+    ])
+    .optional()
+    .describe('Typ av husarbete'),
+  OrderedQuantity: z.string().optional().describe('Beställt antal enligt Fortnox'),
   Price: z.number().describe('Pris per enhet (exkl. moms)'),
-  AccountNumber: z.number().optional().describe('Kontonummer (default: 3001)'),
+  Project: z.string().optional().describe('Projektnummer'),
+  StockPointCode: z.string().optional().describe('Lagerställekod'),
+  StockPointId: z.string().optional().describe('Lagerställe-id'),
+  Unit: z.string().max(20).optional().describe('Enhet (max 20 tecken)'),
   VAT: z.number().optional().describe('Momssats i procent (default: 25)'),
-  Unit: z.string().optional().describe('Enhet (t.ex. "st", "tim")'),
-  Discount: z.number().optional().describe('Rabatt i procent'),
+  VATCode: z.string().optional().describe('Momskod'),
 });
 
 const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be numeric');
@@ -105,18 +153,7 @@ export function registerOrderTools(
       documentNumber: DocumentNumberSchema.describe('Ordernummer att uppdatera'),
       CustomerNumber: z.string().optional().describe('Kundnummer'),
       OrderRows: z
-        .array(
-          z.strictObject({
-            ArticleNumber: z.string().optional().describe('Artikelnummer'),
-            Description: z.string().optional().describe('Beskrivning'),
-            DeliveredQuantity: z.number().optional().describe('Antal'),
-            Price: z.number().optional().describe('Pris per enhet (exkl. moms)'),
-            AccountNumber: z.number().optional().describe('Kontonummer'),
-            VAT: z.number().optional().describe('Momssats i procent'),
-            Unit: z.string().optional().describe('Enhet'),
-            Discount: z.number().optional().describe('Rabatt i procent'),
-          }),
-        )
+        .array(OrderRowSchema.partial())
         .optional()
         .describe('Orderrader (ersätter alla befintliga rader)'),
       DeliveryDate: z.string().optional().describe('Leveransdatum (YYYY-MM-DD)'),

--- a/tests/tools/orders.test.ts
+++ b/tests/tools/orders.test.ts
@@ -98,6 +98,113 @@ describe('order tools', () => {
       const body = JSON.parse(fetchCall[1].body);
       expect(body.Order.CustomerNumber).toBe('42');
     });
+
+    it('advertises and preserves complete order rows for create and update', async () => {
+      mockFetch({ Order: { DocumentNumber: '2', CustomerNumber: '42' } });
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const createTool = tools.find((tool) => tool.name === 'fortnox_create_order');
+      const updateTool = tools.find((tool) => tool.name === 'fortnox_update_order');
+      type RowProperties = Record<string, { enum?: string[] }>;
+      type OrderToolInput = {
+        properties: {
+          OrderRows: {
+            items: {
+              properties: RowProperties;
+              additionalProperties?: boolean;
+              required?: string[];
+            };
+          };
+        };
+      };
+      const createRows = (createTool?.inputSchema as OrderToolInput).properties.OrderRows.items;
+      const updateRows = (updateTool?.inputSchema as OrderToolInput).properties.OrderRows.items;
+
+      expect(Object.keys(createRows.properties)).toHaveLength(19);
+      expect(Object.keys(updateRows.properties)).toHaveLength(19);
+      expect(createRows.additionalProperties).toBe(false);
+      expect(updateRows.additionalProperties).toBe(false);
+      expect(createRows.required).toEqual(
+        expect.arrayContaining(['Description', 'DeliveredQuantity', 'Price']),
+      );
+      expect(updateRows.required ?? []).toEqual([]);
+      expect(createRows.properties.DiscountType?.enum).toEqual(['AMOUNT', 'PERCENT']);
+      expect(createRows.properties.HouseWorkType?.enum).toHaveLength(24);
+      expect(createRows.properties.HouseWorkType?.enum).toContain('CONSTRUCTION');
+      expect(createRows.properties.HouseWorkType?.enum).toContain('ITSERVICES');
+      expect(createRows.properties.HouseWorkType?.enum).toContain('WASHINGANDCAREOFCLOTHING');
+
+      const row = {
+        AccountNumber: 3001,
+        ArticleNumber: 'CONSULTING',
+        Cost: null,
+        CostCenter: null,
+        DeliveredQuantity: '2.5',
+        Description: 'Teknisk rådgivning',
+        Discount: 10,
+        DiscountType: 'PERCENT',
+        HouseWork: true,
+        HouseWorkHoursToReport: null,
+        HouseWorkType: 'ITSERVICES',
+        OrderedQuantity: '3.0',
+        Price: 1200,
+        Project: 'P1',
+        StockPointCode: 'STH',
+        StockPointId: '12',
+        Unit: 'tim',
+        VAT: 25.5,
+        VATCode: 'SE25',
+      };
+
+      const created = await client.callTool({
+        name: 'fortnox_create_order',
+        arguments: { CustomerNumber: '42', OrderRows: [row], confirm: true },
+      });
+      const updated = await client.callTool({
+        name: 'fortnox_update_order',
+        arguments: { documentNumber: '2', OrderRows: [row], confirm: true },
+      });
+
+      expect(created.isError).not.toBe(true);
+      expect(updated.isError).not.toBe(true);
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(JSON.parse(calls[0][1].body).Order.OrderRows[0]).toEqual(row);
+      expect(JSON.parse(calls[1][1].body).Order.OrderRows[0]).toEqual(row);
+    });
+
+    it.each([
+      ['a fractional account number', { AccountNumber: 3001.5 }],
+      ['an out-of-range cost', { Cost: 10_000_000_000 }],
+      ['an overlong description', { Description: 'x'.repeat(256) }],
+      ['an unknown discount type', { DiscountType: 'UNKNOWN' }],
+      ['too many house-work hours', { HouseWorkHoursToReport: 1000 }],
+      ['an unknown house-work type', { HouseWorkType: 'UNKNOWN' }],
+      ['a numeric ordered quantity', { OrderedQuantity: 3 }],
+      ['a numeric stock-point id', { StockPointId: 12 }],
+      ['an overlong unit', { Unit: 'x'.repeat(21) }],
+    ])('rejects %s before making an order request', async (_case, invalidFields) => {
+      mockFetch({ Order: {} });
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_create_order',
+        arguments: {
+          CustomerNumber: '42',
+          OrderRows: [
+            {
+              Description: 'Test',
+              DeliveredQuantity: 1,
+              Price: 100,
+              ...invalidFields,
+            },
+          ],
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
   });
 
   describe('fortnox_create_invoice_from_order', () => {


### PR DESCRIPTION
## Summary

- declare all 19 fields in the current Fortnox order-row request component
- preserve numeric `DeliveredQuantity` compatibility while accepting the specified string form
- share one strict row schema between create and partial update operations
- refresh the privacy-safe audit baseline from 11 missing order fields to zero
- add discovery, requiredness, constraint, nullability, and POST/PUT payload regression coverage

This completes all four row-schema mappings in #131.

Closes #131.

## Verification

- `npm test -- tests/tools/orders.test.ts` (15 tests)
- `npm run verify` (916 tests)
- `npm run audit:schemas` (all six mappings report `missing=0`)
- release gate: 0 production vulnerabilities, embedded consumer passed, npm pack dry-run passed
- native Codex review: no blocking findings
- independent M5 review was attempted but returned an unusable token-exhausted response; tracked in `Magnus-Gille/gille-inference#226` (related connector/telemetry failures: #225 and #227)

No release or live Fortnox mutation is included.
