### PR TITLE
feat: attach files to customer invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ So you control the credentials, the scopes, and which company is connected end t
    | `offer`              | Offert               | Offer               | **Order**                   | Offers — **opt-in**, see below                 |
    | `order`              | Order                | Order               | **Order**                   | Orders — **opt-in**, see below                 |
    | `salary`             | Lön                  | Salary              | **Lön**                     | Payroll: employees, salary/attendance/absence transactions, schedule times — **opt-in**, see below |
+   | `archive`            | Arkivplats           | File Archive        | **Arkivplats**              | Attaching files to customer invoices — **opt-in**, see below |
 
    Enable every non-opt-in scope. noxctl requests that exact set at authorize time, and
    Fortnox rejects the whole authorization if the app has not been granted a scope that
@@ -122,9 +123,13 @@ So you control the credentials, the scopes, and which company is connected end t
      then authorize with `noxctl init --with-orders` (or `FORTNOX_WITH_ORDERS=1`).
    - **Payroll (Lön licence).** Enable **Lön** on the app, then authorize with
      `noxctl init --with-salary` (or `FORTNOX_WITH_SALARY=1`).
+   - **File archive (Arkivplats licence).** Enable **Arkivplats** on the app, then
+     authorize with `noxctl init --with-archive` (or `FORTNOX_WITH_ARCHIVE=1`). Only
+     needed for `noxctl invoices attach` — voucher and supplier-invoice attachments
+     use the `inbox`/`connectfile` scopes instead and don't need it.
 
-   Both can be combined. The granted scope set is remembered per profile, so token
-   refreshes keep working.
+   All three can be combined. The granted scope set is remembered per profile, so
+   token refreshes keep working.
 
 5. Save the integration
 
