### PR TITLE
ci: audit write schemas in weekly drift check

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          cache: npm
 
       - name: Check for API changes
         id: diff
@@ -35,6 +39,48 @@ jobs:
             echo "error=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check MCP write-schema coverage
+        id: schema_audit
+        if: steps.diff.outputs.error != 'true'
+        shell: bash
+        run: |
+          # This privileged weekly job needs dependencies for MCP discovery, but
+          # dependency lifecycle scripts are unnecessary and must not run here.
+          set +e
+          npm ci --ignore-scripts --no-audit >/dev/null 2>&1
+          INSTALL_EXIT_CODE=$?
+          set -e
+
+          if [ "$INSTALL_EXIT_CODE" -ne 0 ]; then
+            # Keep the public diagnostic bounded. npm's raw output is not needed
+            # to distinguish setup failure from schema drift.
+            OUTPUT="Schema audit setup failed (npm ci exit $INSTALL_EXIT_CODE)."
+            EXIT_CODE=2
+          else
+            set +e
+            OUTPUT=$(npm run audit:schemas --silent 2>&1)
+            EXIT_CODE=$?
+            set -e
+          fi
+
+          echo "$OUTPUT"
+          {
+            echo "summary<<SCHEMA_AUDIT_EOF"
+            echo "$OUTPUT"
+            echo "SCHEMA_AUDIT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$EXIT_CODE" -eq 1 ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "error=false" >> "$GITHUB_OUTPUT"
+          elif [ "$EXIT_CODE" -eq 0 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "error=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "error=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit updated snapshot
@@ -118,6 +164,71 @@ jobs:
                   '',
                   'This may be transient (rate limiting) or indicate a URL change.',
                 ].join('\n'),
+                labels: ['api-drift'],
+              });
+            }
+
+      - name: Report MCP write-schema audit
+        if: steps.schema_audit.outputs.changed == 'true' || steps.schema_audit.outputs.error == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SCHEMA_AUDIT_SUMMARY: ${{ steps.schema_audit.outputs.summary }}
+          SCHEMA_AUDIT_CHANGED: ${{ steps.schema_audit.outputs.changed }}
+          SCHEMA_AUDIT_ERROR: ${{ steps.schema_audit.outputs.error }}
+        with:
+          script: |
+            const summary = process.env.SCHEMA_AUDIT_SUMMARY;
+            const changed = process.env.SCHEMA_AUDIT_CHANGED === 'true';
+            const errored = process.env.SCHEMA_AUDIT_ERROR === 'true';
+            if (changed === errored) {
+              core.setFailed('Expected exactly one write-schema audit outcome');
+              return;
+            }
+
+            const today = new Date().toISOString().slice(0, 10);
+            const title = changed ? 'MCP write schema drift' : 'MCP write schema audit failed';
+            const introduction = changed
+              ? 'The weekly check detected a change in the opaque MCP write-schema coverage baseline.'
+              : 'The weekly MCP write-schema audit could not complete.';
+            const guidance = changed
+              ? 'Review the affected mapping IDs locally and update tool schemas before refreshing the opaque baseline.'
+              : 'Inspect the workflow failure and restore the privacy-safe audit path.';
+            const report = [
+              introduction,
+              '',
+              '```text',
+              summary,
+              '```',
+              '',
+              guidance,
+              '',
+              'The full Fortnox specification and raw property names are intentionally not included.',
+            ].join('\n');
+
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'api-drift',
+              per_page: 100,
+            });
+            const existing = open.data.find(
+              (issue) => !issue.pull_request && issue.title === title,
+            );
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: [`Detected again on ${today}.`, '', report].join('\n'),
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: report,
                 labels: ['api-drift'],
               });
             }

--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
   workflow_dispatch: # Allow manual trigger
 
