### PR TITLE
fix: customer write schema drops Type, Phone, and Country fields

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1885,7 +1885,7 @@ customers
     'after',
     `
 Examples:
-  echo '{"Email":"new@acme.se","Phone":"08-123456"}' | noxctl customers update 25 --input - --yes`,
+  echo '{"Email":"new@acme.se","Phone1":"08-123456"}' | noxctl customers update 25 --input - --yes`,
   )
   .action(
     async (customerNumber: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -13,6 +13,82 @@ const CustomerNumberSchema = z
   .string()
   .regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,49}$/, 'Customer number must be alphanumeric');
 
+// The full writable Customer field set (Fortnox `CustomerSinglePayloadItem`).
+// The MCP SDK silently strips any argument the schema does not declare, so a
+// field missing here never reaches Fortnox and never raises an error — it just
+// vanishes (#96, same class of bug as the Supplier field gap). The operations
+// layer forwards whatever it is given.
+//
+// Country / DeliveryCountry / VisitingCountry are deliberately NOT declared
+// here: Fortnox rejects them on write ("Fältet Country är endast läsbart") —
+// they're server-derived from the matching *CountryCode field, which is the
+// real writable source and is exposed below. operations/customers.ts strips
+// the *Country fields defensively too, so a `get` response fed straight back
+// into create/update still works, but the tool schema should not offer a
+// field that would then be silently dropped a second time.
+const customerWritableFields = {
+  Name: z.string().optional().describe('Kundnamn'),
+  Type: z.enum(['PRIVATE', 'COMPANY']).optional().describe('Kundtyp: privatperson eller företag'),
+  OrganisationNumber: z.string().optional().describe('Organisations- eller personnummer'),
+  Email: z.string().optional().describe('E-postadress'),
+  Phone1: z.string().optional().describe('Telefonnummer'),
+  Phone2: z.string().optional().describe('Alternativt telefonnummer'),
+  Fax: z.string().optional().describe('Faxnummer'),
+  WWW: z.string().optional().describe('Webbplats'),
+  Address1: z.string().optional().describe('Adressrad 1'),
+  Address2: z.string().optional().describe('Adressrad 2'),
+  ZipCode: z.string().optional().describe('Postnummer'),
+  City: z.string().optional().describe('Ort'),
+  CountryCode: z.string().optional().describe('Landskod (t.ex. "SE") — det skrivbara landfältet'),
+  DeliveryName: z.string().optional().describe('Leveransadress namn'),
+  DeliveryAddress1: z.string().optional().describe('Leveransadress rad 1'),
+  DeliveryAddress2: z.string().optional().describe('Leveransadress rad 2'),
+  DeliveryZipCode: z.string().optional().describe('Leveransadress postnummer'),
+  DeliveryCity: z.string().optional().describe('Leveransadress ort'),
+  DeliveryCountryCode: z.string().optional().describe('Leveransadress landskod'),
+  DeliveryFax: z.string().optional().describe('Leveransadress fax'),
+  DeliveryPhone1: z.string().optional().describe('Leveransadress telefon'),
+  DeliveryPhone2: z.string().optional().describe('Leveransadress alternativt telefon'),
+  VisitingAddress: z.string().optional().describe('Besöksadress'),
+  VisitingZipCode: z.string().optional().describe('Besöksadress postnummer'),
+  VisitingCity: z.string().optional().describe('Besöksadress ort'),
+  VisitingCountryCode: z.string().optional().describe('Besöksadress landskod'),
+  GLN: z.string().optional().describe('GLN-nummer (13 tecken)'),
+  GLNDelivery: z.string().optional().describe('GLN-nummer för leverans (13 tecken)'),
+  ExternalReference: z.string().optional().describe('Externt referens-id'),
+  OurReference: z.string().optional().describe('Vår referens'),
+  YourReference: z.string().optional().describe('Er referens'),
+  Comments: z.string().optional().describe('Kommentarer'),
+  Currency: z.string().optional().describe('Valuta (t.ex. "SEK")'),
+  CostCenter: z.string().optional().describe('Kostnadsställe'),
+  Project: z.string().optional().describe('Projektnummer'),
+  PriceList: z.string().optional().describe('Prislista'),
+  TermsOfDelivery: z.string().optional().describe('Leveransvillkor (kod)'),
+  TermsOfPayment: z.string().optional().describe('Betalningsvillkor (kod)'),
+  WayOfDelivery: z.string().optional().describe('Leveranssätt (kod)'),
+  VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
+  VATType: z
+    .enum(['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT'])
+    .optional()
+    .describe('Momstyp'),
+  SalesAccount: z.string().optional().describe('Försäljningskonto (4 siffror)'),
+  InvoiceAdministrationFee: z.string().optional().describe('Faktureringsavgift'),
+  InvoiceDiscount: z.number().optional().describe('Fakturarabatt i procent'),
+  InvoiceFreight: z.string().optional().describe('Fraktavgift'),
+  InvoiceRemark: z.string().optional().describe('Fakturaanmärkning'),
+  ShowPriceVATIncluded: z.boolean().optional().describe('Visa priser inklusive moms'),
+  EmailInvoice: z.string().optional().describe('E-post för fakturor'),
+  EmailInvoiceCC: z.string().optional().describe('Kopia (CC) för fakturamejl'),
+  EmailInvoiceBCC: z.string().optional().describe('Hemlig kopia (BCC) för fakturamejl'),
+  EmailOffer: z.string().optional().describe('E-post för offerter'),
+  EmailOfferCC: z.string().optional().describe('Kopia (CC) för offertmejl'),
+  EmailOfferBCC: z.string().optional().describe('Hemlig kopia (BCC) för offertmejl'),
+  EmailOrder: z.string().optional().describe('E-post för ordrar'),
+  EmailOrderCC: z.string().optional().describe('Kopia (CC) för ordermejl'),
+  EmailOrderBCC: z.string().optional().describe('Hemlig kopia (BCC) för ordermejl'),
+  Active: z.boolean().optional().describe('Aktiv kund'),
+};
+
 export function registerCustomerTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
@@ -42,7 +118,7 @@ export function registerCustomerTools(
 
   server.tool(
     'fortnox_get_customer',
-    'Hämta en enskild kund från Fortnox. Returnerar: CustomerNumber, Name, OrganisationNumber, Email, Phone, Address1, ZipCode, City, Country, VATNumber.',
+    'Hämta en enskild kund från Fortnox. Returnerar: CustomerNumber, Name, Type, OrganisationNumber, Email, Phone1, Address1, ZipCode, City, Country, VATNumber.',
     {
       customerNumber: CustomerNumberSchema.describe('Kundnummer'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
@@ -57,15 +133,8 @@ export function registerCustomerTools(
     'fortnox_create_customer',
     'Skapa en ny kund i Fortnox',
     {
+      ...customerWritableFields,
       Name: z.string().describe('Kundnamn'),
-      OrganisationNumber: z.string().optional().describe('Organisationsnummer'),
-      Email: z.string().optional().describe('E-postadress'),
-      Phone: z.string().optional().describe('Telefonnummer'),
-      Address1: z.string().optional().describe('Adressrad 1'),
-      Address2: z.string().optional().describe('Adressrad 2'),
-      ZipCode: z.string().optional().describe('Postnummer'),
-      City: z.string().optional().describe('Ort'),
-      VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
       confirm: z.boolean().optional().describe('Bekräfta att kunden ska skapas'),
       dryRun: z.boolean().optional().describe('Visa vad som skulle skickas utan att skapa kunden'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
@@ -86,15 +155,7 @@ export function registerCustomerTools(
     'Uppdatera en befintlig kund i Fortnox',
     {
       customerNumber: CustomerNumberSchema.describe('Kundnummer att uppdatera'),
-      Name: z.string().optional().describe('Kundnamn'),
-      OrganisationNumber: z.string().optional().describe('Organisationsnummer'),
-      Email: z.string().optional().describe('E-postadress'),
-      Phone: z.string().optional().describe('Telefonnummer'),
-      Address1: z.string().optional().describe('Adressrad 1'),
-      Address2: z.string().optional().describe('Adressrad 2'),
-      ZipCode: z.string().optional().describe('Postnummer'),
-      City: z.string().optional().describe('Ort'),
-      VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
+      ...customerWritableFields,
       confirm: z.boolean().optional().describe('Bekräfta att kunden ska uppdateras'),
       dryRun: z
         .boolean()

--- a/src/views.ts
+++ b/src/views.ts
@@ -52,9 +52,12 @@ export const customerListColumns: Column[] = [
 export const customerDetailColumns: Column[] = [
   { key: 'CustomerNumber', header: 'Customer #', width: 20 },
   { key: 'Name', header: 'Name', width: 40 },
+  { key: 'Type', header: 'Type', width: 8 },
   { key: 'OrganisationNumber', header: 'Org Nr', width: 20 },
   { key: 'Email', header: 'Email', width: 40 },
-  { key: 'Phone', header: 'Phone', width: 20 },
+  // The real Fortnox field is Phone1 (there is no bare "Phone") — see the write
+  // schema fix in tools/customers.ts for the same mismatch on the write side.
+  { key: 'Phone1', header: 'Phone', width: 20 },
   { key: 'Address1', header: 'Address', width: 40 },
   { key: 'ZipCode', header: 'Zip Code', width: 10 },
   { key: 'City', header: 'City', width: 20 },

--- a/tests/tools/customers.test.ts
+++ b/tests/tools/customers.test.ts
@@ -138,7 +138,7 @@ describe('customer tools', () => {
           Name: 'Full Example AB',
           OrganisationNumber: '556677-8899',
           Email: 'info@full-example.example',
-          Phone: '08-123456',
+          Phone1: '08-123456',
           Address1: 'Exempelgatan 1',
           ZipCode: '11122',
           City: 'Uppsala',
@@ -150,6 +150,7 @@ describe('customer tools', () => {
       const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
       expect(body.Customer.OrganisationNumber).toBe('556677-8899');
       expect(body.Customer.City).toBe('Uppsala');
+      expect(body.Customer.Phone1).toBe('08-123456');
     });
   });
 
@@ -194,6 +195,130 @@ describe('customer tools', () => {
 
       expect(result.isError).toBe(true);
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  // Same class of bug as #96 (Supplier field gap): the MCP SDK silently strips
+  // any argument the Zod schema does not declare, so an undeclared field
+  // reaches neither Fortnox nor an error message — it just vanishes. Type and
+  // Phone1/Phone2 were missing entirely, and Phone was declared under a name
+  // Fortnox's Customer resource doesn't have (only Phone1/Phone2 exist).
+  describe('customer write schemas cover the real Customer resource', () => {
+    const extendedFields = {
+      Type: 'PRIVATE',
+      Phone1: '08-123456',
+      Phone2: '070-1234567',
+      Fax: '08-654321',
+      WWW: 'https://example.test',
+      Address2: 'Plan 4',
+      CountryCode: 'SE',
+      DeliveryName: 'Lagret',
+      DeliveryAddress1: 'Lagergatan 1',
+      DeliveryZipCode: '11133',
+      DeliveryCity: 'Uppsala',
+      DeliveryCountryCode: 'SE',
+      VisitingAddress: 'Besöksgatan 2',
+      VisitingZipCode: '11144',
+      VisitingCity: 'Uppsala',
+      VisitingCountryCode: 'SE',
+      GLN: '1234567890123',
+      ExternalReference: 'ext-42',
+      OurReference: 'Anna Andersson',
+      YourReference: 'Erik Eriksson',
+      Comments: 'VIP customer',
+      Currency: 'SEK',
+      CostCenter: 'CC1',
+      Project: '12',
+      PriceList: 'A',
+      TermsOfDelivery: 'EXW',
+      TermsOfPayment: '30',
+      VATNumber: 'SE556677889901',
+      VATType: 'SEVAT',
+      SalesAccount: '3001',
+      InvoiceRemark: 'Handle with care',
+      ShowPriceVATIncluded: false,
+      EmailInvoice: 'invoices@example.test',
+      Active: true,
+    };
+
+    // The claim is full coverage of the Customer resource, so assert the
+    // schema's property list itself — sending a subset of values cannot
+    // detect a field quietly dropped from the schema.
+    const writableCustomerFields = Object.keys(extendedFields);
+
+    it('declares every writable Customer field on create', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_create_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      for (const field of writableCustomerFields) {
+        expect(declared).toContain(field);
+      }
+    });
+
+    it('declares every writable Customer field on update', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_update_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      for (const field of writableCustomerFields) {
+        expect(declared).toContain(field);
+      }
+    });
+
+    // Regression guard: Country/DeliveryCountry/VisitingCountry are genuinely
+    // read-only on this resource (Fortnox rejects them with "Fältet Country är
+    // endast läsbart") — they must stay off the writable schema, not just be
+    // silently stripped a second time at the operations layer.
+    it('does not declare the read-only *Country fields', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_update_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      expect(declared).not.toContain('Country');
+      expect(declared).not.toContain('DeliveryCountry');
+      expect(declared).not.toContain('VisitingCountry');
+    });
+
+    it('forwards extended fields on create', async () => {
+      mockFetch({ Customer: { CustomerNumber: '3' } });
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_create_customer',
+        arguments: { Name: 'New Customer', confirm: true, ...extendedFields },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const sent = JSON.parse(fetchCall[1].body as string).Customer;
+      for (const [key, value] of Object.entries(extendedFields)) {
+        expect(sent[key]).toEqual(value);
+      }
+    });
+
+    it('forwards extended fields on update', async () => {
+      mockFetch({ Customer: { CustomerNumber: '3' } });
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_update_customer',
+        arguments: { customerNumber: '3', confirm: true, ...extendedFields },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const sent = JSON.parse(fetchCall[1].body as string).Customer;
+      for (const [key, value] of Object.entries(extendedFields)) {
+        expect(sent[key]).toEqual(value);
+      }
+      expect(sent.customerNumber).toBeUndefined();
+    });
+
+    it('rejects an invalid Type value', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_customer',
+        arguments: { Name: 'Bad Type', Type: 'INDIVIDUAL', confirm: true },
+      });
+
+      expect(result.isError).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Same bug class as #96 (Supplier field gap): the MCP SDK silently strips any argument the Zod schema does not declare, so a field missing from the schema reaches neither Fortnox nor an error message — it just vanishes. fortnox_create_customer/fortnox_update_customer only declared 9 of the ~60 writable Customer fields, unlike suppliers.ts which already got the comprehensive fix for this same bug class.

Found via a real customer creation: Type ("Privat"/"Företag") silently never saved, and Phone was declared under a field name Fortnox's Customer resource doesn't have at all — only Phone1/Phone2 exist (the old field just vanished the same way).

- Added the full writable Customer field set (Fortnox CustomerSinglePayloadItem) to tools/customers.ts, shared between create and update, matching the customerWritableFields pattern suppliers.ts already established.
- Type is now a proper enum (PRIVATE/COMPANY).
- Phone -> Phone1 (plus Phone2), matching the real API field.
- CountryCode is exposed (not Country): Fortnox rejects Country on write ("Fältet Country är endast läsbart") and derives it from *CountryCode instead — operations/customers.ts already stripped Country defensively, but the tool schema offered it anyway, which just reproduced the same silent-drop bug one layer up. Confirmed against the live Fortnox account.
- Fixed customerDetailColumns in views.ts, which had the same Phone vs Phone1 mismatch on the read side — phone numbers never displayed even when Fortnox had them.
- Fixed a CLI help example still showing the wrong "Phone" field name (the CLI's own --input path was never affected, since it forwards arbitrary JSON with no schema).

Verified live: Type and CountryCode now save correctly on a real customer, with Country auto-populating from CountryCode as expected.