@@ -351,6 +356,8 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl invoices pdf <docNumber> [--file <path>\|-] [--mark-sent]` | `fortnox_invoice_pdf` | Download the invoice PDF (via `/preview`, no side effect). `--mark-sent` also flags it as sent afterwards (mutation) |
 | `noxctl invoices bookkeep <docNumber>` | `fortnox_bookkeep_invoice` | Bookkeep an invoice (mutation) |
 | `noxctl invoices credit <docNumber>` | `fortnox_credit_invoice` | Credit an invoice (mutation) |
+| `noxctl invoices attach <docNumber> <file...> [--no-include-on-send]` | `fortnox_attach_invoice_files` | Upload receipt/underlag files and attach them to a customer invoice (mutation; needs the Fortnox **archive** scope — `noxctl init --with-archive`) |
+| `noxctl invoices attachments <docNumber>` | `fortnox_list_invoice_attachments` | List files currently attached to a customer invoice |
 
 ### Invoice payments (inbetalningar)
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -70,6 +70,14 @@ export const LEGACY_SCOPES =
 // client-credentials refresh re-requests the same set.
 export const SALARY_SCOPE = 'salary';
 
+// The file archive (Arkivplats) scope. Opt-in for the same reason as salary:
+// requesting it at authorize time fails for apps without the Arkivplats
+// permission enabled. Needed for `noxctl invoices attach` — customer invoices
+// have no `invoicefileconnections` (the pattern vouchers/supplier invoices use),
+// so attaching a file to one goes through the archive instead. `noxctl init
+// --with-archive` (or FORTNOX_WITH_ARCHIVE=1) appends it.
+export const ARCHIVE_SCOPE = 'archive';
+
 /**
  * Effective scope string for a profile: the granted set if recorded, else the
  * frozen LEGACY_SCOPES — what a credential predating the `scopes` field was

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,8 @@ import {
   invoiceListColumns,
   invoiceDetailColumns,
   invoiceConfirmColumns,
+  invoiceAttachmentColumns,
+  invoiceAttachmentListColumns,
   customerListColumns,
   customerDetailColumns,
   voucherListColumns,
@@ -323,299 +325,329 @@ program
     '--with-orders',
     'Also request the offer/order scopes — requires the Order licence on the Fortnox company',
   )
-  .action(async (initOpts: { profile?: string; withSalary?: boolean; withOrders?: boolean }) => {
-    const { inspectCredentials, runOAuthSetup, SCOPES, SALARY_SCOPE, ORDER_SCOPES } =
-      await import('./auth.js');
-    const { validateProfileName } = await import('./profile-name.js');
+  .option(
+    '--with-archive',
+    'Also request the archive (Arkivplats) scope — lets noxctl read files from the Fortnox file archive, e.g. attachments made via the Fortnox web UI',
+  )
+  .action(
+    async (initOpts: {
+      profile?: string;
+      withSalary?: boolean;
+      withOrders?: boolean;
+      withArchive?: boolean;
+    }) => {
+      const {
+        inspectCredentials,
+        runOAuthSetup,
+        SCOPES,
+        SALARY_SCOPE,
+        ORDER_SCOPES,
+        ARCHIVE_SCOPE,
+      } = await import('./auth.js');
+      const { validateProfileName } = await import('./profile-name.js');
 
-    // Opt-in scopes: flag for TTY, env var for non-interactive/CI runs. Both are
-    // licence-gated in Fortnox (Lön / Order), and asking for a scope the company
-    // is not licensed for fails the whole authorization — hence not defaults.
-    const withSalary = Boolean(initOpts.withSalary) || process.env.FORTNOX_WITH_SALARY === '1';
-    const withOrders = Boolean(initOpts.withOrders) || process.env.FORTNOX_WITH_ORDERS === '1';
-    const scopes = [SCOPES, withOrders ? ORDER_SCOPES : '', withSalary ? SALARY_SCOPE : '']
-      .filter(Boolean)
-      .join(' ');
+      // Opt-in scopes: flag for TTY, env var for non-interactive/CI runs. All are
+      // licence-gated in Fortnox (Lön / Order / Arkivplats), and asking for a scope
+      // the company is not licensed for fails the whole authorization — hence not
+      // defaults.
+      const withSalary = Boolean(initOpts.withSalary) || process.env.FORTNOX_WITH_SALARY === '1';
+      const withOrders = Boolean(initOpts.withOrders) || process.env.FORTNOX_WITH_ORDERS === '1';
+      const withArchive = Boolean(initOpts.withArchive) || process.env.FORTNOX_WITH_ARCHIVE === '1';
+      const scopes = [
+        SCOPES,
+        withOrders ? ORDER_SCOPES : '',
+        withSalary ? SALARY_SCOPE : '',
+        withArchive ? ARCHIVE_SCOPE : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
 
-    let targetProfile: string;
-    try {
-      targetProfile = validateProfileName(initOpts.profile ?? resolvedProfileInfo.name);
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exit(2);
-    }
+      let targetProfile: string;
+      try {
+        targetProfile = validateProfileName(initOpts.profile ?? resolvedProfileInfo.name);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(2);
+      }
 
-    // If `init --profile <name>` names a different profile than the preAction
-    // hook resolved, rebind the in-process resolved profile so downstream work
-    // (verification via getCompanyInfo, runOAuthSetup's internal saveCredentials
-    // call chain) targets the profile being initialized — not a stale pointer.
-    if (targetProfile.toLowerCase() !== resolvedProfileInfo.name.toLowerCase()) {
-      setResolvedProfile(targetProfile, 'flag');
-      resolvedProfileInfo = { name: targetProfile, source: 'flag' };
-    }
+      // If `init --profile <name>` names a different profile than the preAction
+      // hook resolved, rebind the in-process resolved profile so downstream work
+      // (verification via getCompanyInfo, runOAuthSetup's internal saveCredentials
+      // call chain) targets the profile being initialized — not a stale pointer.
+      if (targetProfile.toLowerCase() !== resolvedProfileInfo.name.toLowerCase()) {
+        setResolvedProfile(targetProfile, 'flag');
+        resolvedProfileInfo = { name: targetProfile, source: 'flag' };
+      }
 
-    // Step 1: Check if already configured
-    const inspection = await inspectCredentials(targetProfile);
-    if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
-      fail(inspection.detail);
-    }
-    const existing = inspection.credentials;
-    if (existing) {
-      console.log('Existing credentials found.');
+      // Step 1: Check if already configured
+      const inspection = await inspectCredentials(targetProfile);
+      if (inspection.state === 'locked' || inspection.state === 'inaccessible') {
+        fail(inspection.detail);
+      }
+      const existing = inspection.credentials;
+      if (existing) {
+        console.log('Existing credentials found.');
 
-      if (process.stdin.isTTY && process.stdout.isTTY) {
-        const rlExisting = createInterface({
+        if (process.stdin.isTTY && process.stdout.isTTY) {
+          const rlExisting = createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          try {
+            const answer = (
+              await rlExisting.question(
+                'Re-run setup? This will replace your current credentials. [y/N] ',
+              )
+            )
+              .trim()
+              .toLowerCase();
+            if (answer !== 'y' && answer !== 'yes') {
+              console.log('Run `noxctl company info` to verify your current connection.');
+              return;
+            }
+          } finally {
+            rlExisting.close();
+          }
+        } else {
+          console.log(
+            'Run `noxctl company info` to verify, or re-run interactively to reconfigure.',
+          );
+          return;
+        }
+      }
+
+      // Step 2: Welcome message
+      console.log('Welcome to noxctl init!');
+      console.log('');
+      console.log("You'll need a Fortnox app from developer.fortnox.se with:");
+      console.log('  - Redirect URI: http://localhost:9876/callback');
+      // Printed from the SCOPES constant itself. A hand-maintained list drifted
+      // from what noxctl actually requests, so following the docs produced an
+      // under-scoped Fortnox app and a confusing rejection at authorize time (#95).
+      console.log('  - Permissions (Behörigheter) for every one of these scopes:');
+      console.log(`      ${scopes.split(' ').join(', ')}`);
+      if (withOrders) {
+        console.log('    (offer/order are included because you passed --with-orders)');
+      }
+      if (withSalary) {
+        console.log('    (salary is included because you passed --with-salary)');
+      }
+      console.log('  - Service account enabled (recommended)');
+      console.log('');
+      console.log('See the README for detailed portal instructions.');
+      console.log('');
+
+      const isTTY = process.stdin.isTTY && process.stdout.isTTY;
+
+      let clientId: string;
+      let clientSecret: string;
+      let serviceAccount: boolean;
+
+      if (!isTTY) {
+        // CI / non-interactive mode: fall back to env vars
+        clientId = process.env.FORTNOX_CLIENT_ID ?? '';
+        clientSecret = process.env.FORTNOX_CLIENT_SECRET ?? '';
+        serviceAccount = process.env.FORTNOX_SERVICE_ACCOUNT === '1';
+
+        if (!clientId || !clientSecret) {
+          console.error(
+            'Error: stdin is not a TTY. Set FORTNOX_CLIENT_ID and FORTNOX_CLIENT_SECRET env vars to run non-interactively.',
+          );
+          process.exit(1);
+        }
+      } else {
+        let rl = createInterface({
           input: process.stdin,
           output: process.stdout,
         });
+
         try {
-          const answer = (
-            await rlExisting.question(
-              'Re-run setup? This will replace your current credentials. [y/N] ',
-            )
+          // Step 3: Prompt for Client ID
+          const envClientId = process.env.FORTNOX_CLIENT_ID;
+          const clientIdPrompt = envClientId ? `Client ID [${envClientId}]: ` : 'Client ID: ';
+          const clientIdAnswer = (await rl.question(clientIdPrompt)).trim();
+          clientId = clientIdAnswer || envClientId || '';
+
+          if (!clientId) {
+            console.error('Error: Client ID is required.');
+            process.exit(1);
+          }
+
+          // Step 4: Prompt for Client Secret (masked input)
+          const envClientSecret = process.env.FORTNOX_CLIENT_SECRET;
+          if (envClientSecret) {
+            process.stdout.write('Client Secret [env var set — press Enter to use it]: ');
+          } else {
+            process.stdout.write('Client Secret: ');
+          }
+          // Temporarily close rl so we can use raw mode for masked input
+          rl.close();
+          const clientSecretAnswer = await new Promise<string>((resolve) => {
+            let buf = '';
+            const stdin = process.stdin;
+            stdin.setRawMode(true);
+            stdin.resume();
+            stdin.setEncoding('utf-8');
+            const onData = (chunk: string) => {
+              for (const ch of chunk) {
+                if (ch === '\r' || ch === '\n') {
+                  stdin.setRawMode(false);
+                  stdin.removeListener('data', onData);
+                  process.stdout.write('\n');
+                  resolve(buf.trim());
+                  return;
+                } else if (ch === '\u007f' || ch === '\b') {
+                  if (buf.length > 0) {
+                    buf = buf.slice(0, -1);
+                    process.stdout.write('\b \b');
+                  }
+                } else if (ch === '\u0003') {
+                  // Ctrl-C
+                  process.exit(1);
+                } else {
+                  buf += ch;
+                }
+              }
+            };
+            stdin.on('data', onData);
+          });
+          // Re-create rl for subsequent questions
+          rl = createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          clientSecret = clientSecretAnswer || envClientSecret || '';
+
+          if (!clientSecret) {
+            console.error('Error: Client Secret is required.');
+            process.exit(1);
+          }
+
+          // Step 5: Service account question — default yes
+          console.log('');
+          console.log('Service account mode lets noxctl refresh tokens automatically without');
+          console.log('opening a browser each time. Enable it in the Fortnox developer portal');
+          console.log(
+            'under your app\'s OAuth settings ("Möjliggör auktorisering som servicekonto").',
+          );
+          console.log('');
+          const saAnswer = (
+            await rl.question('Is service account mode enabled for your app? [Y/n] ')
           )
             .trim()
             .toLowerCase();
-          if (answer !== 'y' && answer !== 'yes') {
-            console.log('Run `noxctl company info` to verify your current connection.');
-            return;
-          }
+          serviceAccount = saAnswer === '' || saAnswer === 'y' || saAnswer === 'yes';
         } finally {
-          rlExisting.close();
+          rl.close();
         }
-      } else {
-        console.log('Run `noxctl company info` to verify, or re-run interactively to reconfigure.');
-        return;
       }
-    }
 
-    // Step 2: Welcome message
-    console.log('Welcome to noxctl init!');
-    console.log('');
-    console.log("You'll need a Fortnox app from developer.fortnox.se with:");
-    console.log('  - Redirect URI: http://localhost:9876/callback');
-    // Printed from the SCOPES constant itself. A hand-maintained list drifted
-    // from what noxctl actually requests, so following the docs produced an
-    // under-scoped Fortnox app and a confusing rejection at authorize time (#95).
-    console.log('  - Permissions (Behörigheter) for every one of these scopes:');
-    console.log(`      ${scopes.split(' ').join(', ')}`);
-    if (withOrders) {
-      console.log('    (offer/order are included because you passed --with-orders)');
-    }
-    if (withSalary) {
-      console.log('    (salary is included because you passed --with-salary)');
-    }
-    console.log('  - Service account enabled (recommended)');
-    console.log('');
-    console.log('See the README for detailed portal instructions.');
-    console.log('');
+      // Step 6: Run OAuth flow
+      await runOAuthSetup({ clientId, clientSecret, serviceAccount }, targetProfile, scopes);
 
-    const isTTY = process.stdin.isTTY && process.stdout.isTTY;
-
-    let clientId: string;
-    let clientSecret: string;
-    let serviceAccount: boolean;
-
-    if (!isTTY) {
-      // CI / non-interactive mode: fall back to env vars
-      clientId = process.env.FORTNOX_CLIENT_ID ?? '';
-      clientSecret = process.env.FORTNOX_CLIENT_SECRET ?? '';
-      serviceAccount = process.env.FORTNOX_SERVICE_ACCOUNT === '1';
-
-      if (!clientId || !clientSecret) {
-        console.error(
-          'Error: stdin is not a TTY. Set FORTNOX_CLIENT_ID and FORTNOX_CLIENT_SECRET env vars to run non-interactively.',
-        );
-        process.exit(1);
-      }
-    } else {
-      let rl = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-
+      // Step 6b: Set the active pointer if this is the first profile or no pointer exists.
       try {
-        // Step 3: Prompt for Client ID
-        const envClientId = process.env.FORTNOX_CLIENT_ID;
-        const clientIdPrompt = envClientId ? `Client ID [${envClientId}]: ` : 'Client ID: ';
-        const clientIdAnswer = (await rl.question(clientIdPrompt)).trim();
-        clientId = clientIdAnswer || envClientId || '';
-
-        if (!clientId) {
-          console.error('Error: Client ID is required.');
-          process.exit(1);
+        const idx = await readProfileIndex();
+        const existingPointer = await readActivePointer();
+        const firstProfile = idx.profiles.length <= 1;
+        if (firstProfile || !existingPointer) {
+          await writeActivePointer(targetProfile);
         }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`Warning: could not update active profile pointer: ${msg}`);
+      }
 
-        // Step 4: Prompt for Client Secret (masked input)
-        const envClientSecret = process.env.FORTNOX_CLIENT_SECRET;
-        if (envClientSecret) {
-          process.stdout.write('Client Secret [env var set — press Enter to use it]: ');
-        } else {
-          process.stdout.write('Client Secret: ');
+      // Step 7: Verify by fetching company info
+      try {
+        const { getCompanyInfo } = await import('./operations/company.js');
+        const data = await getCompanyInfo();
+        const company = data as Record<string, unknown>;
+        console.log('');
+        console.log('Connected successfully!');
+        if (company['CompanyName']) {
+          console.log(`  Company: ${company['CompanyName']}`);
         }
-        // Temporarily close rl so we can use raw mode for masked input
-        rl.close();
-        const clientSecretAnswer = await new Promise<string>((resolve) => {
-          let buf = '';
-          const stdin = process.stdin;
-          stdin.setRawMode(true);
-          stdin.resume();
-          stdin.setEncoding('utf-8');
-          const onData = (chunk: string) => {
-            for (const ch of chunk) {
-              if (ch === '\r' || ch === '\n') {
-                stdin.setRawMode(false);
-                stdin.removeListener('data', onData);
-                process.stdout.write('\n');
-                resolve(buf.trim());
-                return;
-              } else if (ch === '\u007f' || ch === '\b') {
-                if (buf.length > 0) {
-                  buf = buf.slice(0, -1);
-                  process.stdout.write('\b \b');
-                }
-              } else if (ch === '\u0003') {
-                // Ctrl-C
-                process.exit(1);
-              } else {
-                buf += ch;
-              }
-            }
-          };
-          stdin.on('data', onData);
-        });
-        // Re-create rl for subsequent questions
-        rl = createInterface({
+        if (company['OrganizationNumber']) {
+          console.log(`  Org number: ${company['OrganizationNumber']}`);
+        }
+      } catch {
+        console.log('');
+        console.log(
+          'OAuth completed. Could not verify company info — you can run `noxctl company info` manually.',
+        );
+      }
+
+      // Step 8: Offer to register MCP server with Claude Code
+      if (process.stdin.isTTY && process.stdout.isTTY) {
+        const rl2 = createInterface({
           input: process.stdin,
           output: process.stdout,
         });
-        clientSecret = clientSecretAnswer || envClientSecret || '';
 
-        if (!clientSecret) {
-          console.error('Error: Client Secret is required.');
-          process.exit(1);
-        }
+        try {
+          // Detect whether we're running via npx or from a local build.
+          const argv0 = process.argv[1] ?? '';
+          const useNpx = argv0.includes('npx') || argv0.includes('.bin/noxctl');
 
-        // Step 5: Service account question — default yes
-        console.log('');
-        console.log('Service account mode lets noxctl refresh tokens automatically without');
-        console.log('opening a browser each time. Enable it in the Fortnox developer portal');
-        console.log(
-          'under your app\'s OAuth settings ("Möjliggör auktorisering som servicekonto").',
-        );
-        console.log('');
-        const saAnswer = (await rl.question('Is service account mode enabled for your app? [Y/n] '))
-          .trim()
-          .toLowerCase();
-        serviceAccount = saAnswer === '' || saAnswer === 'y' || saAnswer === 'yes';
-      } finally {
-        rl.close();
-      }
-    }
-
-    // Step 6: Run OAuth flow
-    await runOAuthSetup({ clientId, clientSecret, serviceAccount }, targetProfile, scopes);
-
-    // Step 6b: Set the active pointer if this is the first profile or no pointer exists.
-    try {
-      const idx = await readProfileIndex();
-      const existingPointer = await readActivePointer();
-      const firstProfile = idx.profiles.length <= 1;
-      if (firstProfile || !existingPointer) {
-        await writeActivePointer(targetProfile);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`Warning: could not update active profile pointer: ${msg}`);
-    }
-
-    // Step 7: Verify by fetching company info
-    try {
-      const { getCompanyInfo } = await import('./operations/company.js');
-      const data = await getCompanyInfo();
-      const company = data as Record<string, unknown>;
-      console.log('');
-      console.log('Connected successfully!');
-      if (company['CompanyName']) {
-        console.log(`  Company: ${company['CompanyName']}`);
-      }
-      if (company['OrganizationNumber']) {
-        console.log(`  Org number: ${company['OrganizationNumber']}`);
-      }
-    } catch {
-      console.log('');
-      console.log(
-        'OAuth completed. Could not verify company info — you can run `noxctl company info` manually.',
-      );
-    }
-
-    // Step 8: Offer to register MCP server with Claude Code
-    if (process.stdin.isTTY && process.stdout.isTTY) {
-      const rl2 = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-
-      try {
-        // Detect whether we're running via npx or from a local build.
-        const argv0 = process.argv[1] ?? '';
-        const useNpx = argv0.includes('npx') || argv0.includes('.bin/noxctl');
-
-        console.log('');
-        const mcpAnswer = (await rl2.question('Register the MCP server with Claude Code? [Y/n] '))
-          .trim()
-          .toLowerCase();
-        const doRegister = mcpAnswer === '' || mcpAnswer === 'y' || mcpAnswer === 'yes';
-
-        if (doRegister) {
-          const { execFile } = await import('node:child_process');
-          // All arguments below are static constants — no user input is interpolated.
-          const mcpArgs = useNpx
-            ? ['mcp', 'add', 'fortnox', '--', 'npx', 'noxctl', 'serve']
-            : ['mcp', 'add', 'fortnox', '--', 'node', argv0, 'serve'];
-
-          await new Promise<void>((resolve) => {
-            execFile('claude', mcpArgs, (err) => {
-              if (err) {
-                const fallbackCmd = ['claude', ...mcpArgs].join(' ');
-                console.log('Could not register automatically. Run this manually:');
-                console.log(`  ${fallbackCmd}`);
-              } else {
-                console.log('MCP server registered. Restart Claude Code to pick it up.');
-              }
-              resolve();
-            });
-          });
-        }
-
-        // Offer npm link for local clone users so `noxctl` is in PATH
-        if (!useNpx) {
           console.log('');
-          const linkAnswer = (await rl2.question('Add `noxctl` to your PATH via npm link? [Y/n] '))
+          const mcpAnswer = (await rl2.question('Register the MCP server with Claude Code? [Y/n] '))
             .trim()
             .toLowerCase();
-          const doLink = linkAnswer === '' || linkAnswer === 'y' || linkAnswer === 'yes';
+          const doRegister = mcpAnswer === '' || mcpAnswer === 'y' || mcpAnswer === 'yes';
 
-          if (doLink) {
-            const { execFile: execFileLink } = await import('node:child_process');
+          if (doRegister) {
+            const { execFile } = await import('node:child_process');
+            // All arguments below are static constants — no user input is interpolated.
+            const mcpArgs = useNpx
+              ? ['mcp', 'add', 'fortnox', '--', 'npx', 'noxctl', 'serve']
+              : ['mcp', 'add', 'fortnox', '--', 'node', argv0, 'serve'];
+
             await new Promise<void>((resolve) => {
-              execFileLink('npm', ['link'], { cwd: process.cwd() }, (err) => {
+              execFile('claude', mcpArgs, (err) => {
                 if (err) {
-                  console.log('Could not link automatically. Run this manually:');
-                  console.log('  npm link');
+                  const fallbackCmd = ['claude', ...mcpArgs].join(' ');
+                  console.log('Could not register automatically. Run this manually:');
+                  console.log(`  ${fallbackCmd}`);
                 } else {
-                  console.log('Done! `noxctl` is now available globally.');
+                  console.log('MCP server registered. Restart Claude Code to pick it up.');
                 }
                 resolve();
               });
             });
           }
+
+          // Offer npm link for local clone users so `noxctl` is in PATH
+          if (!useNpx) {
+            console.log('');
+            const linkAnswer = (
+              await rl2.question('Add `noxctl` to your PATH via npm link? [Y/n] ')
+            )
+              .trim()
+              .toLowerCase();
+            const doLink = linkAnswer === '' || linkAnswer === 'y' || linkAnswer === 'yes';
+
+            if (doLink) {
+              const { execFile: execFileLink } = await import('node:child_process');
+              await new Promise<void>((resolve) => {
+                execFileLink('npm', ['link'], { cwd: process.cwd() }, (err) => {
+                  if (err) {
+                    console.log('Could not link automatically. Run this manually:');
+                    console.log('  npm link');
+                  } else {
+                    console.log('Done! `noxctl` is now available globally.');
+                  }
+                  resolve();
+                });
+              });
+            }
+          }
+        } finally {
+          rl2.close();
         }
-      } finally {
-        rl2.close();
       }
-    }
-  });
+    },
+  );
 
 // --- logout ---
 program
@@ -1602,6 +1634,76 @@ invoices
       data,
       invoiceConfirmColumns,
       'Invoice',
+    );
+  });
+
+invoices
+  .command('attach <documentNumber> <files...>')
+  .description('Upload receipt/underlag files and attach them to a customer invoice')
+  .option(
+    '--no-include-on-send',
+    'Do not bundle the file when the invoice is sent (default: bundled)',
+  )
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without uploading')
+  .addHelpText(
+    'after',
+    `
+Requires the "archive" scope — run \`noxctl init --with-archive\` first if
+\`noxctl doctor\` reports it missing.
+
+Examples:
+  noxctl invoices attach 91110646 underlag.pdf
+  noxctl invoices attach 91110646 underlag.pdf --no-include-on-send`,
+  )
+  .action(
+    async (
+      documentNumber: string,
+      files: string[],
+      opts: { includeOnSend?: boolean; yes?: boolean; dryRun?: boolean },
+    ) => {
+      const { attachInvoiceFiles } = await import('./operations/invoices.js');
+      if (
+        !(await confirmMutation(
+          `Attach ${files.length} file(s) to invoice ${documentNumber}`,
+          opts,
+          {
+            files,
+            includeOnSend: opts.includeOnSend ?? true,
+          },
+        ))
+      ) {
+        return;
+      }
+      const results = await attachInvoiceFiles({
+        documentNumber,
+        filePaths: files,
+        includeOnSend: opts.includeOnSend,
+      });
+      if (json()) {
+        console.log(JSON.stringify({ Attachments: results }, null, 2));
+      } else {
+        outputList(
+          results as unknown as Record<string, unknown>[],
+          invoiceAttachmentColumns,
+          false,
+          results,
+        );
+      }
+    },
+  );
+
+invoices
+  .command('attachments <documentNumber>')
+  .description('List files attached to a customer invoice')
+  .action(async (documentNumber: string) => {
+    const { listInvoiceAttachments } = await import('./operations/invoices.js');
+    const results = await listInvoiceAttachments(documentNumber);
+    outputList(
+      results as unknown as Record<string, unknown>[],
+      invoiceAttachmentListColumns,
+      json(),
+      { Attachments: results },
     );
   });
 

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -96,7 +96,12 @@ function getErrorHint(statusCode: number, message: string, endpoint?: string): s
 }
 
 function endpointToScope(endpoint: string): string | undefined {
-  const path = endpoint.split('?')[0]!.toLowerCase();
+  // Endpoints that select the API root directly (a leading "/3/..." or
+  // "/api/...", used by newer product APIs alongside the classic relative
+  // "vouchers"-style paths) carry that prefix into the 403 hint lookup below,
+  // so strip it before matching against the bare resource-name mapping.
+  let path = endpoint.split('?')[0]!.toLowerCase();
+  if (path.startsWith('/3/')) path = path.slice(3);
   const mapping: Record<string, string> = {
     articles: 'article',
     customers: 'customer',

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, extname } from 'node:path';
 import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
 import { documentSegment } from '../identifiers.js';
 
@@ -44,6 +46,27 @@ export interface MarkInvoicePrintedResult {
    * otherwise leave the saved file a version behind the one marked as sent.
    */
   pdf?: Buffer;