+concurrency:
+  group: api-drift-check
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -35,10 +39,13 @@ jobs:
 
           if [ "$EXIT_CODE" -eq 1 ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif [ "$EXIT_CODE" -eq 2 ]; then
+            echo "error=false" >> "$GITHUB_OUTPUT"
+          elif [ "$EXIT_CODE" -ne 0 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "error=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "error=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check MCP write-schema coverage
@@ -132,14 +139,14 @@ jobs:
             // persistent HTTP 429). Rather than open a fresh issue each Monday,
             // append a comment to the existing open fetch-failure issue if one
             // exists, so the failure history lives in a single tracker.
-            const open = await github.rest.issues.listForRepo({
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'api-drift',
               per_page: 100,
             });
-            const existing = open.data.find(
+            const existing = open.find(
               (i) => !i.pull_request && /fetch failed|drift check|429/i.test(i.title),
             );
 
@@ -205,14 +212,14 @@ jobs:
               'The full Fortnox specification and raw property names are intentionally not included.',
             ].join('\n');
 
-            const open = await github.rest.issues.listForRepo({
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'api-drift',
               per_page: 100,
             });
-            const existing = open.data.find(
+            const existing = open.find(
               (issue) => !issue.pull_request && issue.title === title,
             );
 

--- a/tests/api-drift-workflow.test.ts
+++ b/tests/api-drift-workflow.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(join(process.cwd(), '.github/workflows/api-drift.yml'), 'utf8');
+
+describe('weekly API drift workflow', () => {
+  it('runs the write-schema audit after a successful spec fetch with pinned Node 22', () => {
+    const fetchIndex = workflow.indexOf('- name: Check for API changes');
+    const auditIndex = workflow.indexOf('- name: Check MCP write-schema coverage');
+
+    expect(workflow).toContain(
+      'actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0',
+    );
+    expect(workflow).toContain('node-version: 22');
+    expect(workflow).toContain('npm ci --ignore-scripts --no-audit');
+    expect(fetchIndex).toBeGreaterThan(-1);
+    expect(auditIndex).toBeGreaterThan(fetchIndex);
+    expect(workflow).toContain("if: steps.diff.outputs.error != 'true'");
+  });
+
+  it('uses only the privacy-safe audit mode and never persists the fetched spec', () => {
+    expect(workflow).toContain('npm run audit:schemas --silent');
+    expect(workflow).not.toContain('audit:schemas -- --update');
+    expect(workflow).not.toContain('--show-fields');
+    expect(workflow).not.toContain('actions/upload-artifact');
+    expect(workflow).not.toMatch(/git add[^\n]*openapi\.json/);
+  });
+
+  it('maps drift and errors to deduplicated issue updates', () => {
+    expect(workflow).toContain('id: schema_audit');
+    expect(workflow).toContain('echo "changed=true" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain('echo "error=true" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain("steps.schema_audit.outputs.changed == 'true'");
+    expect(workflow).toContain("steps.schema_audit.outputs.error == 'true'");
+    expect(workflow).toContain('MCP write schema drift');
+    expect(workflow).toContain('MCP write schema audit failed');
+    expect(workflow).toContain('github.rest.issues.listForRepo');
+    expect(workflow).toContain('github.rest.issues.createComment');
+    expect(workflow).toContain('github.rest.issues.create({');
+  });
+});

--- a/tests/api-drift-workflow.test.ts
+++ b/tests/api-drift-workflow.test.ts
@@ -19,6 +19,11 @@ describe('weekly API drift workflow', () => {
     expect(workflow).toContain("if: steps.diff.outputs.error != 'true'");
   });
 
+  it('treats every unexpected fetch exit as an error before the schema audit', () => {
+    expect(workflow).toContain('elif [ "$EXIT_CODE" -ne 0 ]; then');
+    expect(workflow).not.toContain('elif [ "$EXIT_CODE" -eq 2 ]; then');
+  });
+
   it('uses only the privacy-safe audit mode and never persists the fetched spec', () => {
     expect(workflow).toContain('npm run audit:schemas --silent');
     expect(workflow).not.toContain('audit:schemas -- --update');
@@ -35,7 +40,9 @@ describe('weekly API drift workflow', () => {
     expect(workflow).toContain("steps.schema_audit.outputs.error == 'true'");
     expect(workflow).toContain('MCP write schema drift');
     expect(workflow).toContain('MCP write schema audit failed');
-    expect(workflow).toContain('github.rest.issues.listForRepo');
+    expect(workflow).toContain('group: api-drift-check');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).toContain('github.paginate(github.rest.issues.listForRepo');
     expect(workflow).toContain('github.rest.issues.createComment');
     expect(workflow).toContain('github.rest.issues.create({');
   });


### PR DESCRIPTION
## Summary

- run the privacy-safe MCP write-schema audit after the weekly Fortnox spec fetch
- distinguish clean, drift, setup failure, audit failure, and unexpected fetch failures without publishing the full spec or raw property names
- serialize workflow runs and create or comment on stable, paginated, deduplicated `api-drift` issues
- pin Node 22 and install dependencies with lifecycle scripts disabled
- add workflow regression tests for ordering, privacy, failure routing, and reporting

## Verification

- `npm test -- tests/api-drift-workflow.test.ts` (4 tests)
- `actionlint .github/workflows/api-drift.yml`
- YAML parse
- `npm run audit:schemas --silent` (all six mappings, missing=0)
- `npm run verify` (79 files, 920 tests)
- `npm audit --omit=dev` (0 vulnerabilities)
- embedded-consumer check
- npm pack dry-run
- Codex Security diff scan: no reportable findings
- fresh final review: PASS after resolving both findings

Closes #136