### PR TITLE
fix: remediate dev dependency audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run format:check
-      - run: npm audit --omit=dev
+      - run: npm audit
       - run: npm pack --dry-run --ignore-scripts
 
   # Every bug in #95 was Windows-only (cmd.exe splitting the OAuth URL on `&`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,10 @@ npm run format:check  # Prettier (check only, what CI runs)
 npm run build         # tsc
 ```
 
-CI runs lint, build, tests, formatting, a production dependency audit, and a
-package dry-run on Ubuntu with Node 22 and 24. A separate Windows Node 22 job
-runs the build and test suite. Every required job must pass.
+CI runs lint, build, tests, formatting, an audit of the complete installed
+dependency graph, and a package dry-run on Ubuntu with Node 22 and 24. A
+separate Windows Node 22 job runs the build and test suite. Every required job
+must pass.
 
 ## Project layout
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -44,7 +44,8 @@ If the scope changes, re-check the Fortnox terms and the privacy wording before 
 ## Release Checks
 
 - `npm run check:release` (lint, formatting, build, tests, production dependency audit, package manifest dry-run)
-- `npm audit` (record any dev-only findings separately; they are not shipped but still affect contributors/CI)
+- CI enforces `npm audit` across production and development dependencies; run it
+  locally as well and require zero known findings before release.
 - Review `git diff --stat origin/main..HEAD`
 - Sanity-read `README.md`, `PRIVACY.md`, and the tax tool descriptions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,16 +1144,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -2564,9 +2564,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2779,9 +2779,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2799,7 +2799,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+const contributing = readFileSync(join(process.cwd(), 'CONTRIBUTING.md'), 'utf8');
+const publishing = readFileSync(join(process.cwd(), 'PUBLISHING.md'), 'utf8');
+
+describe('CI workflow', () => {
+  it('audits the complete installed dependency graph', () => {
+    expect(workflow).toContain('- run: npm audit\n');
+    expect(workflow).not.toContain('npm audit --omit=dev');
+    expect(contributing).toMatch(/complete installed\s+dependency graph/);
+    expect(publishing).toContain(
+      'CI enforces `npm audit` across production and development dependencies',
+    );
+    expect(publishing).toContain('`npm run check:release`');
+    expect(publishing).toContain('production dependency audit');
+  });
+});

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -8,7 +8,7 @@ const publishing = readFileSync(join(process.cwd(), 'PUBLISHING.md'), 'utf8');
 
 describe('CI workflow', () => {
   it('audits the complete installed dependency graph', () => {
-    expect(workflow).toContain('- run: npm audit\n');
+    expect(workflow).toMatch(/- run: npm audit\r?\n/);
     expect(workflow).not.toContain('npm audit --omit=dev');
     expect(contributing).toMatch(/complete installed\s+dependency graph/);
     expect(publishing).toContain(


### PR DESCRIPTION
Closes #140.

## Summary
- update the vulnerable transitive development dependencies in the lockfile
- make CI audit the complete installed dependency graph
- add a regression test and align contributor and release documentation

## Verification
- npm audit: 0 vulnerabilities
- npm audit --omit=dev: 0 vulnerabilities
- npm run check:release: passed with 938 tests
- actionlint .github/workflows/ci.yml: passed
- package tarball checksum unchanged from version 0.8.0