+}
+
+export interface InvoiceAttachment {
+  id: string;
+  entityId: number;
+  entityType: 'F';
+  fileId: string;
+  includeOnSend: boolean;
+}
+
+export interface AttachInvoiceFilesParams {
+  documentNumber: string;
+  filePaths: string[];
+  includeOnSend?: boolean;
+}
+
+export interface AttachInvoiceFileResult {
+  fileName: string;
+  fileId: string;
+  attachmentId: string;
+  includeOnSend: boolean;
 }
 
 export function createInvoiceOperations(transport: FortnoxTransport) {
@@ -210,6 +233,125 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     return data?.Invoice || {};
   }
 
+  const MIME_BY_EXT: Record<string, string> = {
+    '.pdf': 'application/pdf',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.heic': 'image/heic',
+    '.tif': 'image/tiff',
+    '.tiff': 'image/tiff',
+    '.txt': 'text/plain',
+    '.csv': 'text/csv',
+    '.xml': 'application/xml',
+  };
+
+  function mimeForFile(filePath: string): string {
+    return MIME_BY_EXT[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+  }
+
+  interface ArchiveFileRow {
+    Id: string;
+    ArchiveFileId: string;
+    Name: string;
+    Size: number;
+    Path: string;
+  }
+  interface ArchiveFileResponse {
+    File: ArchiveFileRow;
+  }
+
+  /**
+   * Upload a file for later attachment to a customer invoice.
+   *
+   * Two details here are not in Fortnox's published OpenAPI spec and were only
+   * found by inspecting the Fortnox web app's own network traffic:
+   *   1. The upload must go to `/3/archive?folderid=inbox_kf` — not `/3/inbox`
+   *      (file_not_found on attach) and not a default-folder `/3/archive`
+   *      (wrong_file_location on attach).
+   *   2. The attach call (createInvoiceAttachment below) needs this response's
+   *      `ArchiveFileId` field, not `Id` — the latter also produces
+   *      wrong_file_location.
+   * Customer invoices have no `invoicefileconnections` — the per-entity
+   * connection pattern used by vouchers/supplier invoices/articles/assets never
+   * covered Faktura — so this goes through the archive plus the separate,
+   * mostly undocumented `/api/fileattachments/attachments-v1` product API
+   * instead.
+   */
+  async function uploadForInvoiceAttachment(filePath: string): Promise<ArchiveFileRow> {
+    const buf = readFileSync(filePath);
+    const form = new FormData();
+    form.append('file', new Blob([buf], { type: mimeForFile(filePath) }), basename(filePath));
+    const data = await transport.request<ArchiveFileResponse>('/3/archive', {
+      method: 'POST',
+      params: { folderid: 'inbox_kf' },
+      rawBody: form,
+    });
+    return data.File;
+  }
+
+  async function listInvoiceAttachments(documentNumber: string): Promise<InvoiceAttachment[]> {
+    return transport.request<InvoiceAttachment[]>('/api/fileattachments/attachments-v1', {
+      params: { entityid: documentNumber, entitytype: 'F' },
+    });
+  }
+
+  async function createInvoiceAttachment(
+    documentNumber: string,
+    fileId: string,
+    includeOnSend: boolean,
+  ): Promise<InvoiceAttachment> {
+    const data = await transport.request<InvoiceAttachment[]>(
+      '/api/fileattachments/attachments-v1',
+      {
+        method: 'POST',
+        body: [{ entityId: Number(documentNumber), entityType: 'F', fileId, includeOnSend }],
+      },
+    );
+    const attachment = data[0];
+    if (!attachment) {
+      throw new Error(`Fortnox did not return an attachment record for invoice ${documentNumber}.`);
+    }
+    return attachment;
+  }
+
+  // Orchestrate: upload each file to the archive, then attach it in order.
+  async function attachInvoiceFiles(
+    params: AttachInvoiceFilesParams,
+  ): Promise<AttachInvoiceFileResult[]> {
+    for (const filePath of params.filePaths) {
+      if (!existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+      if (!statSync(filePath).isFile()) throw new Error(`Not a file: ${filePath}`);
+    }
+    const includeOnSend = params.includeOnSend ?? true;
+    const results: AttachInvoiceFileResult[] = [];
+    for (const filePath of params.filePaths) {
+      try {
+        const file = await uploadForInvoiceAttachment(filePath);
+        const attachment = await createInvoiceAttachment(
+          params.documentNumber,
+          file.ArchiveFileId,
+          includeOnSend,
+        );
+        results.push({
+          fileName: file.Name,
+          fileId: attachment.fileId,
+          attachmentId: attachment.id,
+          includeOnSend: attachment.includeOnSend,
+        });
+      } catch (err) {
+        const done = results.map((r) => r.fileName).join(', ') || 'none';
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Failed attaching "${basename(filePath)}" to invoice ${params.documentNumber}: ${detail}. Files already attached this run: ${done}.`,
+        );
+      }
+    }
+    return results;
+  }
+
   return {
     listInvoices,
     getInvoice,
@@ -220,6 +362,8 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     markInvoicePrinted,
     bookkeepInvoice,
     creditInvoice,
+    attachInvoiceFiles,
+    listInvoiceAttachments,
   };
 }
 
@@ -233,4 +377,6 @@ export const {
   markInvoicePrinted,
   bookkeepInvoice,
   creditInvoice,
+  attachInvoiceFiles,
+  listInvoiceAttachments,
 } = createInvoiceOperations(defaultFortnoxTransport);

--- a/src/scope-probes.ts
+++ b/src/scope-probes.ts
@@ -26,4 +26,5 @@ export const scopeProbeEndpoints: Record<string, string> = {
   inbox: 'inbox',
   connectfile: 'voucherfileconnections?limit=1',
   salary: 'employees?limit=1',
+  archive: 'archive',
 };

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -11,13 +11,19 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
-import { invoiceListColumns, invoiceDetailColumns, invoiceConfirmColumns } from '../views.js';
+import {
+  invoiceListColumns,
+  invoiceDetailColumns,
+  invoiceConfirmColumns,
+  invoiceAttachmentListColumns,
+} from '../views.js';
 import {
   confirmationResponse,
   detailResponse,
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 const InvoiceRowSchema = z.strictObject({
@@ -147,6 +153,8 @@ export function registerInvoiceTools(
     markInvoicePrinted,
     bookkeepInvoice,
     creditInvoice,
+    attachInvoiceFiles,
+    listInvoiceAttachments,
   } = operations;
   server.tool(
     'fortnox_list_invoices',
@@ -452,6 +460,66 @@ export function registerInvoiceTools(
         `Kreditfaktura skapad för faktura ${documentNumber}.`,
         invoice,
         invoiceConfirmColumns,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_attach_invoice_files',
+    'Ladda upp kvitto/underlagsfiler och koppla dem till en kundfaktura i Fortnox. Kräver "archive"-behörigheten (noxctl init --with-archive).',
+    {
+      documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
+      files: z.array(z.string()).describe('Sökvägar till filer som ska laddas upp och kopplas'),
+      includeOnSend: z
+        .boolean()
+        .optional()
+        .describe('Bunta med filen när fakturan skickas (default: true)'),
+      confirm: z.boolean().optional().describe('Bekräfta att filerna ska kopplas'),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe('Visa vad som skulle skickas utan att ladda upp filerna'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, files, includeOnSend, confirm, dryRun, includeRaw }) => {
+      if (dryRun) {
+        return dryRunResponse(`attach ${files.length} file(s) to invoice ${documentNumber}`, {
+          documentNumber,
+          files,
+          includeOnSend: includeOnSend ?? true,
+        });
+      }
+      if (!confirm) {
+        requireConfirmation(`attach ${files.length} file(s) to invoice ${documentNumber}`);
+      }
+      const results = await attachInvoiceFiles({
+        documentNumber,
+        filePaths: files,
+        includeOnSend,
+      });
+      const ids = results.map((r) => r.fileId).join(', ');
+      const summary = `Kopplade ${results.length} fil(er) till faktura ${documentNumber}. Fil-ID: ${ids}`;
+      return textResponse(
+        includeRaw ? `${summary}\n\n${JSON.stringify(results, null, 2)}` : summary,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_list_invoice_attachments',
+    'Lista filer som är kopplade till en kundfaktura i Fortnox.',
+    {
+      documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, includeRaw }) => {
+      const results = await listInvoiceAttachments(documentNumber);
+      return listResponse(
+        results as unknown as Record<string, unknown>[],
+        invoiceAttachmentListColumns,
+        results,
+        undefined,
         includeRaw,
       );
     },

--- a/src/views.ts
+++ b/src/views.ts
@@ -506,6 +506,20 @@ export const voucherAttachmentColumns: Column[] = [
   { key: 'voucherYear', header: 'Year', width: 5, align: 'right' },
 ];
 
+// --- Invoice file attachment views ---
+
+export const invoiceAttachmentColumns: Column[] = [
+  { key: 'fileName', header: 'File', width: 40 },
+  { key: 'fileId', header: 'File ID', width: 36 },
+  { key: 'includeOnSend', header: 'On send', width: 8 },
+];
+
+export const invoiceAttachmentListColumns: Column[] = [
+  { key: 'fileId', header: 'File ID', width: 36 },
+  { key: 'includeOnSend', header: 'On send', width: 8 },
+  { key: 'id', header: 'Attachment ID', width: 36 },
+];
+
 // --- Payroll / Lön views (target ≤80 cols) ---
 
 const redactPayrollValue = (): string => '[redacted — use JSON/includeRaw for explicit access]';

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -96,6 +96,24 @@ describe('CLI smoke tests', () => {
     expect(output).toContain('pdf');
     expect(output).toContain('bookkeep');
     expect(output).toContain('credit');
+    expect(output).toContain('attach');
+    expect(output).toContain('attachments');
+  });
+
+  it('noxctl invoices attach --help documents the archive scope requirement', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'invoices', 'attach', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('--no-include-on-send');
+    expect(output).toContain('--dry-run');
+    expect(output).toContain('archive');
+  });
+
+  it('noxctl init --help shows the --with-archive flag', () => {
+    const output = execFileSync('node', [CLI_PATH, 'init', '--help'], execOpts) as string;
+    expect(output).toContain('--with-archive');
   });
 
   it('noxctl invoices pdf --help documents the destination and --mark-sent options', () => {

--- a/tests/operations/invoices.test.ts
+++ b/tests/operations/invoices.test.ts
@@ -1,9 +1,26 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
   // Needed by FortnoxApiError, which prefixes messages with the active profile.
   getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+const fsMock = vi.hoisted(() => {
+  const readFileSync = vi.fn(() => Buffer.from('fake-file-content'));
+  const existsSync = vi.fn(() => true);
+  const statSync = vi.fn(() => ({ isFile: () => true }));
+  return { readFileSync, existsSync, statSync };
+});
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: fsMock.readFileSync,
+    existsSync: fsMock.existsSync,
+    statSync: fsMock.statSync,
+  },
+  readFileSync: fsMock.readFileSync,
+  existsSync: fsMock.existsSync,
+  statSync: fsMock.statSync,
 }));
 
 function mockFetch(response: unknown) {
@@ -48,6 +65,13 @@ function mockPdfThenInvoice(invoice: Record<string, unknown>) {
 }
 
 describe('invoice operations', () => {
+  beforeEach(() => {
+    // Re-establish fs defaults each test (restoreAllMocks below clears them).
+    fsMock.readFileSync.mockReturnValue(Buffer.from('fake-file-content'));
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.statSync.mockReturnValue({ isFile: () => true });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -357,6 +381,251 @@ describe('invoice operations', () => {
       expect(fetchCall[0]).toContain('invoices/1001/credit');
       expect(fetchCall[1].method).toBe('PUT');
       expect(result.CreditInvoiceReference).toBe('1001');
+    });
+  });
+
+  describe('attachInvoiceFiles', () => {
+    it('uploads to /3/archive?folderid=inbox_kf and attaches with ArchiveFileId (not Id)', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+
+      const mockFn = vi
+        .fn()
+        // upload: POST /3/archive?folderid=inbox_kf
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                File: { Id: 'wrong-id', ArchiveFileId: 'arch-1', Name: 'underlag.pdf' },
+              }),
+            ),
+          json: () =>
+            Promise.resolve({
+              File: { Id: 'wrong-id', ArchiveFileId: 'arch-1', Name: 'underlag.pdf' },
+            }),
+        })
+        // attach: POST /api/fileattachments/attachments-v1
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                {
+                  id: 'attach-1',
+                  entityId: 91110646,
+                  entityType: 'F',
+                  fileId: 'arch-1',
+                  includeOnSend: true,
+                },
+              ]),
+            ),
+          json: () =>
+            Promise.resolve([
+              {
+                id: 'attach-1',
+                entityId: 91110646,
+                entityType: 'F',
+                fileId: 'arch-1',
+                includeOnSend: true,
+              },
+            ]),
+        });
+      global.fetch = mockFn;
+
+      const results = await attachInvoiceFiles({
+        documentNumber: '91110646',
+        filePaths: ['/tmp/underlag.pdf'],
+      });
+
+      const [uploadUrl, uploadInit] = mockFn.mock.calls[0] as [string, RequestInit];
+      expect(uploadUrl).toContain('/3/archive');
+      expect(uploadUrl).toContain('folderid=inbox_kf');
+      expect(uploadInit.method).toBe('POST');
+      expect(uploadInit.body).toBeInstanceOf(FormData);
+
+      const [attachUrl, attachInit] = mockFn.mock.calls[1] as [string, RequestInit];
+      expect(attachUrl).toContain('/api/fileattachments/attachments-v1');
+      const attachBody = JSON.parse(attachInit.body as string);
+      // The critical, easy-to-regress detail: the ARCHIVE upload's `Id` must
+      // never be used — only `ArchiveFileId`. Using `Id` here fails on the
+      // real API with wrong_file_location.
+      expect(attachBody[0].fileId).toBe('arch-1');
+      expect(attachBody[0].fileId).not.toBe('wrong-id');
+      expect(attachBody[0].entityType).toBe('F');
+      expect(attachBody[0].entityId).toBe(91110646);
+
+      expect(results).toEqual([
+        {
+          fileName: 'underlag.pdf',
+          fileId: 'arch-1',
+          attachmentId: 'attach-1',
+          includeOnSend: true,
+        },
+      ]);
+    });
+
+    it('defaults includeOnSend to true when not specified', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      const mockFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(JSON.stringify({ File: { ArchiveFileId: 'a1', Name: 'x.pdf' } })),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                { id: 'att1', entityId: 1, entityType: 'F', fileId: 'a1', includeOnSend: true },
+              ]),
+            ),
+        });
+      global.fetch = mockFn;
+
+      await attachInvoiceFiles({ documentNumber: '1', filePaths: ['/tmp/x.pdf'] });
+
+      const [, attachInit] = mockFn.mock.calls[1] as [string, RequestInit];
+      const body = JSON.parse(attachInit.body as string);
+      expect(body[0].includeOnSend).toBe(true);
+    });
+
+    it('honors an explicit includeOnSend: false', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      const mockFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(JSON.stringify({ File: { ArchiveFileId: 'a2', Name: 'y.pdf' } })),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                { id: 'att2', entityId: 1, entityType: 'F', fileId: 'a2', includeOnSend: false },
+              ]),
+            ),
+        });
+      global.fetch = mockFn;
+
+      await attachInvoiceFiles({
+        documentNumber: '1',
+        filePaths: ['/tmp/y.pdf'],
+        includeOnSend: false,
+      });
+
+      const [, attachInit] = mockFn.mock.calls[1] as [string, RequestInit];
+      const body = JSON.parse(attachInit.body as string);
+      expect(body[0].includeOnSend).toBe(false);
+    });
+
+    it('fails fast (before any upload) when a file path does not exist', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      fsMock.existsSync.mockReturnValue(false);
+      mockFetch({});
+
+      await expect(
+        attachInvoiceFiles({ documentNumber: '1', filePaths: ['/tmp/missing.pdf'] }),
+      ).rejects.toThrow(/File not found: \/tmp\/missing\.pdf/);
+
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('rejects a directory path before uploading', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      fsMock.statSync.mockReturnValue({ isFile: () => false });
+      mockFetch({});
+
+      await expect(
+        attachInvoiceFiles({ documentNumber: '1', filePaths: ['/tmp/adir'] }),
+      ).rejects.toThrow(/Not a file: \/tmp\/adir/);
+
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('surfaces already-attached files when a later file fails mid-batch', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      const mockFn = vi
+        .fn()
+        // file 1 upload OK
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(JSON.stringify({ File: { ArchiveFileId: 'a1', Name: 'a.pdf' } })),
+        })
+        // file 1 attach OK
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                { id: 'att1', entityId: 1, entityType: 'F', fileId: 'a1', includeOnSend: true },
+              ]),
+            ),
+        })
+        // file 2 upload FAILS
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve(JSON.stringify({ ErrorInformation: { message: 'boom' } })),
+        });
+      global.fetch = mockFn;
+
+      await expect(
+        attachInvoiceFiles({ documentNumber: '1', filePaths: ['/tmp/a.pdf', '/tmp/b.pdf'] }),
+      ).rejects.toThrow(/already attached this run: a\.pdf/);
+    });
+
+    it('throws when Fortnox returns no attachment record for the invoice', async () => {
+      const { attachInvoiceFiles } = await import('../../src/operations/invoices.js');
+      const mockFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(JSON.stringify({ File: { ArchiveFileId: 'a1', Name: 'a.pdf' } })),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify([])),
+        });
+      global.fetch = mockFn;
+
+      await expect(
+        attachInvoiceFiles({ documentNumber: '1', filePaths: ['/tmp/a.pdf'] }),
+      ).rejects.toThrow(/did not return an attachment record/);
+    });
+  });
+
+  describe('listInvoiceAttachments', () => {
+    it('GETs the fileattachments product API filtered by entity id/type', async () => {
+      const { listInvoiceAttachments } = await import('../../src/operations/invoices.js');
+      mockFetch([
+        { id: 'att1', entityId: 91110646, entityType: 'F', fileId: 'a1', includeOnSend: true },
+      ]);
+
+      const result = await listInvoiceAttachments('91110646');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('/api/fileattachments/attachments-v1');
+      expect(url).toContain('entityid=91110646');
+      expect(url).toContain('entitytype=F');
+      expect(result).toEqual([
+        { id: 'att1', entityId: 91110646, entityType: 'F', fileId: 'a1', includeOnSend: true },
+      ]);
     });
   });
 });

--- a/tests/scope-probes.test.ts
+++ b/tests/scope-probes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SCOPES, SALARY_SCOPE, ORDER_SCOPES, LEGACY_SCOPES } from '../src/auth.js';
+import { SCOPES, SALARY_SCOPE, ORDER_SCOPES, LEGACY_SCOPES, ARCHIVE_SCOPE } from '../src/auth.js';
 import { scopeProbeEndpoints } from '../src/scope-probes.js';
 
 // `noxctl doctor` / `fortnox_status` probe one endpoint per granted scope and
@@ -11,6 +11,7 @@ describe('scope probe coverage', () => {
     ...SCOPES.split(' '),
     ...ORDER_SCOPES.split(' '),
     SALARY_SCOPE,
+    ARCHIVE_SCOPE,
     ...LEGACY_SCOPES.split(' '),
   ];
 

--- a/tests/tools/invoices.test.ts
+++ b/tests/tools/invoices.test.ts
@@ -570,4 +570,118 @@ describe('invoice tools', () => {
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     });
   });
+
+  describe('fortnox_attach_invoice_files', () => {
+    it('returns isError when confirm is missing', async () => {
+      mockFetch({});
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_attach_invoice_files',
+        arguments: { documentNumber: '91110646', files: ['/tmp/underlag.pdf'] },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('returns dryRun preview without uploading', async () => {
+      mockFetch({});
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_attach_invoice_files',
+        arguments: { documentNumber: '91110646', files: ['/tmp/underlag.pdf'], dryRun: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Dry run');
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('uploads to /3/archive?folderid=inbox_kf and attaches with ArchiveFileId', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'noxctl-attach-test-'));
+      const filePath = join(dir, 'underlag.pdf');
+      writeFileSync(filePath, 'fake receipt bytes');
+
+      const mockFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                File: { Id: 'wrong-id', ArchiveFileId: 'arch-1', Name: 'underlag.pdf' },
+              }),
+            ),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                {
+                  id: 'attach-1',
+                  entityId: 91110646,
+                  entityType: 'F',
+                  fileId: 'arch-1',
+                  includeOnSend: true,
+                },
+              ]),
+            ),
+        });
+      global.fetch = mockFn;
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_attach_invoice_files',
+        arguments: { documentNumber: '91110646', files: [filePath], confirm: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [uploadUrl] = mockFn.mock.calls[0] as [string];
+      expect(uploadUrl).toContain('/3/archive');
+      expect(uploadUrl).toContain('folderid=inbox_kf');
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('arch-1');
+
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+
+  describe('fortnox_list_invoice_attachments', () => {
+    it('lists attachments via the fileattachments product API', async () => {
+      mockFetch([
+        { id: 'att1', entityId: 91110646, entityType: 'F', fileId: 'a1', includeOnSend: true },
+      ]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_invoice_attachments',
+        arguments: { documentNumber: '91110646' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('a1');
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('/api/fileattachments/attachments-v1');
+      expect(calledUrl).toContain('entityid=91110646');
+      expect(calledUrl).toContain('entitytype=F');
+    });
+
+    it('is read-only — no confirmation required', async () => {
+      mockFetch([]);
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_invoice_attachments',
+        arguments: { documentNumber: '91110646' },
+      });
+
+      expect(result.isError).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
Customer invoices have no invoicefileconnections — the per-entity connection pattern used by vouchers/supplier invoices/articles/assets never covered Faktura — so attaching a receipt/underlag to one goes through the file archive plus a separate, mostly undocumented product API instead.

- fortnox_attach_invoice_files / `invoices attach <docNumber> <files...>`
- fortnox_list_invoice_attachments / `invoices attachments <docNumber>`

Two load-bearing details are not in Fortnox's published OpenAPI spec and were only found by inspecting the Fortnox web app's own network traffic:
  1. The upload must go to `/3/archive?folderid=inbox_kf` — not `/3/inbox` (file_not_found on attach) and not a default-folder `/3/archive` (wrong_file_location on attach).
  2. The attach call needs that upload response's `ArchiveFileId` field, not `Id` (also wrong_file_location).

Requires a new opt-in `archive` scope (`noxctl init --with-archive`) — attaching is licence-gated behind Arkivplats, same reasoning as the existing salary/order opt-ins. Listing attachments needs no new scope and works with any profile, verified live.

Also fixes endpointToScope() so 403 hints resolve correctly for absolute-path endpoints like /3/archive (it was only matching the classic relative "vouchers"-style paths).