### PR TITLE
feat: read voucher file attachments (list + download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl vouchers get <series> <number>` | `fortnox_get_voucher` | Get a single voucher with rows |
 | `noxctl vouchers create --input <file>` | `fortnox_create_voucher` | Create a voucher with debit/credit rows (mutation) |
 | `noxctl vouchers attach <series> <number> <file...> [--year]` | `fortnox_attach_voucher_files` | Upload receipt/underlag files and link them to a voucher (mutation; needs the Fortnox archive scope) |
+| `noxctl vouchers attachments <series> <number> [--year]` | `fortnox_list_voucher_attachments` | List files (receipts/underlag) already attached to a voucher — read-only, default scopes only |
+| `noxctl vouchers file <fileId> [-f <path>]` | `fortnox_get_voucher_file` | Download a file attached to a voucher (get `fileId` from `vouchers attachments`) — read-only, default scopes only |
 | `noxctl accounts list [--search <term>]` | `fortnox_list_accounts` | View chart of accounts, search by name or number |
 
 ### Financial reports

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2248,6 +2248,77 @@ Examples:
     },
   );
 
+vouchers
+  .command('attachments <series> <voucherNumber>')
+  .description('List files (receipts/underlag) attached to a voucher')
+  .option(
+    '--year <number>',
+    'Financial year (recommended — voucher numbers reset between financial years)',
+    parseInt,
+  )
+  .action(async (series: string, voucherNumber: string, opts: { year?: number }) => {
+    const { listVoucherAttachments } = await import('./operations/vouchers.js');
+    const attachments = await listVoucherAttachments(series, voucherNumber, opts.year);
+    if (json()) {
+      console.log(JSON.stringify({ Attachments: attachments }, null, 2));
+    } else {
+      outputList(
+        attachments as unknown as Record<string, unknown>[],
+        voucherAttachmentColumns,
+        false,
+        attachments,
+      );
+    }
+  });
+
+vouchers
+  .command('file <fileId>')
+  .description('Download a file attached to a voucher (get the fileId from "vouchers attachments")')
+  .option(
+    '-f, --file <path>',
+    'Write the file here (- for stdout; default: voucher-file-<fileId><ext>)',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  noxctl vouchers attachments A 60 --year 4
+  noxctl vouchers file c7e578d8-59a7-4e00-b29b-b99e4d9ede63
+  noxctl vouchers file c7e578d8-59a7-4e00-b29b-b99e4d9ede63 --file receipt.pdf`,
+  )
+  .action(async (fileId: string, opts: { file?: string }) => {
+    const { getVoucherFile, extensionForMime } = await import('./operations/vouchers.js');
+    const toStdout = opts.file === '-';
+
+    if (toStdout && program.opts().output === 'json') {
+      throw new Error(
+        '--file - writes raw file bytes to stdout and cannot be combined with --output json.',
+      );
+    }
+
+    const file = await getVoucherFile(fileId);
+
+    if (toStdout) {
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(file.buffer, (err) => (err ? reject(err) : resolve()));
+      });
+      return;
+    }
+
+    const path = opts.file ?? `voucher-file-${fileId}${extensionForMime(file.contentType)}`;
+    writeFileSync(path, file.buffer);
+    outputConfirmation(
+      `File saved to ${path} (${file.contentType}, ${file.buffer.length} bytes).`,
+      json(),
+      {
+        FileId: fileId,
+        Path: path,
+        ContentType: file.contentType,
+        Bytes: file.buffer.length,
+      },
+    );
+  });
+
 // --- invoice-payments ---
 const invoicePayments = program
   .command('invoice-payments')

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -240,6 +240,7 @@ export interface FortnoxTransport {
   requestWithMetadata<T>(endpoint: string, options?: RequestOptions): Promise<FortnoxResponse<T>>;
   requestPdf(endpoint: string, options?: RequestOptions): Promise<Buffer>;
   requestPdfFromMutation(endpoint: string, options?: RequestOptions): Promise<Buffer | undefined>;
+  requestFile(endpoint: string, options?: RequestOptions): Promise<FortnoxFile>;
   fetchAllPages<T extends Record<string, unknown>>(
     endpoint: string,
     dataKey: string,
@@ -538,6 +539,47 @@ async function requestPdfFromMutation(
   );
 }
 
+export interface FortnoxFile {
+  buffer: Buffer;
+  contentType: string;
+}
+
+/**
+ * Fetch an arbitrary binary file from one of Fortnox's file endpoints (inbox,
+ * archive) — the read counterpart to the raw-body uploads elsewhere in this
+ * file. Unlike requestPdf this makes no assumption about the file type:
+ * voucher/invoice attachments can be PDF, JPEG, PNG, etc., so the caller's
+ * Content-Type is trusted rather than checked against a magic number. Still
+ * guards against a 2xx response that is actually a JSON error envelope, which
+ * would otherwise be saved to disk and look like a valid file.
+ */
+async function requestFile(
+  runtime: ClientRuntime,
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<FortnoxFile> {
+  return request<FortnoxFile>(runtime, endpoint, options, async (response) => {
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    const error = fortnoxErrorInBody(buffer);
+    if (error) {
+      throw new FortnoxApiError(
+        response.status,
+        error.message,
+        error.code !== undefined ? `Error code: ${error.code}` : undefined,
+        endpoint,
+        undefined,
+        runtime.getDiagnosticContext(),
+      );
+    }
+
+    const contentType = (response.headers?.get?.('content-type') || 'application/octet-stream')
+      .split(';')[0]!
+      .trim();
+    return { buffer, contentType };
+  });
+}
+
 /**
  * Fetch all pages of a paginated Fortnox list endpoint.
  * `dataKey` is the envelope key (e.g. "Invoices", "Customers").
@@ -656,6 +698,9 @@ function createFortnoxClientInternal(
     ): Promise<Buffer | undefined> {
       return requestPdfFromMutation(runtime, endpoint, requestOptions);
     },
+    requestFile(endpoint: string, requestOptions: RequestOptions = {}): Promise<FortnoxFile> {
+      return requestFile(runtime, endpoint, requestOptions);
+    },
     fetchAllPages<T extends Record<string, unknown>>(
       endpoint: string,
       dataKey: string,
@@ -705,6 +750,13 @@ export async function fortnoxRequestPdfFromMutation(
   options: RequestOptions = {},
 ): Promise<Buffer | undefined> {
   return defaultFortnoxTransport.requestPdfFromMutation(endpoint, options);
+}
+
+export async function fortnoxRequestFile(
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<FortnoxFile> {
+  return defaultFortnoxTransport.requestFile(endpoint, options);
 }
 
 export async function fetchAllPages<T extends Record<string, unknown>>(

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -37,6 +37,20 @@ export interface VoucherFileAttachment {
   connection: Record<string, unknown>;
 }
 
+export interface VoucherAttachment {
+  fileName: string;
+  fileId: string;
+  voucherSeries: string;
+  voucherNumber: string;
+  voucherYear?: number;
+}
+
+export interface VoucherFileContent {
+  fileId: string;
+  contentType: string;
+  buffer: Buffer;
+}
+
 export function createVoucherOperations(transport: FortnoxTransport) {
   const { listFinancialYears } = createFinancialYearOperations(transport);
 
@@ -99,6 +113,9 @@ export function createVoucherOperations(transport: FortnoxTransport) {
   interface VoucherFileConnectionResponse {
     VoucherFileConnection: Record<string, unknown>;
   }
+  interface VoucherFileConnectionListResponse {
+    VoucherFileConnections: Record<string, unknown>[];
+  }
 
   const MIME_BY_EXT: Record<string, string> = {
     '.pdf': 'application/pdf',
@@ -117,6 +134,16 @@ export function createVoucherOperations(transport: FortnoxTransport) {
 
   function mimeForFile(filePath: string): string {
     return MIME_BY_EXT[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+  }
+
+  // Best-effort reverse of MIME_BY_EXT, for naming a downloaded file when the
+  // caller doesn't specify an output path.
+  const EXT_BY_MIME: Record<string, string> = Object.fromEntries(
+    Object.entries(MIME_BY_EXT).map(([ext, mime]) => [mime, ext]),
+  );
+
+  function extensionForMime(contentType: string): string {
+    return EXT_BY_MIME[contentType] ?? '';
   }
 
   // Upload a single file to the Fortnox inbox; returns the archived File object (has .Id).
@@ -224,6 +251,45 @@ export function createVoucherOperations(transport: FortnoxTransport) {
     return results;
   }
 
+  // List the files already attached to a voucher — the read counterpart to
+  // attachVoucherFiles. `financialYear` is optional (Fortnox will match across
+  // years without it) but recommended: voucher numbers reset every financial
+  // year, so series+number alone can be ambiguous.
+  async function listVoucherAttachments(
+    series: string,
+    voucherNumber: string,
+    financialYear?: number,
+  ): Promise<VoucherAttachment[]> {
+    const data = await transport.request<VoucherFileConnectionListResponse>(
+      'voucherfileconnections',
+      {
+        params: {
+          voucherseries: series,
+          vouchernumber: voucherNumber,
+          voucheryear: financialYear,
+        },
+      },
+    );
+    return (data.VoucherFileConnections ?? []).map((c) => ({
+      fileName: String(c.Name ?? ''),
+      fileId: String(c.FileId),
+      voucherSeries: String(c.VoucherSeries ?? series),
+      voucherNumber: String(c.VoucherNumber ?? voucherNumber),
+      voucherYear: c.VoucherYear !== undefined ? Number(c.VoucherYear) : undefined,
+    }));
+  }
+
+  // Download the actual bytes of a file attached to a voucher (or sitting in
+  // the inbox generally) — the read counterpart to uploadInboxFile. fileId
+  // comes from listVoucherAttachments (its `fileId`) or from a prior
+  // uploadInboxFile/attachVoucherFiles call.
+  async function getVoucherFile(fileId: string): Promise<VoucherFileContent> {
+    const { buffer, contentType } = await transport.requestFile(
+      `inbox/${encodeURIComponent(fileId)}`,
+    );
+    return { fileId, contentType, buffer };
+  }
+
   return {
     listVouchers,
     getVoucher,
@@ -231,6 +297,9 @@ export function createVoucherOperations(transport: FortnoxTransport) {
     uploadInboxFile,
     createVoucherFileConnection,
     attachVoucherFiles,
+    listVoucherAttachments,
+    getVoucherFile,
+    extensionForMime,
   };
 }
 
@@ -241,4 +310,7 @@ export const {
   uploadInboxFile,
   createVoucherFileConnection,
   attachVoucherFiles,
+  listVoucherAttachments,
+  getVoucherFile,
+  extensionForMime,
 } = createVoucherOperations(defaultFortnoxTransport);

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -1,8 +1,19 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
 import {
   accountListColumns,
+  voucherAttachmentColumns,
   voucherDetailColumns,
   voucherListColumns,
   voucherRowColumns,
@@ -14,6 +25,57 @@ import {
   requireConfirmation,
   textResponse,
 } from '../tool-output.js';
+
+/**
+ * Write a downloaded file to `target`, refusing to write through a symlink.
+ * Mirrors writePdf() in tools/invoices.ts, generalized to an arbitrary
+ * buffer/content-type rather than an assumed PDF — voucher attachments can be
+ * PDF, JPEG, PNG, etc.
+ *
+ * These paths come from tool arguments, i.e. they are model-generated and can
+ * be influenced by whatever the model just read. O_EXCL already refuses to
+ * follow a symlink; O_NOFOLLOW gives the overwrite path the same guarantee,
+ * so "replace this file" can never silently truncate a symlink's target
+ * instead. O_NOFOLLOW is POSIX-only, so Windows falls back to an explicit
+ * lstat check.
+ */
+function writeBinaryFile(target: string, data: Buffer, overwrite?: boolean): void {
+  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
+  const flags = overwrite
+    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
+    : O_WRONLY | O_CREAT | O_EXCL;
+
+  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    throw new Error(
+      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+    );
+  }
+
+  try {
+    const fd = openSync(target, flags, 0o600);
+    try {
+      let written = 0;
+      while (written < data.length) {
+        written += writeSync(fd, data, written, data.length - written);
+      }
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      throw new Error(
+        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
+      );
+    }
+    if (code === 'ELOOP') {
+      throw new Error(
+        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+      );
+    }
+    throw err;
+  }
+}
 
 // The full writable VoucherRow field set (Fortnox `VoucherRowSinglePayloadItem`).
 // The MCP SDK strips any key the schema does not declare, so an undeclared field
@@ -55,7 +117,16 @@ export function registerBookkeepingTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listAccounts, listVouchers, getVoucher, createVoucher, attachVoucherFiles } = operations;
+  const {
+    listAccounts,
+    listVouchers,
+    getVoucher,
+    createVoucher,
+    attachVoucherFiles,
+    listVoucherAttachments,
+    getVoucherFile,
+    extensionForMime,
+  } = operations;
   server.tool(
     'fortnox_list_vouchers',
     'Lista verifikationer i Fortnox. Returnerar: VoucherSeries, VoucherNumber, TransactionDate, Description.',
@@ -199,6 +270,61 @@ export function registerBookkeepingTools(
       const summary = `Kopplade ${results.length} fil(er) till verifikation ${series}/${voucherNumber}. Fil-ID: ${ids}`;
       return textResponse(
         includeRaw ? `${summary}\n\n${JSON.stringify(results, null, 2)}` : summary,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_list_voucher_attachments',
+    'Lista filer (kvitton/underlag) som är kopplade till en verifikation i Fortnox. Returnerar: File (filnamn), File ID, Year. Använd fileId med fortnox_get_voucher_file för att hämta själva filen.',
+    {
+      series: z.string().describe('Verifikationsserie (t.ex. "A")'),
+      voucherNumber: z.string().describe('Verifikationsnummer'),
+      financialYear: z
+        .number()
+        .optional()
+        .describe(
+          'Räkenskapsår. Rekommenderas — verifikationsnummer återanvänds mellan räkenskapsår, så serie+nummer ensamt kan vara tvetydigt.',
+        ),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ series, voucherNumber, financialYear, includeRaw }) => {
+      const attachments = await listVoucherAttachments(series, voucherNumber, financialYear);
+      return listResponse(
+        attachments as unknown as Record<string, unknown>[],
+        voucherAttachmentColumns,
+        attachments,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_voucher_file',
+    'Ladda ner en fil som är kopplad till en verifikation och spara den på disk. Returnerar sökvägen till filen (inte filinnehållet). Hämta fileId via fortnox_list_voucher_attachments.',
+    {
+      fileId: z.string().describe('Fil-ID, från fortnox_list_voucher_attachments'),
+      outputPath: z
+        .string()
+        .optional()
+        .describe(
+          'Sökväg att spara filen till. Skriver inte över en befintlig fil om inte overwrite är satt. Utelämnas: en ny privat temp-katalog används.',
+        ),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe('Tillåt att en befintlig fil på outputPath skrivs över'),
+    },
+    async ({ fileId, outputPath, overwrite }) => {
+      const file = await getVoucherFile(fileId);
+      const ext = extensionForMime(file.contentType);
+      const target = outputPath
+        ? resolve(outputPath)
+        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `voucher-file-${fileId}${ext}`);
+      writeBinaryFile(target, file.buffer, overwrite);
+      return textResponse(
+        `Sparade fil (${file.contentType}, ${file.buffer.length} bytes) till ${target}`,
       );
     },
   );

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -143,6 +143,8 @@ describe('CLI smoke tests', () => {
     expect(output).toContain('list');
     expect(output).toContain('create');
     expect(output).toContain('attach');
+    expect(output).toContain('attachments');
+    expect(output).toContain('file');
   });
 
   it('noxctl vouchers attach --help shows file and year options', () => {
@@ -153,6 +155,24 @@ describe('CLI smoke tests', () => {
     ) as string;
     expect(output).toContain('--year');
     expect(output).toContain('--dry-run');
+  });
+
+  it('noxctl vouchers attachments --help shows the year option', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'vouchers', 'attachments', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('--year');
+  });
+
+  it('noxctl vouchers file --help shows the file option', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'vouchers', 'file', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('--file');
   });
 
   it('noxctl reports --help shows report subcommands', () => {

--- a/tests/operations/transport-binding.test.ts
+++ b/tests/operations/transport-binding.test.ts
@@ -11,6 +11,7 @@ function stubTransport(companyName: string): FortnoxTransport {
     requestWithMetadata: vi.fn(),
     requestPdf: vi.fn(),
     requestPdfFromMutation: vi.fn(),
+    requestFile: vi.fn(),
     fetchAllPages: vi.fn(),
   } as FortnoxTransport;
 }

--- a/tests/operations/vouchers.test.ts
+++ b/tests/operations/vouchers.test.ts
@@ -30,6 +30,20 @@ function mockFetch(response: unknown) {
   });
 }
 
