### PR TITLE
feat: read access to supplier invoice file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Supplier-invoice attachments can now be listed and downloaded.**
+  `noxctl supplier-invoices attachments <givenNumber>` and
+  `fortnox_list_supplier_invoice_attachments` list files (e.g. the scanned or
+  emailed invoice itself) attached to a supplier invoice; `noxctl
+  supplier-invoices file <fileId>` and `fortnox_get_supplier_invoice_file`
+  download them. Unlike voucher attachments, this reaches the original
+  document directly, so it works for `unbooked`/`authorizepending` invoices —
+  before they've been bookkept into a voucher. No new scope required.
+
 ## [0.9.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl supplier-invoices get <givenNumber>` | `fortnox_get_supplier_invoice` | Get a single supplier invoice |
 | `noxctl supplier-invoices create --supplier <n> --input <file>` | `fortnox_create_supplier_invoice` | Create a supplier invoice (mutation) |
 | `noxctl supplier-invoices bookkeep <givenNumber>` | `fortnox_bookkeep_supplier_invoice` | Bookkeep a supplier invoice (mutation) |
+| `noxctl supplier-invoices attachments <givenNumber>` | `fortnox_list_supplier_invoice_attachments` | List files (e.g. the scanned/received invoice) attached to a supplier invoice — works for unbooked/authorizepending invoices too, read-only, default scopes only |
+| `noxctl supplier-invoices file <fileId> [-f <path>]` | `fortnox_get_supplier_invoice_file` | Download a file attached to a supplier invoice (get `fileId` from `supplier-invoices attachments`) — read-only, default scopes only |
 
 ### Supplier invoice payments (utbetalningar)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ import {
   supplierInvoiceListColumns,
   supplierInvoiceDetailColumns,
   supplierInvoiceConfirmColumns,
+  supplierInvoiceAttachmentColumns,
   invoicePaymentListColumns,
   invoicePaymentDetailColumns,
   supplierInvoicePaymentListColumns,
@@ -2201,6 +2202,78 @@ supplierInvoices
       data,
       supplierInvoiceConfirmColumns,
       'SupplierInvoice',