+function binaryResponse(bytes: Buffer, contentType: string) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+  };
+}
+
+function mockBinary(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue(binaryResponse(bytes, contentType));
+}
+
 describe('voucher operations', () => {
   beforeEach(() => {
     // Re-establish fs defaults each test (restoreAllMocks below clears them).
@@ -436,6 +450,107 @@ describe('voucher operations', () => {
           financialYear: 4,
         }),
       ).rejects.toThrow(/already attached this run: a\.pdf/);
+    });
+  });
+
+  describe('listVoucherAttachments', () => {
+    it('GETs voucherfileconnections filtered by series/number/year and maps the response', async () => {
+      const { listVoucherAttachments } = await import('../../src/operations/vouchers.js');
+      mockFetch({
+        VoucherFileConnections: [
+          {
+            FileId: 'f1',
+            Name: 'receipt.pdf',
+            VoucherSeries: 'A',
+            VoucherNumber: '60',
+            VoucherYear: 4,
+          },
+        ],
+      });
+
+      const result = await listVoucherAttachments('A', '60', 4);
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('voucherfileconnections');
+      expect(url).toContain('voucherseries=A');
+      expect(url).toContain('vouchernumber=60');
+      expect(url).toContain('voucheryear=4');
+      expect(result).toEqual([
+        {
+          fileName: 'receipt.pdf',
+          fileId: 'f1',
+          voucherSeries: 'A',
+          voucherNumber: '60',
+          voucherYear: 4,
+        },
+      ]);
+    });
+
+    it('omits the voucheryear param when no financial year is given', async () => {
+      const { listVoucherAttachments } = await import('../../src/operations/vouchers.js');
+      mockFetch({ VoucherFileConnections: [] });
+
+      await listVoucherAttachments('A', '60');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).not.toContain('voucheryear');
+    });
+
+    it('returns an empty array when the voucher has no attachments', async () => {
+      const { listVoucherAttachments } = await import('../../src/operations/vouchers.js');
+      mockFetch({ VoucherFileConnections: [] });
+
+      const result = await listVoucherAttachments('A', '61', 4);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getVoucherFile', () => {
+    it('GETs inbox/{fileId} and returns the raw bytes with content-type', async () => {
+      const { getVoucherFile } = await import('../../src/operations/vouchers.js');
+      const bytes = Buffer.from('fake-pdf-bytes');
+      mockBinary(bytes, 'application/pdf');
+
+      const result = await getVoucherFile('f1');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('inbox/f1');
+      expect(result.fileId).toBe('f1');
+      expect(result.contentType).toBe('application/pdf');
+      expect(result.buffer.equals(bytes)).toBe(true);
+    });
+
+    it('strips parameters off the content-type header (e.g. charset)', async () => {
+      const { getVoucherFile } = await import('../../src/operations/vouchers.js');
+      mockBinary(Buffer.from('hello'), 'text/plain; charset=utf-8');
+
+      const result = await getVoucherFile('f2');
+
+      expect(result.contentType).toBe('text/plain');
+    });
+
+    it('throws when Fortnox answers 2xx with a JSON error envelope instead of file bytes', async () => {
+      const { getVoucherFile } = await import('../../src/operations/vouchers.js');
+      const bytes = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'not found', code: 123 } }),
+      );
+      mockBinary(bytes, 'application/json');
+
+      await expect(getVoucherFile('missing')).rejects.toThrow(/not found/);
+    });
+  });
+
+  describe('extensionForMime', () => {
+    it('maps known content-types back to a file extension', async () => {
+      const { extensionForMime } = await import('../../src/operations/vouchers.js');
+      expect(extensionForMime('application/pdf')).toBe('.pdf');
+      expect(extensionForMime('image/jpeg')).toBe('.jpeg');
+    });
+
+    it('returns an empty string for an unknown content-type', async () => {
+      const { extensionForMime } = await import('../../src/operations/vouchers.js');
+      expect(extensionForMime('application/x-mystery')).toBe('');
     });
   });
 });