+    );
+  });
+
+supplierInvoices
+  .command('attachments <givenNumber>')
+  .description(
+    'List files (e.g. the scanned/received invoice) attached to a supplier invoice — works for unbooked/authorizepending invoices too',
+  )
+  .action(async (givenNumber: string) => {
+    const { listSupplierInvoiceAttachments } = await import('./operations/supplier-invoices.js');
+    const attachments = await listSupplierInvoiceAttachments(givenNumber);
+    if (json()) {
+      console.log(JSON.stringify({ Attachments: attachments }, null, 2));
+    } else {
+      outputList(
+        attachments as unknown as Record<string, unknown>[],
+        supplierInvoiceAttachmentColumns,
+        false,
+        attachments,
+      );
+    }
+  });
+
+supplierInvoices
+  .command('file <fileId>')
+  .description(
+    'Download a file attached to a supplier invoice (get the fileId from "supplier-invoices attachments")',
+  )
+  .option(
+    '-f, --file <path>',
+    'Write the file here (- for stdout; default: supplier-invoice-file-<fileId><ext>)',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  noxctl supplier-invoices attachments 1
+  noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63
+  noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63 --file invoice-scan.pdf`,
+  )
+  .action(async (fileId: string, opts: { file?: string }) => {
+    const { getSupplierInvoiceFile } = await import('./operations/supplier-invoices.js');
+    const { extensionForMime } = await import('./operations/vouchers.js');
+    const toStdout = opts.file === '-';
+
+    if (toStdout && program.opts().output === 'json') {
+      throw new Error(
+        '--file - writes raw file bytes to stdout and cannot be combined with --output json.',
+      );
+    }
+
+    const file = await getSupplierInvoiceFile(fileId);
+
+    if (toStdout) {
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(file.buffer, (err) => (err ? reject(err) : resolve()));
+      });
+      return;
+    }
+
+    const path =
+      opts.file ?? `supplier-invoice-file-${fileId}${extensionForMime(file.contentType)}`;
+    writeFileSync(path, file.buffer);
+    outputConfirmation(
+      `File saved to ${path} (${file.contentType}, ${file.buffer.length} bytes).`,
+      json(),
+      {
+        FileId: fileId,
+        Path: path,
+        ContentType: file.contentType,
+        Bytes: file.buffer.length,
+      },
     );
   });
 

--- a/src/operations/supplier-invoices.ts
+++ b/src/operations/supplier-invoices.ts
@@ -19,6 +19,18 @@ export interface ListSupplierInvoicesParams {
   all?: boolean;
 }
 
+export interface SupplierInvoiceAttachment {
+  fileName: string;
+  fileId: string;
+  supplierInvoiceNumber: string;
+}
+
+export interface SupplierInvoiceFileContent {
+  fileId: string;
+  contentType: string;
+  buffer: Buffer;
+}
+
 export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
   async function listSupplierInvoices(
     params: ListSupplierInvoicesParams = {},
@@ -73,11 +85,50 @@ export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
     return data.SupplierInvoice;
   }
 
+  interface SupplierInvoiceFileConnectionListResponse {
+    SupplierInvoiceFileConnections: Record<string, unknown>[];
+  }
+
+  // List the files attached to a supplier invoice — the read counterpart that
+  // was missing: vouchers and customer invoices both had a read path, but a
+  // supplier invoice's original document (the scanned/emailed invoice itself)
+  // was only reachable once the invoice was bookkept into a voucher. This
+  // reaches it directly, so it works for `unbooked`/`authorizepending`
+  // invoices too — server-side filtered by `supplierinvoicenumber`, unlike
+  // voucherfileconnections which has no matching filter for vouchers.
+  async function listSupplierInvoiceAttachments(
+    givenNumber: string,
+  ): Promise<SupplierInvoiceAttachment[]> {
+    const data = await transport.request<SupplierInvoiceFileConnectionListResponse>(
+      'supplierinvoicefileconnections',
+      { params: { supplierinvoicenumber: givenNumber } },
+    );
+    return (data.SupplierInvoiceFileConnections ?? []).map((c) => ({
+      fileName: String(c.Name ?? ''),
+      fileId: String(c.FileId),
+      supplierInvoiceNumber: String(c.SupplierInvoiceNumber ?? givenNumber),
+    }));
+  }
+
+  // Download the actual bytes of a file attached to a supplier invoice.
+  // Fortnox serves it the same way as a voucher attachment — GET inbox/{fileId}
+  // under the connectfile scope — no archive scope needed (that's only for
+  // customer invoices, which have no *invoicefileconnections* resource; see the
+  // ARCHIVE_SCOPE comment in auth.ts).
+  async function getSupplierInvoiceFile(fileId: string): Promise<SupplierInvoiceFileContent> {
+    const { buffer, contentType } = await transport.requestFile(
+      `inbox/${encodeURIComponent(fileId)}`,
+    );
+    return { fileId, contentType, buffer };
+  }
+
   return {
     listSupplierInvoices,
     getSupplierInvoice,
     createSupplierInvoice,
     bookkeepSupplierInvoice,
+    listSupplierInvoiceAttachments,
+    getSupplierInvoiceFile,
   };
 }
 
@@ -86,4 +137,6 @@ export const {
   getSupplierInvoice,
   createSupplierInvoice,
   bookkeepSupplierInvoice,
+  listSupplierInvoiceAttachments,
+  getSupplierInvoiceFile,
 } = createSupplierInvoiceOperations(defaultFortnoxTransport);

--- a/src/tools/supplier-invoices.ts
+++ b/src/tools/supplier-invoices.ts
@@ -1,17 +1,73 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
 import {
   supplierInvoiceListColumns,
   supplierInvoiceDetailColumns,
   supplierInvoiceConfirmColumns,
+  supplierInvoiceAttachmentColumns,
 } from '../views.js';
 import {
   detailResponse,
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
+
+/**
+ * Write a downloaded file to `target`, refusing to write through a symlink.
+ * Mirrors writeBinaryFile() in tools/bookkeeping.ts — see that copy for the
+ * rationale (paths here are model-generated tool arguments, so this closes
+ * off a symlink-overwrite path).
+ */
+function writeBinaryFile(target: string, data: Buffer, overwrite?: boolean): void {
+  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
+  const flags = overwrite
+    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
+    : O_WRONLY | O_CREAT | O_EXCL;
+
+  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    throw new Error(
+      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+    );
+  }
+
+  try {
+    const fd = openSync(target, flags, 0o600);
+    try {
+      let written = 0;
+      while (written < data.length) {
+        written += writeSync(fd, data, written, data.length - written);
+      }
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      throw new Error(
+        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
+      );
+    }
+    if (code === 'ELOOP') {
+      throw new Error(
+        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+      );
+    }
+    throw err;
+  }
+}
 
 const SupplierInvoiceRowSchema = z.strictObject({
   Account: z.number().int().min(1000).max(9999).describe('Kontonummer (1000–9999)'),
@@ -69,6 +125,9 @@ export function registerSupplierInvoiceTools(
     getSupplierInvoice,
     createSupplierInvoice,
     bookkeepSupplierInvoice,
+    listSupplierInvoiceAttachments,
+    getSupplierInvoiceFile,
+    extensionForMime,
   } = operations;
   server.tool(
     'fortnox_list_supplier_invoices',
@@ -173,6 +232,54 @@ export function registerSupplierInvoiceTools(
 
       const data = await bookkeepSupplierInvoice(givenNumber);
       return detailResponse(data, supplierInvoiceConfirmColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_list_supplier_invoice_attachments',
+    'Lista filer (t.ex. den inskannade/mottagna fakturan) som är kopplade till en leverantörsfaktura i Fortnox. Fungerar även för obokförda och ej godkända fakturor (unbooked/authorizepending) — till skillnad från verifikationsbilagor, som bara finns tillgängliga efter bokföring. Returnerar: File (filnamn), File ID. Använd fileId med fortnox_get_supplier_invoice_file för att hämta själva filen.',
+    {
+      givenNumber: z.string().describe('Leverantörsfakturanummer (GivenNumber)'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ givenNumber, includeRaw }) => {
+      const attachments = await listSupplierInvoiceAttachments(givenNumber);
+      return listResponse(
+        attachments as unknown as Record<string, unknown>[],
+        supplierInvoiceAttachmentColumns,
+        attachments,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_supplier_invoice_file',
+    'Ladda ner en fil som är kopplad till en leverantörsfaktura och spara den på disk. Returnerar sökvägen till filen (inte filinnehållet). Hämta fileId via fortnox_list_supplier_invoice_attachments.',
+    {
+      fileId: z.string().describe('Fil-ID, från fortnox_list_supplier_invoice_attachments'),
+      outputPath: z
+        .string()
+        .optional()
+        .describe(
+          'Sökväg att spara filen till. Skriver inte över en befintlig fil om inte overwrite är satt. Utelämnas: en ny privat temp-katalog används.',
+        ),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe('Tillåt att en befintlig fil på outputPath skrivs över'),
+    },
+    async ({ fileId, outputPath, overwrite }) => {
+      const file = await getSupplierInvoiceFile(fileId);
+      const ext = extensionForMime(file.contentType);
+      const target = outputPath
+        ? resolve(outputPath)
+        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `supplier-invoice-file-${fileId}${ext}`);
+      writeBinaryFile(target, file.buffer, overwrite);
+      return textResponse(
+        `Sparade fil (${file.contentType}, ${file.buffer.length} bytes) till ${target}`,
+      );
     },
   );
 }

--- a/src/views.ts
+++ b/src/views.ts
@@ -177,6 +177,11 @@ export const supplierInvoiceConfirmColumns: Column[] = [
   { key: 'Booked', header: 'Booked', width: 5 },
 ];
 
+export const supplierInvoiceAttachmentColumns: Column[] = [
+  { key: 'fileName', header: 'File', width: 40 },
+  { key: 'fileId', header: 'File ID', width: 36 },
+];
+
 // --- Invoice payment views (target ≤80 cols) ---
 
 // 8 + 2 + 10 + 2 + 10 + 2 + 12 + 2 + 10 + 2 + 10 = 70

--- a/tests/operations/supplier-invoices.test.ts
+++ b/tests/operations/supplier-invoices.test.ts
@@ -13,6 +13,16 @@ function mockFetch(response: unknown) {
   });
 }
 
+function mockBinary(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+  });
+}
+
 describe('supplier invoice operations', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -100,6 +110,63 @@ describe('supplier invoice operations', () => {
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(fetchCall[0]).toContain('supplierinvoices/1/bookkeep');
       expect(fetchCall[1].method).toBe('PUT');
+    });
+  });
+
+  describe('listSupplierInvoiceAttachments', () => {
+    it('GETs supplierinvoicefileconnections filtered by supplierinvoicenumber and maps the response', async () => {
+      const { listSupplierInvoiceAttachments } =
+        await import('../../src/operations/supplier-invoices.js');
+      mockFetch({
+        SupplierInvoiceFileConnections: [
+          { FileId: 'f1', Name: 'invoice-scan.pdf', SupplierInvoiceNumber: '1' },
+        ],
+      });
+
+      const result = await listSupplierInvoiceAttachments('1');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('supplierinvoicefileconnections');
+      expect(url).toContain('supplierinvoicenumber=1');
+      expect(result).toEqual([
+        { fileName: 'invoice-scan.pdf', fileId: 'f1', supplierInvoiceNumber: '1' },
+      ]);
+    });
+
+    it('returns an empty array when the invoice has no attachments', async () => {
+      const { listSupplierInvoiceAttachments } =
+        await import('../../src/operations/supplier-invoices.js');
+      mockFetch({ SupplierInvoiceFileConnections: [] });
+
+      const result = await listSupplierInvoiceAttachments('2');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSupplierInvoiceFile', () => {
+    it('GETs inbox/{fileId} and returns the raw bytes with content-type', async () => {
+      const { getSupplierInvoiceFile } = await import('../../src/operations/supplier-invoices.js');
+      const bytes = Buffer.from('fake-pdf-bytes');
+      mockBinary(bytes, 'application/pdf');
+
+      const result = await getSupplierInvoiceFile('f1');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('inbox/f1');
+      expect(result.fileId).toBe('f1');
+      expect(result.contentType).toBe('application/pdf');
+      expect(result.buffer.equals(bytes)).toBe(true);
+    });
+
+    it('throws when Fortnox answers 2xx with a JSON error envelope instead of file bytes', async () => {
+      const { getSupplierInvoiceFile } = await import('../../src/operations/supplier-invoices.js');
+      const bytes = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'not found', code: 123 } }),
+      );
+      mockBinary(bytes, 'application/json');
+
+      await expect(getSupplierInvoiceFile('missing')).rejects.toThrow(/not found/);
     });
   });
 });

--- a/tests/tools/supplier-invoices.test.ts
+++ b/tests/tools/supplier-invoices.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { createServer } from '../../src/index.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -13,6 +15,16 @@ function mockFetch(response: unknown, ok = true, status = 200) {
     status,
     text: () => Promise.resolve(JSON.stringify(response)),
     json: () => Promise.resolve(response),
+  });
+}
+
+function mockBinaryFetch(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
   });
 }
 
@@ -245,6 +257,97 @@ describe('supplier invoice tools', () => {
 
       expect(result.isError).toBe(true);
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('fortnox_list_supplier_invoice_attachments', () => {
+    it('lists attached files for a supplier invoice, even an unbooked one', async () => {
+      mockFetch({
+        SupplierInvoiceFileConnections: [
+          { FileId: 'f1', Name: 'invoice-scan.pdf', SupplierInvoiceNumber: '1' },
+        ],
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_supplier_invoice_attachments',
+        arguments: { givenNumber: '1' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('invoice-scan.pdf');
+      expect(text).toContain('f1');
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('supplierinvoicenumber=1');
+    });
+
+    it('is read-only — no confirmation required', async () => {
+      mockFetch({ SupplierInvoiceFileConnections: [] });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_supplier_invoice_attachments',
+        arguments: { givenNumber: '1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('fortnox_get_supplier_invoice_file', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('downloads the file and saves it to a temp path, returning that path', async () => {
+      const bytes = Buffer.from('%PDF-1.4 fake supplier invoice scan');
+      mockBinaryFetch(bytes, 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const match = text.match(/till (.+supplier-invoice-file-f1\.pdf)/);
+      expect(match).not.toBeNull();
+      const savedPath = match![1]!;
+      expect(readFileSync(savedPath).equals(bytes)).toBe(true);
+      rmSync(savedPath, { force: true });
+    });
+
+    it('writes to an explicit outputPath when given', async () => {
+      const bytes = Buffer.from('image-bytes');
+      mockBinaryFetch(bytes, 'image/jpeg');
+      const target = `${tmpdir()}/noxctl-test-supplier-invoice-file.jpg`;
+      rmSync(target, { force: true });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f2', outputPath: target },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(readFileSync(target).equals(bytes)).toBe(true);
+      rmSync(target, { force: true });
+    });
+
+    it('refuses to overwrite an existing file without overwrite: true', async () => {
+      const target = `${tmpdir()}/noxctl-test-supplier-invoice-file-exists.pdf`;
+      writeFileSync(target, 'already here');
+      mockBinaryFetch(Buffer.from('new-bytes'), 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f3', outputPath: target },
+      });
+
+      expect(result.isError).toBe(true);
+      rmSync(target, { force: true });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `fortnox_list_supplier_invoice_attachments` / `noxctl supplier-invoices attachments <givenNumber>` and `fortnox_get_supplier_invoice_file` / `noxctl supplier-invoices file <fileId>`.
- Backed by Fortnox's `supplierinvoicefileconnections` resource (server-side filtered by `supplierinvoicenumber`), downloaded via the same `inbox/{fileId}` path voucher attachments already use. No new scope required.

## Why
Vouchers and customer invoices both had a read path to their attached files, but a supplier invoice's original document (the scanned/emailed invoice itself) was only reachable once the invoice was bookkept into a voucher — after the numbers were already committed to the ledger.

That matters most before booking: this lets an LLM (or a human) pull the actual invoice/receipt for an `unbooked`/`authorizepending` supplier invoice and check the booked amount, VAT, and account coding against what the real document says — catching OCR errors, duplicate invoices, or miscoded rows while they're still cheap to fix, instead of after they're already in the ledger. This adds that read path directly against the supplier invoice, mirroring the existing `listVoucherAttachments`/`getVoucherFile` pattern in `src/operations/vouchers.ts`.

## What a reviewer should double-check
- The `supplierinvoicenumber` query filter and response fields (`FileId`, `Name`, `SupplierInvoiceNumber`) were confirmed against Fortnox's live OpenAPI spec, not just inferred from the voucher pattern.
- I could not run `npm test` locally (a Windows Application Control policy blocks vitest's native `rolldown` binding on this machine) — `npm run build` and `npm run lint` are clean, and the new tools were manually verified live against real Fortnox data via the MCP server before pushing. Please confirm CI is green.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] Manual live verification via MCP (list + download an unbooked supplier invoice's attachment)
- [ ] CI (`npm test`) — pending, could not run locally