--- a/tests/tools/bookkeeping.test.ts
+++ b/tests/tools/bookkeeping.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { createServer } from '../../src/index.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -13,6 +15,16 @@ function mockFetch(response: unknown, ok = true, status = 200) {
     status,
     text: () => Promise.resolve(JSON.stringify(response)),
     json: () => Promise.resolve(response),
+  });
+}
+
+function mockBinaryFetch(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
   });
 }
 
@@ -240,6 +252,105 @@ describe('bookkeeping tools', () => {
       const text = (result.content as { type: string; text: string }[])[0].text;
       expect(text).toContain('Dry run');
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('fortnox_list_voucher_attachments', () => {
+    it('lists attached files for a voucher', async () => {
+      mockFetch({
+        VoucherFileConnections: [
+          {
+            FileId: 'f1',
+            Name: 'receipt.pdf',
+            VoucherSeries: 'A',
+            VoucherNumber: '60',
+            VoucherYear: 4,
+          },
+        ],
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_voucher_attachments',
+        arguments: { series: 'A', voucherNumber: '60', financialYear: 4 },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('receipt.pdf');
+      expect(text).toContain('f1');
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('voucherseries=A');
+      expect(calledUrl).toContain('vouchernumber=60');
+      expect(calledUrl).toContain('voucheryear=4');
+    });
+
+    it('is read-only — no confirmation required', async () => {
+      mockFetch({ VoucherFileConnections: [] });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_voucher_attachments',
+        arguments: { series: 'A', voucherNumber: '60' },
+      });
+
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('fortnox_get_voucher_file', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('downloads the file and saves it to a temp path, returning that path', async () => {
+      const bytes = Buffer.from('%PDF-1.4 fake receipt bytes');
+      mockBinaryFetch(bytes, 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_voucher_file',
+        arguments: { fileId: 'f1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const match = text.match(/till (.+voucher-file-f1\.pdf)/);
+      expect(match).not.toBeNull();
+      const savedPath = match![1]!;
+      expect(readFileSync(savedPath).equals(bytes)).toBe(true);
+      rmSync(savedPath, { force: true });
+    });
+
+    it('writes to an explicit outputPath when given', async () => {
+      const bytes = Buffer.from('image-bytes');
+      mockBinaryFetch(bytes, 'image/jpeg');
+      const target = `${tmpdir()}/noxctl-test-voucher-file.jpg`;
+      rmSync(target, { force: true });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_voucher_file',
+        arguments: { fileId: 'f2', outputPath: target },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(readFileSync(target).equals(bytes)).toBe(true);
+      rmSync(target, { force: true });
+    });
+
+    it('refuses to overwrite an existing file without overwrite: true', async () => {
+      const target = `${tmpdir()}/noxctl-test-voucher-file-exists.pdf`;
+      writeFileSync(target, 'already here');
+      mockBinaryFetch(Buffer.from('new-bytes'), 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_voucher_file',
+        arguments: { fileId: 'f3', outputPath: target },
+      });
+
+      expect(result.isError).toBe(true);
+      rmSync(target, { force: true });
     });
   });
 


### PR DESCRIPTION
noxctl vouchers attach was write-only: nothing could list what was already attached to a voucher or fetch the bytes back. This adds the read side.

- fortnox_list_voucher_attachments / `vouchers attachments <series> <number>` — lists attached files via the documented GET /3/voucherfileconnections endpoint.
- fortnox_get_voucher_file / `vouchers file <fileId>` — downloads a file's bytes via GET /3/inbox/{fileId} and saves it to disk, returning the path (mirrors the existing invoices pdf command).
- fortnoxRequestFile() in fortnox-client.ts is a generic binary- download counterpart to requestPdf(), trusting Content-Type instead of a PDF magic-number check since a receipt can be PDF/JPEG/PNG/etc.

Both new endpoints map to scopes already in the default 14 (connectfile, inbox) — no opt-in scope needed.

Verified live against real Fortnox data (re-downloaded a known receipt, came back byte-identical).