### PR TITLE
feat: complete the open-source Fortnox core API surface

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -90,6 +90,10 @@ jobs:
             echo "error=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check implementation coverage
+        if: steps.diff.outputs.error != 'true' && steps.schema_audit.outputs.error != 'true'
+        run: npm run audit:api-coverage --silent
+
       - name: Commit updated snapshot
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Supplier-invoice attachments can now be listed and downloaded.**
+  `noxctl supplier-invoices attachments <givenNumber>` and
+  `fortnox_list_supplier_invoice_attachments` list files (e.g. the scanned or
+  emailed invoice itself) attached to a supplier invoice; `noxctl
+  supplier-invoices file <fileId>` and `fortnox_get_supplier_invoice_file`
+  download them. Unlike voucher attachments, this reaches the original
+  document directly, so it works for `unbooked`/`authorizepending` invoices —
+  before they've been bookkept into a voucher. No new scope required.
+
 ## [0.9.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ strict and validated before any request is sent.
 
 | CLI group | MCP surface | Purpose |
 |---|---|---|
-| `noxctl archive` | `fortnox_*_archive*` | List/get, multipart upload, delete path/entry |
+| `noxctl archive` | `fortnox_*_archive*` | List/download, multipart upload, delete path/entry |
 | `noxctl inbox` | `fortnox_*_inbox*` | List, multipart upload, safe download, delete |
 | `noxctl attachments` | `fortnox_*_document_attachment*` | Attach/list/count/validate/update/detach for invoices, offers, orders, and contracts |
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl supplier-invoices get <givenNumber>` | `fortnox_get_supplier_invoice` | Get a single supplier invoice |
 | `noxctl supplier-invoices create --supplier <n> --input <file>` | `fortnox_create_supplier_invoice` | Create a supplier invoice (mutation) |
 | `noxctl supplier-invoices bookkeep <givenNumber>` | `fortnox_bookkeep_supplier_invoice` | Bookkeep a supplier invoice (mutation) |
+| `noxctl supplier-invoices attachments <givenNumber>` | `fortnox_list_supplier_invoice_attachments` | List files (e.g. the scanned/received invoice) attached to a supplier invoice — works for unbooked/authorizepending invoices too, read-only, default scopes only |
+| `noxctl supplier-invoices file <fileId> [-f <path>]` | `fortnox_get_supplier_invoice_file` | Download a file attached to a supplier invoice (get `fileId` from `supplier-invoices attachments`) — read-only, default scopes only |
 
 ### Supplier invoice payments (utbetalningar)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ no shared credential and no backend operated by this project.
   Secret Service, or a DPAPI-protected Windows store.
 - **Multiple companies:** named profiles keep Fortnox tenants separate.
 
+### API coverage boundary
+
+noxctl tracks the complete published Fortnox operation inventory in an opaque,
+privacy-safe implementation manifest. Every family is classified as complete,
+partial, excluded, or blocked, and implemented families are verified against actual
+operation exports, discovered MCP tools, and CLI commands.
+
+The open-source core deliberately excludes separate product domains such as warehouse
+management, partner onboarding/KYC, integration-marketplace administration, and the
+standalone time-reporting API. Shared reference/configuration resources are read-first:
+their reads are supported, while writes are explicitly excluded from the v1 core.
+Remote URL attachment connections are also excluded because they introduce a separate
+remote-fetch trust boundary. These are product-boundary decisions, not hidden gaps.
+
 ## Quick start
 
 You need Node.js 22.12+, a Fortnox account with API access, and your own Fortnox
@@ -498,6 +512,44 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl financial-years get <id>` | `fortnox_get_financialyear` | Get a single financial year |
 | `noxctl financial-years locked-period` | `fortnox_get_lockedperiod` | Show through which date bookkeeping is locked |
 
+### Reference and setup data (read-only)
+
+The following command groups expose `list` and, where Fortnox provides it, `get` in
+both CLI and MCP: `currencies`, `units`, `modes-of-payments`,
+`terms-of-deliveries`, `terms-of-payments`, `ways-of-delivery`, `voucher-series`,
+`predefined-voucher-series`, `account-charts`, `predefined-accounts`, and
+`customer-references`.
+
+```bash
+noxctl currencies list
+noxctl terms-of-payments get 30
+noxctl account-charts list
+```
+
+### Accruals (periodiseringar)
+
+| CLI group | MCP tool prefix | Operations |
+|---|---|---|
+| `noxctl invoice-accruals` | `fortnox_*_invoice_accrual` | list, get, create, update, delete |
+| `noxctl supplier-invoice-accruals` | `fortnox_*_supplier_invoice_accrual` | list, get, create, update, delete |
+| `noxctl contract-accruals` | `fortnox_*_contract_accrual` | list, get, create, update, delete |
+
+Every mutation supports confirmation and dry-run preview. Nested accrual rows are
+strict and validated before any request is sent.
+
+### Archive, inbox, and cross-document attachments
+
+| CLI group | MCP surface | Purpose |
+|---|---|---|
+| `noxctl archive` | `fortnox_*_archive*` | List/get, multipart upload, delete path/entry |
+| `noxctl inbox` | `fortnox_*_inbox*` | List, multipart upload, safe download, delete |
+| `noxctl attachments` | `fortnox_*_document_attachment*` | Attach/list/count/validate/update/detach for invoices, offers, orders, and contracts |
+
+Voucher and supplier-invoice file connections additionally expose get/connect/detach
+commands under their existing CLI groups. Binary downloads default to a private
+temporary directory, use mode `0600`, refuse symlink targets and accidental overwrite,
+and only replace an existing regular file when `--overwrite` is explicit.
+
 ### Payroll (Lön)
 
 > **Requires the `salary` scope**, which is **opt-in**. Enable the **Lön** permission on your Fortnox app, then run `noxctl init --with-salary` (or set `FORTNOX_WITH_SALARY=1` in non-interactive setups). Without it, these endpoints return `403 Forbidden`. See [Setup](#1-create-a-fortnox-app).
@@ -673,7 +725,8 @@ npm run test:watch   # watch mode
 npm run lint         # ESLint with typescript-eslint
 npm run format       # format
 npm run check:api    # refresh the git-ignored OpenAPI cache and detect API drift
-npm run audit:schemas # compare selected MCP write schemas with the local cache
+npm run audit:schemas # inventory and recursively audit every mutating MCP input
+npm run audit:api-coverage # verify the full operation inventory and implementation evidence
 ```
 
 ## Architecture

--- a/TODO.md
+++ b/TODO.md
@@ -10,13 +10,22 @@ package metadata, changelog, and README rather than as snapshots here.
 
 Weekly GitHub Actions workflow (`api-drift.yml`) fetches the Fortnox OpenAPI spec and compares it against the committed **fingerprint** (`api-spec/openapi-fingerprint.json` — opaque hashes only; the full spec is not stored in the repo, per Fortnox Developer Agreement cl. 6.1/6.3). Opens a GitHub issue labeled `api-drift` when endpoints/schemas change. Run locally with `npm run check:api`. Can also be triggered manually from the Actions tab.
 
-After fetching the local, git-ignored cache, run `npm run audit:schemas` to compare
-selected MCP write schemas with their OpenAPI payload components. Normal output and
-`api-spec/tool-schema-coverage.json` contain counts and opaque hashes only. Use
+After fetching the local, git-ignored cache, run `npm run audit:schemas` to inventory
+every discovered mutating MCP tool and recursively compare every mapped structured
+input with its OpenAPI payload component. Normal output and
+`api-spec/tool-schema-coverage.json` contain stable IDs, counts, result classes, and
+opaque hashes only. Use
 `npm run audit:schemas -- --show-fields` for an explicit local diagnostic, and update
 the baseline with `npm run audit:schemas -- --update` only after reviewing an intended
-specification or tool-schema change. The coverage audit is deliberately local until
-its privacy boundary has been validated before CI integration.
+specification or tool-schema change. The weekly workflow runs this audit after fetching
+the spec.
+
+`npm run audit:api-coverage` verifies the complete operation inventory against
+`api-spec/api-implementation-map.json`, including real operation exports, MCP tool
+discovery, and CLI help. The committed map and baseline are opaque; raw paths and
+operation IDs are available only with `--show-details`. The release gate runs the
+offline evidence check, while the weekly workflow also detects new or removed upstream
+families and operations.
 
 ## Roadmap
 
@@ -36,6 +45,10 @@ its privacy boundary has been validated before CI integration.
 9. ~~**Price Lists / Prices**~~ ✅ Done
 10. ~~**Financial Years / Locked Period**~~ ✅ Done
 17. ~~**Payroll / Lön** — employees, salary/attendance/absence transactions, schedule times (opt-in `salary` scope)~~ ✅ Done
+18. ~~**Core API lifecycle parity** — complete current resource operations with explicit product-boundary exclusions~~ ✅ Done (#153)
+19. ~~**Reference/setup reads** — currencies, units, payment/delivery settings, voucher series, account charts and customer references~~ ✅ Done (#154)
+20. ~~**Accruals** — invoice, supplier-invoice and contract accrual CRUD~~ ✅ Done (#155)
+21. ~~**Archive, inbox and file connections** — binary-safe downloads and complete selected attachment lifecycles~~ ✅ Done (#156)
 
 ### Tier 4 — Backlog
 

--- a/api-spec/api-implementation-coverage.json
+++ b/api-spec/api-implementation-coverage.json
@@ -1,0 +1,839 @@
+{
+  "formatVersion": 1,
+  "records": [
+    {
+      "id": "company-order-bank-process-api-companyorderbankprocess",
+      "classification": "excluded",
+      "publicOperationCount": 8,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 8,
+      "stateHash": "af8d452b73416feccb7bad11b841c046ddcccc6754c998d4d9d92254902d9483",
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "company-order-bank-process-api-startcompanyorderbankprocess",
+      "classification": "excluded",
+      "publicOperationCount": 6,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 6,
+      "stateHash": "c4a87a3cc49e82aa84ccaff06807da5d9e5619cf3007114902671998627d4e0a",
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "company-order-bank-process-webhook-api-bankprocesswebhook",
+      "classification": "excluded",
+      "publicOperationCount": 6,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 6,
+      "stateHash": "a2f1bab6c81a26eb27c47c6c2618fbdcbb47f9fbdeb592e7a464a10b3aab648c",
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "fileattachments-attachment",
+      "classification": "complete",
+      "publicOperationCount": 6,
+      "implementedCount": 6,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "8987e557fcd5acda545c9e9e9b6d9ad2a3472e9cc627162ce3798e819cddb1e6"
+    },
+    {
+      "id": "fortnox-absencetransactions",
+      "classification": "complete",
+      "publicOperationCount": 6,
+      "implementedCount": 6,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "f0879eb7df97413ae787c6d085a8ebf1affc1b49d7292bbc5d5ae8c9aa29c895"
+    },
+    {
+      "id": "fortnox-accountcharts",
+      "classification": "complete",
+      "publicOperationCount": 1,
+      "implementedCount": 1,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "9c861c376169db5934d391358549d687df9f309919664430fa6412f809a9eeca"
+    },
+    {
+      "id": "fortnox-accounts",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "4f9db088195f33e50ed18173076147a11746936fde7940083e36f4ead0517441"
+    },
+    {
+      "id": "fortnox-archive",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "2f4941d75d4217091046b72706d757f7328dc3ed03da7710981125fc1cd57a26"
+    },
+    {
+      "id": "fortnox-articlefileconnections",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "5fea8d3e7b93fa5bb9064216e6054d39cd46fa51ba83e971c6f2be1fd7a715d5",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-articles",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "18686839471e941a55debff61fa5d01580afe23c23740fab97ebe704ca988782"
+    },
+    {
+      "id": "fortnox-articleurlconnection",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "0b2cc2d6252cfc7c7b3d6b56b33eeebf52610d56a2e8e4d3b3f9de05aafe0c16",
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-articleurlconnections",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "fd2634cca994b40c20078cd3d628650d36931fc3fe3577b7ee077626189ac451",
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-assetfileconnection",
+      "classification": "excluded",
+      "publicOperationCount": 3,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "aebbd24aefd4d1824dc7e432313a921bfd0e83b43a40f6bd42c67814a738b9de",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-assets",
+      "classification": "excluded",
+      "publicOperationCount": 12,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 12,
+      "stateHash": "f2493ac0b98f1209e93e51b963973232405c964f6903ca32c63e169d8aa4265f",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-assettypes",
+      "classification": "excluded",
+      "publicOperationCount": 5,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 5,
+      "stateHash": "7700840c8c0982cdee26e61cee1a8b948a1801df43d3c088c79cf7d32125e551",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-attendancetransactions",
+      "classification": "complete",
+      "publicOperationCount": 6,
+      "implementedCount": 6,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "cac8298a3372376e4243bf08186c0f5bb2dc49eeb9c12229082cae45d60eaf4a"
+    },
+    {
+      "id": "fortnox-companyinformation",
+      "classification": "complete",
+      "publicOperationCount": 1,
+      "implementedCount": 1,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "41840331287e70252d898c9397ff1cddf87c1482db661cafe34973ebfdaf20c8"
+    },
+    {
+      "id": "fortnox-companysettings",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "781e3f15790dce465ce1907524600ed2330a6266f5ece5be3bb86a50f4507472",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-contractaccruals",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "96eb045e4c3831d10e8e7ce4aca4743e43eb7e0b603ac531b69b3f38b72f11b6"
+    },
+    {
+      "id": "fortnox-contracts",
+      "classification": "complete",
+      "publicOperationCount": 7,
+      "implementedCount": 7,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "2c8b97568110d6e13ba388dbb45c0f2857790fc5b1f4fc3b51ed795e76326df7"
+    },
+    {
+      "id": "fortnox-contracttemplates",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "15a37bc496f9a196f1ae1797fcf935d16399e4a60a372ae2d31086e5e2373013",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-costcenters",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "b9c2f9a7b634c232d547cf8ca3bdd43a381a32da3d7b7fa55b0089413ce29f3c"
+    },
+    {
+      "id": "fortnox-currencies",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "9297816e92f4b8a905cbc208b852cd652b1e3d09e514ae631c9ab713788823cf",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-customerreferences",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "8e758ab26f0a5b964597cf3ef064f8bd0eac57f5469172a287cb6c4d4a47d360",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-customers",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "de245d9109091e9e3f17ef12c81de3cc1aacf2c09fa8fc24934566be87e5638c"
+    },
+    {
+      "id": "fortnox-employees",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "264d6fa52185dc8e1c1137462922a19a70274a85c96639e81660fc2e0cf09d95"
+    },
+    {
+      "id": "fortnox-euvatlimitregulation",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "54bdfdf2872735697382a2e7e52a269f13123a803757b1bb8849d8943b9d54bf",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-expenses",
+      "classification": "excluded",
+      "publicOperationCount": 3,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "b6060514e8281f948f711d2121f8ffe23460e9c5c193e68ab3ddfd02b685cca5",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-financeinvoices",
+      "classification": "excluded",
+      "publicOperationCount": 7,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 7,
+      "stateHash": "967ac7893d9a313e75c00cf7a1af825243f5abcf75f301914b15809f79ddf97b",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-financialyears",
+      "classification": "complete",
+      "publicOperationCount": 3,
+      "implementedCount": 3,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "0c89be09356f7b65b6b05683b29a234f6906a9b13fb470f1a73107b916a04143"
+    },
+    {
+      "id": "fortnox-inbox",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "698ad21f58bb7e78559c9551fcbfd3210d2b846630e897ba919dd9de50e040a8"
+    },
+    {
+      "id": "fortnox-invoiceaccruals",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "f788b55677826c69376689c793fd1f7711af53829afcba8ffd65ec5f9173f612"
+    },
+    {
+      "id": "fortnox-invoicepayments",
+      "classification": "complete",
+      "publicOperationCount": 6,
+      "implementedCount": 6,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "9ec23cc1b800c3803d1a9cc58292eb8313e8aab912ab190f670ec2b6c4a43d24"
+    },
+    {
+      "id": "fortnox-invoices",
+      "classification": "complete",
+      "publicOperationCount": 15,
+      "implementedCount": 14,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "39a1bfe6f038d793ceef2acc6f81428053f8e3d242b5df4149c499ad5ae0bfe1",
+      "rationale": "Warehouse lifecycle transitions are outside the core accounting boundary."
+    },
+    {
+      "id": "fortnox-labels",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "1190d0da452f5eb8a4cd2ae45b7ed509df9a62a93fcd2ca040061245d3ed0909",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-lockedperiod",
+      "classification": "complete",
+      "publicOperationCount": 1,
+      "implementedCount": 1,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "09c68374269123df99ac9cc378b444115904fc935596fa6db3cfedf02fd51538"
+    },
+    {
+      "id": "fortnox-me",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "b7482b5efab17f77e6214db39f3c98177c16ecc32aeef5155a61b13a69368809",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-modesofpayments",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "789f8c2d92b738cd12ddce16bf67493ff9ca7434fe2e2c1861478f8f8555b518",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-offers",
+      "classification": "complete",
+      "publicOperationCount": 11,
+      "implementedCount": 11,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "8d190386c51b6ce7a978456349daffc7b38f6b641b484053a2da73221656e548"
+    },
+    {
+      "id": "fortnox-orders",
+      "classification": "complete",
+      "publicOperationCount": 10,
+      "implementedCount": 10,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "44704519d04cd799d72234f6fd425214c9f4384b7c19bd9654c9943d80de5986"
+    },
+    {
+      "id": "fortnox-predefinedaccounts",
+      "classification": "complete",
+      "publicOperationCount": 3,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "1eb4fbd3e279a820985d8eb4439ce69c8d0faea526ad73ede85032d74482cff7",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-predefinedvoucherseries",
+      "classification": "complete",
+      "publicOperationCount": 3,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "1732dc15be27f9167b566c0d9bd2d7a178cb222a4dd2be7c1bffe3d416e77c70",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-pricelists",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "86da5e9fbee1402a7decadccd7476a4221a2bd0b2172eba318c6658035a8eadb"
+    },
+    {
+      "id": "fortnox-prices",
+      "classification": "complete",
+      "publicOperationCount": 8,
+      "implementedCount": 8,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "d4b945b379d3894aaff6be05ccc491b746f84d9445e6cded29f9c913dd679522"
+    },
+    {
+      "id": "fortnox-printtemplates",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "4d0564d2e6d95503e4ffb5b86892568d690a7f44eda0626560f9dad5064bca01",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-projects",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "f427b145477c57d12659ddb8b4e484f468865ec2534fca7ee61752d19042b7af"
+    },
+    {
+      "id": "fortnox-salarytransactions",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "45855e32a9138be5f5c63a9bee15953a20c2e62f73419645f1b81b73a5d5d352"
+    },
+    {
+      "id": "fortnox-scheduletimes",
+      "classification": "complete",
+      "publicOperationCount": 3,
+      "implementedCount": 3,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "c98060a4d136f83db5215c1bf11cc084f492389de10f9c47e269bec281e81f60"
+    },
+    {
+      "id": "fortnox-sie",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "28037f492013b466b28ca882d3ad553ce634561c74bd7b02100753e0ed1af8c1",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-supplierinvoiceaccruals",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "925893bbc0650b9aed5e6b930a763dbb79ac30652a4c8502abc1df73e9c28ce7"
+    },
+    {
+      "id": "fortnox-supplierinvoiceexternalurlconnections",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "07cdb3c1023a7d225eef067532dfb92de5677f56a877f75f5811be6ef7e8a691",
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-supplierinvoicefileconnections",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "458027cba3536beddc4073ee9242f4385491333637db0cd1d5b56a09df0a7c2e"
+    },
+    {
+      "id": "fortnox-supplierinvoicepayments",
+      "classification": "complete",
+      "publicOperationCount": 6,
+      "implementedCount": 6,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "9a949e4f40aef9d3659fc13942771d7bf99eae7b725d77e219cefbc0d4bd759a"
+    },
+    {
+      "id": "fortnox-supplierinvoices",
+      "classification": "complete",
+      "publicOperationCount": 9,
+      "implementedCount": 9,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "d2942627bb05ff9d05d5b0e15ebaad60255579b68f99c5f599d71b3dd44c6cfe"
+    },
+    {
+      "id": "fortnox-suppliers",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "4d6bf29eb39b1c513bc789a833a9b02859f3646cb508430ebd46b7cc9ae4ae39"
+    },
+    {
+      "id": "fortnox-taxreductions",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "7e885268bba03e93538190b8e05d332b37509a727c96c0c6a0309e8e9ba0e0c3"
+    },
+    {
+      "id": "fortnox-termsofdeliveries",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 2,
+      "stateHash": "96ab81fedd3d1db4c732d1738ef2c854e7f201d9f796c4a74eb46dcc4cf768a3",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-termsofpayments",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "916141631529183a970218db6981c2285f403c34f5d6b61feb58e82c15bfc1ed",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-trustedemailsenders",
+      "classification": "excluded",
+      "publicOperationCount": 3,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "c37ca839137a68f85b3c00ff1b69edee9cbd2f9929db7dd229e4d9df06c49830",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-units",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "f2c89b1f065ae51a73ae8135279cecc2c2b2e8d5b8a3415b1efb3758aa2278c0",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-vacationdebtbasis",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "bc880f917b61ba9006c03443c9459f13b8a973e76741ffac426b6e251fb98f7f",
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-voucherfileconnections",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 4,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "4d58d7559ae09092fc9f0cf27d5554d77e55cb179b9ebd5c2ab55bb68e430029"
+    },
+    {
+      "id": "fortnox-vouchers",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "4d8d1ec375d2877377524360ee1c981323de598b4beedec407e37c155bff94d7"
+    },
+    {
+      "id": "fortnox-voucherseries",
+      "classification": "complete",
+      "publicOperationCount": 4,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 2,
+      "stateHash": "e3080c1d71f37ee3fb9ae6a323da74b3c35600a611f7a3aed597204e736718d8",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-wayofdeliveries",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "da2886f007fc4ec973e1fa378e638327a7ddc7981ff62b45f763b05899c74924",
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "integration-developer-integration-ratings",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "b41d5dd52565c4b7396e5a1417dafeda726b4fa6e40e0891a7660fd4f29ab52d",
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "integration-developer-integration-sales",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "1eb2fc4a063a25bbcdbd773a5e146634470e96503a960cb1fe115a03c8d99db6",
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "integration-developer-users",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "54c79b52d9af48d34fe3496532c0efbe67dd9c6a10e1d0258d6f725ce968d777",
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "recurring-api-invoicerequests",
+      "classification": "complete",
+      "publicOperationCount": 3,
+      "implementedCount": 3,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "652390d82dba1e6af4cddc26cbf065bca21d3fa92282fb54bfd50b6efbccedfd"
+    },
+    {
+      "id": "recurring-api-recurringdeviations",
+      "classification": "complete",
+      "publicOperationCount": 2,
+      "implementedCount": 2,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "d77065ffa0a86d1ab04433cd71600b6f24710736db451d68499e57a125f63a5a"
+    },
+    {
+      "id": "recurring-api-recurrings",
+      "classification": "complete",
+      "publicOperationCount": 5,
+      "implementedCount": 5,
+      "missingCount": 0,
+      "excludedCount": 0,
+      "stateHash": "e25fed5c17ba778638b6917fb896a3f518254ab15501ce150d3574b669fefb6c"
+    },
+    {
+      "id": "time-reporting-articles",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "a62e03349a28aa5d24226efe4e21ef90089f69c8b9c97296e9174a1d51a92fa5",
+      "rationale": "The separate time-reporting API is outside the initial payroll transaction boundary."
+    },
+    {
+      "id": "time-reporting-registrations",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "6be825e3746a6e14a0eb42ce6023894ceed8f972ae0d5c28d9e7e175b3ea8fa2",
+      "rationale": "The separate time-reporting API is outside the initial payroll transaction boundary."
+    },
+    {
+      "id": "warehouse-customdocumenttype",
+      "classification": "excluded",
+      "publicOperationCount": 3,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 3,
+      "stateHash": "0acc862ef58557e901fbca2b80464101cdd50c5eeb39ae99bae57ebc715b2ef0",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-custominbounddocument",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "d0f0b895555c71467378ae92942cc3a54838d53fe5bf5b7d3513a02641d89e1f",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-customoutbounddocument",
+      "classification": "excluded",
+      "publicOperationCount": 4,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 4,
+      "stateHash": "7a7345b159ed63fb37d9e2de6c194a6085b8b8ab3bb6be711711a278004b53cc",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-incominggoods",
+      "classification": "excluded",
+      "publicOperationCount": 8,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 8,
+      "stateHash": "f6f1b80fa0559e57b3a80ec1fc5289c7b896aa184302cea3907c5313ee02cd25",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualdocument",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "159b20d74a861ffceae77dfb543e97659efeb8076a8973fdd641d8d59725d805",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualinbounddocument",
+      "classification": "excluded",
+      "publicOperationCount": 6,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 6,
+      "stateHash": "9ddd06ea65abfc923d3a1a34eb90147a6dfb82e13943afab66e2fc21e9378799",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualoutbounddocument",
+      "classification": "excluded",
+      "publicOperationCount": 6,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 6,
+      "stateHash": "45a0dd1cc8ce64302c317260a09b3332cb0b0c86252ec3d2b2edac255a768b8b",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-productionorder",
+      "classification": "excluded",
+      "publicOperationCount": 8,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 8,
+      "stateHash": "8613fa3300d583cc19d6ffb831049fe4097f8aa30b97dce4f37405b4169da83d",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-purchaseorder",
+      "classification": "excluded",
+      "publicOperationCount": 15,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 15,
+      "stateHash": "dfb145eec81d86c9166fd09a9166ed4542c37038a5c69dd9eb8991864b108352",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stockpoint",
+      "classification": "excluded",
+      "publicOperationCount": 8,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 8,
+      "stateHash": "067c3c917c23467e2d860974788eb9866066962d8a2648aa98eff8ddc21f94dd",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stockstatus",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "f8eecc26d927352edadc30eb5d72d7370a39f0f02ecde1788f436d816b14935e",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stocktaking",
+      "classification": "excluded",
+      "publicOperationCount": 13,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 13,
+      "stateHash": "d1be0e76058603713e3776dc9bed022fe5f5c39b4bcdcd74c8281795a0a8fb3d",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stocktransfer",
+      "classification": "excluded",
+      "publicOperationCount": 5,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 5,
+      "stateHash": "112ea358298b5ba228a7f72dcd0178cf4454c6234eb0c569b3e8b6939af3a9c2",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-tenant",
+      "classification": "excluded",
+      "publicOperationCount": 1,
+      "implementedCount": 0,
+      "missingCount": 0,
+      "excludedCount": 1,
+      "stateHash": "189f1d8ff127b5d247f138fdf240e293c923d3499ccf895f5cf59d499f9f89f6",
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    }
+  ]
+}

--- a/api-spec/api-implementation-map.json
+++ b/api-spec/api-implementation-map.json
@@ -1,0 +1,2086 @@
+{
+  "formatVersion": 1,
+  "families": [
+    {
+      "id": "company-order-bank-process-api-companyorderbankprocess",
+      "tagHash": "d6dee35428a2cb1873e653c00151ed89a9a02172966e64d5961e185157712e6a",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "07e67569fdc68de4c3fdbaa2e175df8d9e133a045ae61444cd01a43e060f634c",
+          "1e75dac6dfa7b5b4b16377c3ed70f29e631396f0977a827ad248ab0505ce9481",
+          "3a67adb25501091993c5aef222fa08d10dbc57611d53de807b0a8342244710e2",
+          "86e0f7c57004e07d39fa582c0a9c7b1dfb189eab0facab02bbe801da6aa2e74a",
+          "8f208effeda050b38e1f1f35f2f1e736c8be1012cebfacf61de4d501686b8fe9",
+          "a14a116ea858def1965f799fae9b79ea3f790cc6e27e7375e9886b73dcc02c4b",
+          "b13655322410dd7c0b58846f1836685bcf00f69bb5d8a83da82090179e69294a",
+          "b48a2631ab5cc0ab4319335abf4009d246d3c9ac8895c04d19f14fa59ab41913"
+        ]
+      },
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "company-order-bank-process-api-startcompanyorderbankprocess",
+      "tagHash": "040c410f624624b5107275ee1ffdc87a69f4f29b043233ea7c96a4b4e80b3bfb",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "00fb322aea39cf0dcb99468456ae13b5f0321564ca33d4724ed5a23c84e8fd0c",
+          "302dcb15dd69f575d8b685c49ea07e305b3487b7f44958f5356c34de7d65da52",
+          "45b8c06ca102da0272f664f02bdc87c43641c5777b259096506ace34ccd9d593",
+          "4c92b1c05bb6179ced1c91b7bc1f35c0d3c82a6052f1d2d2e2cb8cb9cf72c973",
+          "642da3801a7717e475689caf46add543aab1c513fc5b12ae406256ce3b6f9ad9",
+          "e90103d476458fa0de15cb0f2f4f19b34e47a101bf406918d6c38773f8282173"
+        ]
+      },
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "company-order-bank-process-webhook-api-bankprocesswebhook",
+      "tagHash": "cb4687ce6306424097fb1db1a8e2fa0f8c9d3ac4c83bc22cf045cb33eeb380b2",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "0615bab8c98cdb4b287dfd4a94e30ad56627a94b31d99b1910b7dbf6ca68da64",
+          "1fee8fc532c970486a73271d03d21bd4468d3a0f1c40e8737bf85846a6bc194b",
+          "c1426c7dae3a31aca70984561bc87d1435db9b052857355a479427fd5478e6b6",
+          "c8a9909120fe734db0fbb90281661b30847a241cb9bde9a4d52f8dfc44e67f88",
+          "f12098179189acc1a290aa27d5fa35a1dd8fef032a79ce7a3e7d6f053ff8ca9d",
+          "fe884a0a54803b2c93be94e1952ed24f2e7bdb8cf0bc84e718639b514f7c1ebf"
+        ]
+      },
+      "rationale": "Bank onboarding and company-order processes are privileged onboarding workflows outside the local core."
+    },
+    {
+      "id": "fileattachments-attachment",
+      "tagHash": "49ce84af943fea37b7d7c53a56cc84aab9ba5c96150bef146c3aa99df6edab8a",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0547354a41fdb1c91eb2dd1ad3be20dd7a3863c8cef093b30571492427d6881b",
+          "0a353a0b4de271098f7c6d8175f92c73e954fb47f1882ac5078c2f1420d6c131",
+          "4e706b6c2b879662a7ccda46e80059b69c33fa9384c5d07cf896051405d9b9ca",
+          "63bb898d9d44befe8c5d5371886e54bd1fc2b1b3316e010fc9cd6a5a79b9aae3",
+          "a99ec989d26420f50e37e6537ed9a352f5d9302e0ef861db16e35ad3f5f3a61a",
+          "eb4afefcef3fd63834e5815f7de53a372395e74b8b345fb89c78420e91b61622"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listDocumentAttachments"
+        ],
+        "mcpTools": [
+          "fortnox_list_document_attachments"
+        ],
+        "cliCommands": [
+          [
+            "attachments",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-absencetransactions",
+      "tagHash": "85f5a5a208f52705b7897ec316d5c4b88a7dd5f7e59922ac3c2c48315b68bed3",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "10db035ffa01a8870bb3dd7fa8de607db25f3300b275f1a7e40031208a1b7e0d",
+          "7826a88f7f216a1936267900342487796a00efbb929b1691cd40d71c0f959624",
+          "a4007d9b6989e67199fc1e20f60123ed8450ec09ce889a6203724bb47c104307",
+          "a82425817dfec2ac71eddf6d41350dfe37a62c60458f39d8727ad6c2a844de80",
+          "b7fe1a9e301245532ee2f8738627232d95433def98ed00e3c5f0dc974b0c9a44",
+          "f8988e6f9cfb7094a2be1376477e64ba0e379870ce4f0d7e026feea9129b76e6"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listAbsenceTransactions"
+        ],
+        "mcpTools": [
+          "fortnox_list_absencetransactions"
+        ],
+        "cliCommands": [
+          [
+            "absence-transactions",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-accountcharts",
+      "tagHash": "8c52e39bc82f689584cd0c556b35a5965f9a969c6f8d7d360f359e4df591b86f",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "d209c97496c94ce4bbdad70209c562167cb8bc8814cde7650423a02a26e30b9d"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listAccountCharts"
+        ],
+        "mcpTools": [
+          "fortnox_list_account_charts"
+        ],
+        "cliCommands": [
+          [
+            "account-charts",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-accounts",
+      "tagHash": "25cb61196675fe99101fcaa13f48e8fdf3fd735927606cf0958119a449d762cc",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0afcbd07be5cfd5afe1be558cf7511ba924d319b9d60f07e931aa8a6dd94ebdc",
+          "2ec9cf2b85ba8ca08780f992b8dac92dd9c8fa1854cbc606f17af6cca2b1f44d",
+          "708e69e5d064b7ed6525944bb9bcd8bef2fe6c87e2ac63d05d5506932f28bb50",
+          "89e0b561680d3b2d9fead0aeed418af7891ea69e88d01a240c81bbd71d55cdbf",
+          "f6c31c71fb26ca09fa28d7988a90937f4dd3b17ea0e7d0886544638d8a6ea1dd"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listAccounts"
+        ],
+        "mcpTools": [
+          "fortnox_list_accounts"
+        ],
+        "cliCommands": [
+          [
+            "accounts",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-archive",
+      "tagHash": "e7255667738dcdc873695f86fb993d8c0ee16e22f77d261698b9f2bec358aec0",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "199cce47b138d222105cc5b63a8a2acd812b6c5f894f164b8b20a1d8decc3450",
+          "8ed57af83d02bd838edbd652a3f030be8d8dc28f14dd22f62d5bb34b1a546f7d",
+          "923ae805985a2cc9852d3c4beedbf42cb623f835528a9ef9bebb4a83e5c2c771",
+          "a2c951c74416c21fdb79e83395b234f7f172a6c0ecf2682819bd2d6c9cb3c7bc",
+          "c939d95f8128427ec66f35877cc9740180186db81f480d506651bb2d789f8a47"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listArchive"
+        ],
+        "mcpTools": [
+          "fortnox_list_archive"
+        ],
+        "cliCommands": [
+          [
+            "archive",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-articlefileconnections",
+      "tagHash": "514a6f588c21942199514185749cf11c39f86644f4754fa0469128670923af8c",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "2d98a8cf029ec0450a06444c7b23cce9bd93bc1f7c6f8ce6a851fae876fb729c",
+          "50a2d228e917042e6ef4c892c41687930106be4bed7fc7721904769468443b9b",
+          "68ff77e214a60b17f005eee5fdb1a5083bad4dbbec78dcb86df7cc2f0d7d5890",
+          "cb9d9a4a78380579a09610d8138f6ecd5b9b8391d891c5119bb6fd14aca81a72"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-articles",
+      "tagHash": "954a7f57b5a6fb81be9a13805147c4ca96ad78231e91911354396c93c82c3bbb",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "14471aaf6a0cbdf871e02b1e574d12b2511287dcaf6d940368d63a5ddf46fa78",
+          "3d37a1d93b2e627266e54a7f0a2f65423f5c45cce131a6ca8e77122bc8c052e8",
+          "3dd4550cbebcebd09888085285f1a07ed1abe9f096033f4530e1bad96794f547",
+          "dbfe59d810117a1657b98ac255d663ae7d760a9833081bcfdabf5d8996e5ffe6",
+          "f19f4c34a5c411c4de53ed9f3b848b00f61397f420040fc39b42ef36be617383"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listArticles"
+        ],
+        "mcpTools": [
+          "fortnox_list_articles"
+        ],
+        "cliCommands": [
+          [
+            "articles",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-articleurlconnection",
+      "tagHash": "ec636e332b6bd39bd46c3cb70a4458b5ac089d738efe14d9d801db088974a8e7",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "40fb57dd393bd9bdeb2b5384c43481d96e1e897cc2691c82cc7c7b33554fba6f",
+          "5777aad1e3fc1810a78643276e4e29abd96949f63045d536fa98e41e7b93af20",
+          "6e91f375943a7167b694b17d849afc5b3860710eed3d86913b0f563bd761cae6",
+          "be4e820b58c26889569267156c120a797149b1f78ff0b74cb97c68db476187fa"
+        ]
+      },
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-articleurlconnections",
+      "tagHash": "9c1414b78aaca8b87f59b85f3f8732755c1dffa0509965ad95c6f02033e29d2b",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "b015c9164188a24775077f5b9e1c9c211a8a39700d27475c0ce46ab5309b0a87"
+        ]
+      },
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-assetfileconnection",
+      "tagHash": "3ec44f85556b60cae7540efb52c7953176fd7a1f02baa265977faf2587578e71",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "184d47db5f50333aa4ff48e54fffe830943e017a2d0e2dc50449e9c397ca2f07",
+          "3eb4556ce843c5862c5f8e27b1d5a0b1557b757f4ec0ed6e62a42b092a1a65de",
+          "bd9c00ea8b95e7d634456b49bddff854922cd54b7bdc9363387d88cc10f3843b"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-assets",
+      "tagHash": "65d4236ea8be82f854d9cb2ecd0874c9b56dfca82628f3d25f1bba88daf8b589",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "1f1d5f21ce2dd53d4bb1c3c5a1db127f86d4b4f2aa67cfdb87d1c068df643558",
+          "25eac60612c36c57acd20159c783187734d8ee34eda3b5f4d97206996dd1eaa7",
+          "44dc5ee886292dd21b799074e0d703f919f93277e954786b022cc551fc7812ea",
+          "70c968c54cefad703931fbca6c920bef5edf2668249eea8530c4e4bacd237cc6",
+          "80cee6ddc2fb7672a979555613742fec07a75711f2102922cbb989dd23a1257f",
+          "87a97c569fb30eaad24ae097b08ee27de6356d4a7496f7462bde671207ecebfa",
+          "8e6e2c476a9394017f85c6512f5e604c45ba47d42174ba344d69ed872cdca229",
+          "a5721c554539166259aa0ffeecbf5eca34d19930bd720afeadf28b794d34c371",
+          "a76cd48680cc21c055ca101f88c3260a48321d23bf50ac89e32b445093333c83",
+          "ba8df91427615615c1aa6e785848e94f698a2138188dbc9d91543780938989cc",
+          "d64b2d0f3e77a6a880b4983d93506754fa65c552bf33f713ea31f7fffac85135",
+          "f008ada0775866b8f4750e0eaa221be4ef6988201edc7aa84bb20f5cbc240d6a"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-assettypes",
+      "tagHash": "abd1f717f169bdb94fd0b9878f9b48ed958e3897f3e21d9394ce31d2f9ccc9b5",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "0ace994f8b856e118cf4f2e7eebd499832cc2667def6b677006d9b56ac24f982",
+          "24232636d8a2036bbc387a6da7a8af205074e88e426d3d76c75a01b79670b966",
+          "39890b4d931096eafa22a609c6726490937bb6f1595a06a1f572ce52cabed61f",
+          "8870023652d9d40c791d6e98312f7d25b2be425b33d9cbcd8830124e7c6ce0f2",
+          "bb7587569095e3303e65c11e4c026102440f83af340b254b9de9f5dab987c6da"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-attendancetransactions",
+      "tagHash": "0f50d4436e3e3d0e5432d1e0324360f618aa168132090cf5cc4149706e127988",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "28e2faf5abd29d4680094d97d9e395548bc53b29ac703089c391e9a9071e23a5",
+          "4fadebba5a844950c943aa9432b24e787e5c490db62ae4d17b970c141fa3fa2d",
+          "b83376feef6aa977be104a2c81b8459d12df11999894c9053b9486ff40bd5f4c",
+          "bdf8261526319ee63406682f6abfab176736ed0746befb0257d83c2275397181",
+          "e8c68e9a8e4e976ac239cdecc7a308f94a2f8b7a77d9062eff8a3bfbffc28de9",
+          "ea656fa54df8062a7a19631a1a56806c28b80b6d32d05b1ccda4fab7f93569a9"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listAttendanceTransactions"
+        ],
+        "mcpTools": [
+          "fortnox_list_attendancetransactions"
+        ],
+        "cliCommands": [
+          [
+            "attendance-transactions",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-companyinformation",
+      "tagHash": "e54a5ef2be2bcba0ca9a70e9fcb37eeba0b874cd47901b10b012af3aef5f6d1e",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "04fb390ef78b839fbbb66dddc092d4c6a77dab13021a81ced7c1a7e15abf5acb"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "getCompanyInfo"
+        ],
+        "mcpTools": [
+          "fortnox_company_info"
+        ],
+        "cliCommands": [
+          [
+            "company",
+            "info"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-companysettings",
+      "tagHash": "9e8b0b01c1067e03fdd205f3b9ecb6a27493cb13b9a8f075a5669daf89ce6072",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "a3fcef131aa4e14fc48bc081dad044afd605cbe7394884e0ba3ce23d6348952f"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-contractaccruals",
+      "tagHash": "631a75844dc39f8824902f7184e0a05b568d5771b9689e14a7a1da0d80e280e2",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "53ac318d9e2e5353e3d412b988f680c2c58a2d170416ab9f3a56bc44b31dc5c8",
+          "6461268756ef6026f9480cb4d28dac02f8c08b916ca436e7a2c3d369ed749357",
+          "8984ae8863e56eb47335f9171d6bd66da7fddd0be7181b919a2322e4de427dbb",
+          "cc5909f10ad7dc1f9e849966b3c9825f212e271a7edf8acd8d7cf41cb4144c72",
+          "df46dfa971aa3b8b78a8e1c6e821a98c844d3a68552571ff4b338f75c7011c5a"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listContractAccruals"
+        ],
+        "mcpTools": [
+          "fortnox_list_contract_accruals"
+        ],
+        "cliCommands": [
+          [
+            "contract-accruals",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-contracts",
+      "tagHash": "5369acdfce28887b9878a3b00c23cbc7766f2da1d19c8418bb05d9b8f0381086",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "17b8d44b108b2588fe246870b80e4256ae1149566228cbe7bbd86f41cf44c3b6",
+          "1f14afedb334329c4203ba04bfe83b0a1b34f172c9d8ecae4fe3627880ba0527",
+          "314c7818f4678589836da56ee9f18535b0b0fa7a7c0a2c275ae0777c8cd404c0",
+          "45140895f263a1103539b56c4c445765d1cac5f695c545a7dde4064912b02829",
+          "a9b96c5094bf111d25283dd4ddf35d5c8085ad79b284eeb5e2e4efa4fb28b58c",
+          "b38b7f82cc5c177609b415a2ee036867cfadaffc6fcee1848972381499eea979",
+          "e1a023d7517d76e36cb1ae3a00e32c043e63df42132b99e47c367bd401d8714d"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listContracts"
+        ],
+        "mcpTools": [
+          "fortnox_list_contracts"
+        ],
+        "cliCommands": [
+          [
+            "contracts",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-contracttemplates",
+      "tagHash": "d83caaf5db3a182680c5be8a6277e3bf030678761ff41508e0f31336efda0c6d",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "537a7e5ce90ac63dfe027d565fd8bd4c5fed3e176be52ca500b0d38da33f55a8",
+          "574f05ac58ef4376298d696ee361c259e2b2aaba57677ca7bc15ec9e1c58f31c",
+          "6f3eddd5c34b9577c4c7520f4beb06e95cba561515ae10a193fb4df36eec1f16",
+          "78f1af1e71d478d4f8a8ef0a3a94a1505998137478a272606ca4522ac6ec2ef8"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-costcenters",
+      "tagHash": "65f757bb4ea3227b95972a6b922759b1d665aec8ef7a01dbc4a02414ccf4a0d9",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0dd73f8985c91e9bf535ba0da5ee56cdee2565959289ea24788835d5d78d2d79",
+          "2390a11d8993073e0ba8ef1317aae1508697001b56957a9151b8c07f16fc0eb4",
+          "46b225724d2e73c8541d8bc007ec32535c18f1a54bbf05f115daebe5160721b1",
+          "760339f71f387c107eaa9dcad6796637c8342cfb2e0a726655f2f57662ee8ee1",
+          "8e4b19fd2dfda52769256717955fbc37b1b6a1de76a8e64d6d2a05e7c19256cd"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listCostCenters"
+        ],
+        "mcpTools": [
+          "fortnox_list_costcenters"
+        ],
+        "cliCommands": [
+          [
+            "costcenters",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-currencies",
+      "tagHash": "72b0d1d2a04d8c671ff4a26ebe8eec686f983c3eb2410ac391a83f29fe3b2271",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "6f61226e4030038336bc0b61327df089e95d2bd6d37222692de1df73b2bfbfff",
+          "d1fee5647415ea4c1e4f642be900b0ee326b7665186f1620aa7ef234228ec3dc"
+        ],
+        "missing": [],
+        "excluded": [
+          "6ac749db29d23fc2f02aa2e15dedff9fdc8aee515c8e485998b994458df88077",
+          "7df178af48e123a5947aa37551644c8a7d8a94eb60bdea12cf4c6f0b51a19238",
+          "82799e49a7a93f7b3543d15318015860ac204156851ff7189560398c5182eff3"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listCurrencies"
+        ],
+        "mcpTools": [
+          "fortnox_list_currencies"
+        ],
+        "cliCommands": [
+          [
+            "currencies",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-customerreferences",
+      "tagHash": "9d7e128f2276fe07b9adf9090b7723718ee43106e082670bd81e29213800b129",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "1728519ce60fcd1c3d53fec2f1922d9e03c25d237229bdd6aaa5d8002db780c4",
+          "db98ba612503fb4461325a16bb2aab241c6c8126071b9735866b4aebf82d24e5"
+        ],
+        "missing": [],
+        "excluded": [
+          "3cd48816beaf9030088bb27876c75878fa3391d447aeef2ac2c14fd6a79151a4",
+          "b56601e726cab5f93c6e3e0b2860aca9c2ccf241d8bb4292afa9c405ab6a9044",
+          "ec3d4a73f2791f8e357dfc2af2e3844776810f1ca692d019ee362bd522807719"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listCustomerReferences"
+        ],
+        "mcpTools": [
+          "fortnox_list_customer_references"
+        ],
+        "cliCommands": [
+          [
+            "customer-references",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-customers",
+      "tagHash": "5050c9e5271ae1754c81eb6a805d0834ae045ef4515135fff58cc3d2fdc306a9",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "194b10e2ae04ecf36cb1ea139262ccd2d2713a6e949cb99cb3e15ae3bab8c273",
+          "9b280e3c4f3d193a319545ac63442d8ac6186bac9088d80ba881530650e5dcd3",
+          "a7a1ebc56b9e5bbefe784a22161e8d1c43bdc9bccbe9f5946e6496ba6e44272e",
+          "cb76c9af1c4c06f2af0aa16b55d776c3845046a6ac543e7c157c589f8d4e813a",
+          "f462afc2dca3bde3da4f4a63c291e0b2c3c93196a685724a74fa5afb62e91857"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listCustomers"
+        ],
+        "mcpTools": [
+          "fortnox_list_customers"
+        ],
+        "cliCommands": [
+          [
+            "customers",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-employees",
+      "tagHash": "1ac1b5824dc55d10fae003986ab919e267f1ae521c46af4b2fd978ba7fcdf5ec",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "738dddd10282c36ccd86b405e481d390be744204448511a9bc4c4c02c3810ced",
+          "80dd2ddc9d160ee5402a8411445445cb82d2ea058a70baa060b814ada1d678ef",
+          "a5bad2f57e43b65571adc6ca96606e13546e5e1d8dc13c6b2108f40b1b6f4ecd",
+          "d109d0ff4ad259d79a92531b0e21df66b214b3c4fbfdb9691ecb0d30fb1bd901"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listEmployees"
+        ],
+        "mcpTools": [
+          "fortnox_list_employees"
+        ],
+        "cliCommands": [
+          [
+            "employees",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-euvatlimitregulation",
+      "tagHash": "2a0d2b9868eca27e6fb106740007e213f1c229b07b4766e60970f2f5fbe398f5",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "c077a9aca6b16f404f114cd1c9e081e31f9707f79c33f21644388dde91e8999b"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-expenses",
+      "tagHash": "f0a29aeb859b575f6be101239a35ff18b8b43635d1ac76e470eabc0a61766bca",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "1ac84fbf7b977c909e06ad1190a990a46ad86ff2068ff532111cdcfe90e667c1",
+          "4cf581472f9c85b0940157a55d3a1886129c4cef735e5026ee3c7768d5fdef6c",
+          "dfec136397f65efc187be5eb496441ef6c24b36c0b25f4be564695d02c84eb01"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-financeinvoices",
+      "tagHash": "67b70b2c68c3aab7f617e0470e7a514ed21276471720b8bf1e705e7a870c093c",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "223a12b451e1349fce2b98bea76b81c1dc539bff6e87c3d09c463fd61b3e77d8",
+          "48e12404dede3e1e3f02d901c09c180eee0ba2c4427200fcbe12f808c391e147",
+          "5099ce41002fe83677ba299559bd670de369ba9ef403188ae5acdf87589ed5f1",
+          "6d7718f9f3f62fd4dc7b2b9bac82bf3d16052a244f013c0787a9361fff73822d",
+          "9c3325daf9049a9a0e137c0db1f791cc9de339bb63cdad59aa93b781af05ffbe",
+          "b2dff4b01676f99b266279f3216bd35496bafd3c0487b16c874c7678d0742a45",
+          "e09fb43a70f119ed8ff86caf6d26046f4d4066a8516c7baa8abc57cd52e79630"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-financialyears",
+      "tagHash": "0fdcbf1701a58d3c206616ccfda0da993456531ee26be446e571835c10c12348",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "059ad2fa45e7b51a2b16a0a354dfa017ba2c426bd7c07a4155a310d866f4b426",
+          "294482062b6395c048e5364de2fac16b74b1fb2bd1b03be8c3fdcbfdfa8b4d15",
+          "3ce8178f8c2645715365b563fcd2139ddf83075bdd6e09cba4323e3f2dbb197e"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listFinancialYears"
+        ],
+        "mcpTools": [
+          "fortnox_list_financialyears"
+        ],
+        "cliCommands": [
+          [
+            "financial-years",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-inbox",
+      "tagHash": "15a6a599d699da9377a561cebed03ef5e307cbc2c5343808942ca9654a602513",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "2ae5a41c4aa5e35ddc6fd8f794bd06a86acbea9948c68ae6e7e44f48310944db",
+          "4a876ea3bec78e3f65bed5acb41d332c41c026b38fbcd61ac19ee407638690e8",
+          "50de50d64fb164604b7f6a6bfa1de7e1bd77cf7428c1a418949e69f6fe53650e",
+          "7629e55437682a574b4f6f3255654fbac48992387ba7c773a247031e92c0b298"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listInbox"
+        ],
+        "mcpTools": [
+          "fortnox_list_inbox"
+        ],
+        "cliCommands": [
+          [
+            "inbox",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-invoiceaccruals",
+      "tagHash": "d8a2aafe1878f1236e49c08a2adb2446015d3e2aeb926de9535e6eafab6759ca",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "03021a75254a27c1f7064e349eb38d4a54ce976598682db1197171f4290ff70b",
+          "2b0b938cef86075873adfcbd43e6bbe22ba2bb2aa43a9b76bc2bb9ac4842fa91",
+          "4d665a44b08e927d19299403eae01cee6cf6e3c7d471fd59c025a35f32d179ec",
+          "b6c34b56d3f0abe70a9082c13ce63920d0201dc5b04fba73039344f3eeac624e",
+          "f30cc9105fdea0dc9da062605c50d4b3b998e9a41cc99e8e37710c4e92b11244"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listInvoiceAccruals"
+        ],
+        "mcpTools": [
+          "fortnox_list_invoice_accruals"
+        ],
+        "cliCommands": [
+          [
+            "invoice-accruals",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-invoicepayments",
+      "tagHash": "87a4acf07054646d18147002b67a64dbb679e35001bf72e8ee40ede88038d427",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "05d1a697d9fa3f04a41d3964d8dbad19f21e4eb1a47b071129249c0d8225b69e",
+          "3709b83897de613978e9abccea291ffb07c0b03908695a111a8b3d099a2872f8",
+          "42f199282aaa939909e2c2b2977b7a956aa3a4144c733f724268ced7c178c45c",
+          "54217ce2dd2b7eaaba60a635c4a0a1b3e098e1b55db968bea5d964c594e86949",
+          "7f9ba604ec1d85a7272cd7892d667c6d41dd4903ced7555d4efed6c6b22ec49e",
+          "ce343adee3d44cf1d2f3433c09b64ecf360dfa3204466fd7e78a8c15df6693ec"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listInvoicePayments"
+        ],
+        "mcpTools": [
+          "fortnox_list_invoice_payments"
+        ],
+        "cliCommands": [
+          [
+            "invoice-payments",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-invoices",
+      "tagHash": "cdef34489047aa708d3119eb2509554560dbae2cbdae7842372e9ff324b33175",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "232844c36bf13765be368a17038f64d10b9684850222ac63386eb061bad47a15",
+          "2b2a5290b9b4d45e69604bb1b2eedf02b5ab12dfb6c96105d1d4db4a2f2b1dd5",
+          "34399b8c3df307f70e599de61fbe2396e804f39cc0ff64c17eb7420330d8722a",
+          "351948cadbc90eac8c0e2b1950a945095a2f841f45a1b521c556f234f810ba9a",
+          "602d7d594039d4faf66f9bb8d39c423d6e5a2fde9c65a7359a5c83f51351920f",
+          "67bc143127755e11c7d1eae5a14a6b5831d3bd38e1b86f3308a03dc1c8d289f0",
+          "7226f7d520665128e71303e56adc1f5c548a1501ad7178bcc1ef8cb224f1f4e2",
+          "779ac983c802a51a2d832cb7d9802ffe946f8b2f287af30ef6669aedbfcdc097",
+          "7d2040d39389830c9160b2b7c648c22e814affd7856496dbc76bca7081b744db",
+          "8c09efbcb680a163d00bab394470a56a05cc049c3faba5e19e4fd82f8b25e0b9",
+          "b4b56c5f85e81e1663b5dd00462235a52e0d5885a9e5846ace99b540ded8e3e0",
+          "cdb07edcd2994cfe68e43fb3183bfef9ce6ac8b87942045e4ff3a924149f3355",
+          "d3a8ed8e6fc16e1570b91617f63b9a450e8a105fa7078dcdeec4a1e76ec65759",
+          "e81e49503ea3d356215f1c4faeb9ca291118ffc254b74235105d348204779f53"
+        ],
+        "missing": [],
+        "excluded": [
+          "9d3117da2a01d94fe1015e3ca5c850763b244cdfe1c943e2e048fb082cbe93e2"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listInvoices"
+        ],
+        "mcpTools": [
+          "fortnox_list_invoices"
+        ],
+        "cliCommands": [
+          [
+            "invoices",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Warehouse lifecycle transitions are outside the core accounting boundary."
+    },
+    {
+      "id": "fortnox-labels",
+      "tagHash": "ea4801a5d0fe0369833d0058daeb89eeed1d16cbeae93a84844085a4a5630b00",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "126364cd81f4f2ba6435b90a8f20a3a5329482d2bbaafc6e671b00838081094e",
+          "5b6095435b24a9bbf75077c113f73c7ad96075280fb5e5b146f0f18f9e2493fb",
+          "8edcae2b0daec67caad2db8b69ed3b8f16feb627124378a7b6a810a3248b168a",
+          "e0f721f49022e61f9f339edd3fc43ca8b73f8cfbd08b5a2d5c4bfbe2b8bf72e4"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-lockedperiod",
+      "tagHash": "9fa65e63d9d38c5cac554f1cc4e1a7f808e2bcb13ce752224f1873f325c395bc",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "b153c972c9ffc8fcab675d3e96d64d79ccdee2bfd3d445cdc4d54fe31e7e3d3b"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "getLockedPeriod"
+        ],
+        "mcpTools": [
+          "fortnox_get_lockedperiod"
+        ],
+        "cliCommands": [
+          [
+            "locked-period"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-me",
+      "tagHash": "7db403cf1acd9a30d38caf7b8d502bda67ce48b6933ddfa7ef491d293aff9515",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "81431b911353616e7ad355c8060f5e700965afea589d9105cc04ba310b7ff3f2"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-modesofpayments",
+      "tagHash": "e20a36dccbf8c358547d4d692f77f392c0b7817b9e8f12e04068976d95df656a",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "b8bb70d2fa44a914035d382632b4605b8680bc17d191558a7ae2fed25ad682c8",
+          "d1dfbfd602fe5cf83eb41c8dd35eb7b525bf536f753f0bee12e6713c2d33e0da"
+        ],
+        "missing": [],
+        "excluded": [
+          "37f668c2e4aace49d7756d8093ec82852d15811f4396d01d63b04a15e29b30cd",
+          "94c1e7d70ad44d2a497afb6e202cbb46007f9afb9c37dc330c54a349ed71019f",
+          "b9250becdd42c8982452c36cadd5fa0b247925ff2e90d2ae3a48664018a0981f"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listModesOfPayments"
+        ],
+        "mcpTools": [
+          "fortnox_list_modes_of_payments"
+        ],
+        "cliCommands": [
+          [
+            "modes-of-payments",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-offers",
+      "tagHash": "31e8601f08dabd9ce986f744d9c15eb61c91999a48c21c295d5a03498c45460b",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "2604464a64da20fb87ea8005972bee13fe286c1bc464979ff1d94f9813cd910a",
+          "2707d9dc15ab8198cbf99283c36cf0128e6c463e9ccb6f5478c0a1f36de38c8d",
+          "38fef0618f4c9fc66c67e1977d57f4d985d0f5f66769821b9249154ff7fa6590",
+          "485550935937c9555ceec0ab2a553c4b8649cf89b2bbacd9769eabc92e00a898",
+          "512580ad4767040b5ee93a127681e1e8c81dfc4cb37bb4024ed719ade16e73a5",
+          "5d4b9bb500e3ea2ea2eab57e1e4dd6f6b16ae04d273c28471dd9734b8d8494ba",
+          "5e5f4df753384ae962afc43bf7377c58625a9bfd326afbdc503e431737d5c9bf",
+          "6eaa660f878b5797864ad7ef70c59f36ed6812fe6bbfb608fa75020a0ba071bc",
+          "8dccbe1a5b190840cdf4c2bbf8efbda210b6b9a2d941eac8c01586e81a2eefff",
+          "a019da7a4b9217c2014e74e27dc9e4c473338ae306e0651a519c26553e783cd2",
+          "a857b279b53ea4de67261dd0ad9b696f0e5e1ad6833b705a5bc2ae80ec2935f3"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listOffers"
+        ],
+        "mcpTools": [
+          "fortnox_list_offers"
+        ],
+        "cliCommands": [
+          [
+            "offers",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-orders",
+      "tagHash": "462139acb32b1a34b7deb902a8588246743f8f37e942a014da492b00d46d78bc",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "04874a90aabc86a499dfa87e71f133f04539feff14ae60be12b929bba37ee65b",
+          "391d72fdd49f0f49c2a8b724662de68c6c56d5e2cc91bb20ca7c4c307c41be9e",
+          "55e9ee41f1cd6735b8d395898378738204af470884ddb1a4bd52b34766c95013",
+          "58111196090b9a83d575435412647bc8306c11f54a044d8f3444847273b5e979",
+          "aada5046af7246544c15c80d9ef6c2f58d3c95c88c4b102d710a04b947359b77",
+          "b357f1849550c9b9fd1605f340ced326bfa9add8ebdfc4cc1ed0a6cb9d771005",
+          "c4723b7152b4b1c3d10b206878fc61dc00a31e3c43811695b691f0aeec4ede52",
+          "cabc28f57b1ce5c64e20af0aac9bb7fc31a2be70ec61152f94dfec3605eb1743",
+          "cb79d041438b74874b0a03d55a947b73b800f4da6fc31ba28d9e5229c6732c3a",
+          "eb4f53fb6b81300ef21e73b6e8c663e90d6cb730e07d12a93d7a5fed5724fa81"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listOrders"
+        ],
+        "mcpTools": [
+          "fortnox_list_orders"
+        ],
+        "cliCommands": [
+          [
+            "orders",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-predefinedaccounts",
+      "tagHash": "2da0865726b5c2c1ce6cdde3ce9d3acf1016ecc118b2cc966385c8c706e7ee7c",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "44785f8aa1082dd6bda7f112a6296f63a5d66d9771960fd2489dfd272739d59b",
+          "56bea4dd7a41dd716906517a26c4d24e59fe581eff026a0a087952d9a70c4687"
+        ],
+        "missing": [],
+        "excluded": [
+          "dad2ca31a157cf44704d1a0fb16fe03e2f21552ab7670f30ce5d70ea1afcd049"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listPredefinedAccounts"
+        ],
+        "mcpTools": [
+          "fortnox_list_predefined_accounts"
+        ],
+        "cliCommands": [
+          [
+            "predefined-accounts",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-predefinedvoucherseries",
+      "tagHash": "783b385fe55b0c19f44774733720e35532809551a91b4dadec11f8a9c0527651",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "b8e9ff63abdbe75c9aa173d9f8fdcb1290740bd3b014369ccb565dca5298d9c3",
+          "e64b2ca0421996d33529186b146b47bd6cdc6852c1871efbaf835bcd70b79135"
+        ],
+        "missing": [],
+        "excluded": [
+          "3873bc7417a63ca2c9fbf9ada143fabeb5e31aa39820ee129e45d625750d56cd"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listPredefinedVoucherSeries"
+        ],
+        "mcpTools": [
+          "fortnox_list_predefined_voucher_series"
+        ],
+        "cliCommands": [
+          [
+            "predefined-voucher-series",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-pricelists",
+      "tagHash": "9dd931b5f702260f630b7b62dd309c93ac1c9523c4fee804c685ca5e3196bab2",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "b1c124d61cf779f61435e849956363fbdd58bc65c20809fb13c2912789e7fc30",
+          "bf0cdb3abbc7397cefc9f0088ef1b9dc5fedbfbb1a1e9bb43a7e21f393358383",
+          "e211b5922f92fa65f37a4933a72f1a8f00cdf938519cdefcb710403243b110bc",
+          "f144a49766b7dd0952b8dee0028186bae6220d357de839595221869a12bf6a16"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listPriceLists"
+        ],
+        "mcpTools": [
+          "fortnox_list_pricelists"
+        ],
+        "cliCommands": [
+          [
+            "pricelists",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-prices",
+      "tagHash": "e8af91a98cc4dc1bf98edbffac275e79dbe8d5bc0326ec32e57dbd3e2b3a34da",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "274df52fc31dac05edd5be8d70f215d601c944582be45929fc2f6e9b75bff6d8",
+          "2e3306105c630c5b344aafd5e0e77c7006b3fcbac32310db5c1ada09646e5c24",
+          "33f417bcfa877e2039728342b51c3f0781811fd354e4fd126551a3573c28b7cc",
+          "4505a4ba609ca851adf6aba959145e6f1f561461f26b08aa891457e1d5524a7e",
+          "5adcc51070ab49ea7a67129bb703cf36f57187c53b1f702cb9edc720e55c0037",
+          "615a3cb219f4a86e0808984950a3b068f8118edaf52fa183028a8d3410686d7d",
+          "91dc203881c1ba519aa2a4d96de69e9ad1732afa53dce47bfce8f1cab2808b0e",
+          "fa6044975f47749daadab47784b86ee2362e768fd69c900ba40612e3f0ca397a"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listPrices"
+        ],
+        "mcpTools": [
+          "fortnox_list_prices"
+        ],
+        "cliCommands": [
+          [
+            "prices",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-printtemplates",
+      "tagHash": "666e95401acc0fe6a26465dc70a834aeb1268aa3c494adde4ea1205016d5a483",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "c41323fbe09abb81409501479fd37f2bc0d83ea24763df9368da561351c81f8e"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-projects",
+      "tagHash": "aee524e88bc72989407e23ec4f53154fdec32b1ead7b39a6e24c639d3bd8f6b2",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0a5d9cd3d4016d1afb1647e00f80476b0592993b113fa67618a4d8c0c9dab384",
+          "1ad005fc392d16c28a376d3b1c11eb9f3b8540018808d31584b88dc0e704b4a2",
+          "2dc83224d5c9120d28508f7843e3c3c1cde1e69919eb8d5cfb4aac2fbad38e22",
+          "74cf87332474ecb873f5695c9d68b99d737e3e23ee979ccc4bbd1fb70524fb49",
+          "e432f6380330ed836110edcc3042202d84b339e3ff18db7f44346416a7408e19"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listProjects"
+        ],
+        "mcpTools": [
+          "fortnox_list_projects"
+        ],
+        "cliCommands": [
+          [
+            "projects",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-salarytransactions",
+      "tagHash": "ad479e7d34a9d6178424675d235f246ea6cf41742a5920d1bc55255efe9d47cf",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "31d04d0fa34ca5a1ec841be31166042a9c328c3f3972a835788bc2e688df3652",
+          "4a1eb1eae2021886f9ddfebd22408d2d0614044ffea868bf83407cd5cb3a128a",
+          "529b249463391f8948f5011954ef270d65e66f3980f3d29502f2feb7638d8d06",
+          "7d9d323d65be91cdb24a04c69c769dab142ca9b54fc9b39f832276310c58969b",
+          "abd4bc33ce9ae823b1e5cc698a337fb91b29d4c2f8470ed95b261160d56886b2"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listSalaryTransactions"
+        ],
+        "mcpTools": [
+          "fortnox_list_salarytransactions"
+        ],
+        "cliCommands": [
+          [
+            "salary-transactions",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-scheduletimes",
+      "tagHash": "6ee60f6724b017550c478b7e4b3bf9eb4374af613a2e9b9f115aeecd0e7dfe64",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "2b610e8f275b2894588e5939c642c599959ceaf4d6f1f335c5a675f9f2bf0482",
+          "8aadebdd33ff538111280286738091f9bbf197d711eb0e449a59df32de8f94ee",
+          "e6a4838e1a685e30acdd6786b0bbf4e6d9b4d54d8e358f31190a367b88e807b2"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "getScheduleTime"
+        ],
+        "mcpTools": [
+          "fortnox_get_scheduletime"
+        ],
+        "cliCommands": [
+          [
+            "schedule-times",
+            "get"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-sie",
+      "tagHash": "3d7f1a6cbbc36bcb75e16b950c5907b44392d1aef4b67f44e9203003bd41f3e3",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "27f9f290930c9e39895f6788261b48b7157be1b9153fa772175d9624e006ecac"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-supplierinvoiceaccruals",
+      "tagHash": "5563ffdf6ec829ab534199d5746766f1fe3190c2ad37e515e55f668e7e4dac5c",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "1f7cc9c3e9e27652c6e4fd1f69719d9191e11689f64daa850c9f65335ce9c8c7",
+          "52aec38b6e4484d9ffec6c12426525e20d1f106eeee6dc1edc720cfcf1ec6e08",
+          "924d6315e55b01cf71bfa3db71692160aea64c6aa5572db61186b2d297e1a3d7",
+          "a9c4e05e28784fe62d9ccb24f6c0418a73c46938fc456a9b32f85e6ee797e633",
+          "e2528a1c3c8edada28bbfcbc627dee92ac06bae0757de1f5b6b12b8f20873e3f"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listSupplierInvoiceAccruals"
+        ],
+        "mcpTools": [
+          "fortnox_list_supplier_invoice_accruals"
+        ],
+        "cliCommands": [
+          [
+            "supplier-invoice-accruals",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-supplierinvoiceexternalurlconnections",
+      "tagHash": "68f5d5e60fb770af936ff3a053f82643c6228c2377104761ba7c6c2768040cf2",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "16213c021ff903f25e1429bab684ce875b27255206b250020c413f8bd90b0e88",
+          "47bde3e593e9af7ad06a12c991795fa446eed6ea373b80cd66b258e1260b1200",
+          "9c2c832842c5a89105323d7871a2c18ee5c164ab61d9b875f8a16c4a772407f6",
+          "b37e448e853d22c8396f83acb3cf3e647d87879721aa573b6dbc177374a2ae08"
+        ]
+      },
+      "rationale": "Remote URL attachment connections are excluded to avoid introducing an arbitrary remote-fetch trust boundary."
+    },
+    {
+      "id": "fortnox-supplierinvoicefileconnections",
+      "tagHash": "73a5fdc101fa9cb6642b2b39797318aac75b6e27148c5fc9100603fd502a94e7",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "49664dac7d72ab4fa5954a573037b39237961c574e885cdcf99dc3312724efb1",
+          "64846dd44a4c53ac76b2f2df693a566f1ec3fb45d9d7662652a73d0a5492c5ee",
+          "99fb6f52cc33b0839f7bf284353cef7cfca30c6bc2853477109245b6b631c8ae",
+          "bc0cc751aae00a55c3d54d3caa4d46e0229d6cf374c079fa1768801630da1cbc"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "getSupplierInvoiceFileConnection"
+        ],
+        "mcpTools": [
+          "fortnox_get_supplier_invoice_file_connection"
+        ],
+        "cliCommands": [
+          [
+            "supplier-invoices",
+            "connection"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-supplierinvoicepayments",
+      "tagHash": "567763a9039037bd790939f15ea518aba0774373607321dea59e27174c1dc317",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "7cc3d0b3598f29af720ad501eb21bda0adde257a65d5a2d1daa7e100017b75e9",
+          "86f2611e7de36f2b0ec24678f92b324e9e378ca28c6e9cc4a5e238bba1fe8e7f",
+          "895799afd4f45bc78caee99dcbb40956f97ec211e0de8d246f5f2f74ba32a9a7",
+          "b6392993e151f97d72e04b99b44c15112ae43b61b38509663286036a9cd7beaf",
+          "bfef24882a679f481bb0546d4acf47497c26cae63f609de39aed147e0c020757",
+          "fafd1d3830251083fabc9abaa3a87db193ed5a86bf4e354a0861e5104f006ba2"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listSupplierInvoicePayments"
+        ],
+        "mcpTools": [
+          "fortnox_list_supplier_invoice_payments"
+        ],
+        "cliCommands": [
+          [
+            "supplier-invoice-payments",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-supplierinvoices",
+      "tagHash": "31ec0738a8694709c83763b2f8ad4bd8d4447ed5f11c08df8a391344732505fe",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "18100a599f890b93ccbb48bfe318fa83bcc9b077227497d1dac3472a620e15bc",
+          "22d6debafa805e0acebaca41c60c6db135a2054b457fc232323d5f73be9ab32e",
+          "8e038169759226e1781180e5fce3cc87caeede593956937c1cffa18b745c60ac",
+          "9a0e1132227fc6d2551055bc76cb208f8c0775b259685114be2394d5f4497648",
+          "ad48bf916ad2843e9e981f55510e51ca17d871c1085b7072bd33d225da9a49a2",
+          "b6c744fff16cad747c17dcf3c0704290dcc66606676212c22119a307ad05f068",
+          "c00bb27ccf619eb579d4d9bb3dd0e514421879b01b6fc8d87b5a5ec21ccd10d6",
+          "e0a247238206f49bb9b8da6943ac267a132ae8c03512a067fc23a3609b001179",
+          "ea416c860704ac22f6a5329fdcf68c151a88a3823556e19f75ce2ce5f55542c5"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listSupplierInvoices"
+        ],
+        "mcpTools": [
+          "fortnox_list_supplier_invoices"
+        ],
+        "cliCommands": [
+          [
+            "supplier-invoices",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-suppliers",
+      "tagHash": "d165d4c0a8fffeff243c52beea85250b5ec056f514eb985208f9defca0623edc",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "324abf62650ecfff5712eedd3122e582b6e7ba9564e1933d80da408f80faa808",
+          "4cd015563e37dcad0cc514bdbe5cba811762e15508e21faf04190e081f7046f0",
+          "7750b3c93e90eadacc7f96a20c6552b553b59ce9e91041e1a70eacbd30f9a9c9",
+          "fb58a72a7e8a6857018c8f08914dd93e83077795a5a5e43f5c208f70df356664"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listSuppliers"
+        ],
+        "mcpTools": [
+          "fortnox_list_suppliers"
+        ],
+        "cliCommands": [
+          [
+            "suppliers",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-taxreductions",
+      "tagHash": "2ca14459ecca2778b7662c9ceb726ab7112d84af5a194160b16f5814f799cbe2",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "440853752be40ad8759738142cd363f2c0df4535c9035a7b6d00e5b3f74572fa",
+          "5546c5481fbde423214708581a892d308813097e6847d9628da619b7c9b3d4f8",
+          "639f6338e913ede174574d874d94a9d8db6e398570a327cea98e7e0afc5320b4",
+          "e1d71bab5322a7b2950bee0c29120657fd09dcfc99d228647ab459096e056848",
+          "ed34ec0ad5ba0f0b8046f3ac2e3f9a795da895fb11dbd9e8a7c012e86916caf7"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listTaxReductions"
+        ],
+        "mcpTools": [
+          "fortnox_list_taxreductions"
+        ],
+        "cliCommands": [
+          [
+            "tax-reductions",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-termsofdeliveries",
+      "tagHash": "15213791c78e3c5ce06b6fdfd3f074df5c348616e410235b1b3618f2141168bf",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0a96cfb41f33005439d1e0c7d72ce5e91e5d4a60aeafcd6a90c5deaa030890ba",
+          "d61ca4f240034c0d10d410df3e5e29087c7bde756bcdb23802bbec46a6cb677d"
+        ],
+        "missing": [],
+        "excluded": [
+          "76c36eb563912e1ba6b95387220d1120cebaaca5089cd0b43a43365441075413",
+          "c007eb12e876f6b32c553eaae3276eba1b44972c90e4aaa70bfcefdee651b02e"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listTermsOfDeliveries"
+        ],
+        "mcpTools": [
+          "fortnox_list_terms_of_deliveries"
+        ],
+        "cliCommands": [
+          [
+            "terms-of-deliveries",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-termsofpayments",
+      "tagHash": "915d51993c7f2105a672b2a45adad6d0de204519a18eba47237c14e40f52f40c",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "ad95c55a71fe8637ea305070c51a6eb197b6859560261d53b6357c5990dbd455",
+          "e2f6442fbc7c3f8e36415b52a7a95ef0ff4d15670a633a3775829514d737b6ae"
+        ],
+        "missing": [],
+        "excluded": [
+          "213d895847916453283ba2eb4f9315b7d4c1a6c1f04fba2b1e591c013d5b0a42",
+          "242e7f11ca858a250acdcbd141b2f1c956eebcdeefbb283f8a6d965cd1c6e942",
+          "62839d1c1e195d5f93a67a645a385f2c8ee0f247cf799e9350921be5865d1efb"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listTermsOfPayments"
+        ],
+        "mcpTools": [
+          "fortnox_list_terms_of_payments"
+        ],
+        "cliCommands": [
+          [
+            "terms-of-payments",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-trustedemailsenders",
+      "tagHash": "64a3cf572b26cbd5909509259d95d9152d672bec12f5d11a33f589e9f0f95cc8",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "2367ea80022592732a31a0457e7bcece152eff93c1fba26fce1ab04d61a073c0",
+          "49ed5d38d06ab382ef9bc404afcd90b2cc2d46505d4ad865396031b0cde059fa",
+          "ffdab3f54b2a2f8e360b9bc55e38a0b6c644bb27a978c555e496aaa2d7fb8e71"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-units",
+      "tagHash": "7cfe76d2e25cbebc10541bbd17cddf5ff051774ca05af86a8d2cb76676dbe0ca",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "99a1258983adc1adf20c62978b7a5b47eb9b8f4a6a12039cd8aa6525dba2e843",
+          "d1f9a0e7eb9363010bf9b08341ae8bc71314de1fc8393ea0fe84df8f572025be"
+        ],
+        "missing": [],
+        "excluded": [
+          "153e246e2273c07890a9890b08297379d3e5a8df3fc7075aabc2a0db26c426e5",
+          "aecfee2b0844533cd989d27771a68f3202be75311f970bb979ab82ffc0134b38",
+          "b8a82e33d598f330910c4cf3bdd86936c242b9aec9543f42124f9511eab08763"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listUnits"
+        ],
+        "mcpTools": [
+          "fortnox_list_units"
+        ],
+        "cliCommands": [
+          [
+            "units",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-vacationdebtbasis",
+      "tagHash": "5efd92986ec0ac205ec16ea4d90303c594c8d18d21e7a13d84f9c459db0a46f8",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "deb27fb94543f9b580e3df8fd53bbbe9e0b038cbca69ce78bd8e97d97e05649b"
+        ]
+      },
+      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+    },
+    {
+      "id": "fortnox-voucherfileconnections",
+      "tagHash": "a2f200f145d1c03d202e565015f4ce4a0db29293841413a098313a633ff99fb2",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "4b355a810510abc7e1a3dc61ff42c751b60a0c0364a456c0b12441ec836c5cc4",
+          "c823f7be9c580c2b76b1fb86a026e5fece563577a0a6218d9540cfe456da61ff",
+          "deed9763c550e89b158f7cb28b38547091711b542bc01d5d2bc5d1bfb48bb66d",
+          "fa4a1c162c3021b906ee2d0011dd4bce2328301e36d86349102a6738ddc5dc55"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "getVoucherFileConnection"
+        ],
+        "mcpTools": [
+          "fortnox_get_voucher_file_connection"
+        ],
+        "cliCommands": [
+          [
+            "vouchers",
+            "connection"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-vouchers",
+      "tagHash": "75650f7352d6dec60dd65976cd49a366c5a01683116391b2a03d8470ef8b05d1",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "49db01f30251cd04017b3b1a80c2f94fa1035795377d5d3a794b756a67c0ef40",
+          "4bdf67ec6d2eeb40cab1f04cccccb91ebf496851dcb3f05210cce52cda7866ad",
+          "97b17074c842f79bb64d1f695998ce4449af4912351b9be12608cb3aab04ba20",
+          "bbb0c3aaaec2ad31b5d6da9c89031d1cc08ccafbbe1c14e9a1803ac0faad6b78",
+          "d0fcb98d4b9d62b5623e733b2b15ee3c29c140c97eb9dcf45da21ece25f3eecc"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listVouchers"
+        ],
+        "mcpTools": [
+          "fortnox_list_vouchers"
+        ],
+        "cliCommands": [
+          [
+            "vouchers",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fortnox-voucherseries",
+      "tagHash": "ca2601cb73b6f99dd8f79093f52f0b249bcf8236659e9628db7125c08f4c3913",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "4dda43965c0f6a2174ce63d2d9ab7fe6160ae0d13e17bab726e4fa9bb7a24040",
+          "cdcf473eee4210d9f8cb1889da637fe7071e93090c4262ccb9a28c5776b32a99"
+        ],
+        "missing": [],
+        "excluded": [
+          "092b48a9d4763c2a4db3b6730cd31985f8c2111bb646442e8bb689f01d711cf2",
+          "ed800d2f62e7e1ef3a94662089a66da16516ffe5e862ff27290e984efb8167da"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listVoucherSeries"
+        ],
+        "mcpTools": [
+          "fortnox_list_voucher_series"
+        ],
+        "cliCommands": [
+          [
+            "voucher-series",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "fortnox-wayofdeliveries",
+      "tagHash": "3531af407d179d123c77b0d9929fa416bcbacecb278438dea7d534d4e63a21a3",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "494b49e621d35dba06c3a39140743d1eca442b2e51827ba38665871c5ad3d9b7",
+          "ceee9c691c77b93b313a1bd62088e2343e76ec9c3499ff0fdaeb4c90d52c100c"
+        ],
+        "missing": [],
+        "excluded": [
+          "4488d41be1245f40c8b666987d4ed214749f013cb78edddbfb2c88bc1d3b0bc0",
+          "6a25e37b6ca1606b8cccb35034b21ce237208fb06eae3c17bcb8498cc44037da",
+          "7834e95736f8d23b16fcfc4d3aaf581a2a010cb45162d6ea5d48ffdd77c32c9f"
+        ]
+      },
+      "evidence": {
+        "operationExports": [
+          "listWaysOfDelivery"
+        ],
+        "mcpTools": [
+          "fortnox_list_ways_of_delivery"
+        ],
+        "cliCommands": [
+          [
+            "ways-of-delivery",
+            "list"
+          ]
+        ]
+      },
+      "rationale": "Reference and setup data is read-first; shared configuration mutations are explicitly outside the v1 core boundary."
+    },
+    {
+      "id": "integration-developer-integration-ratings",
+      "tagHash": "4ed9411235d23dd5c17e3b3898dff93b5bfe7e3f219100b3c228f77affc80150",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "bb4adb61decc00d526cbe74d13cbd731bc596bc1a8ccd58f5a2f262fd356b52c"
+        ]
+      },
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "integration-developer-integration-sales",
+      "tagHash": "4e9d31266757e3d690ec8f030ee1d45b07eaace74a23d5dac72ba33f0b04c8ff",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "076f665c24539c9ee3a4692e48de13716333aa716d035313236f46b16b3aa20b"
+        ]
+      },
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "integration-developer-users",
+      "tagHash": "7e333b44ada4fd6f79f837069721d82a2cf9b92179f5b30b36333a4883f06c9f",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "a0a8533773dbb711f4a31979228cd5a1caa0981c81c8b678c3e013215a266946"
+        ]
+      },
+      "rationale": "Integration marketplace administration is not an end-user accounting workflow."
+    },
+    {
+      "id": "recurring-api-invoicerequests",
+      "tagHash": "d2f9585da1a9862ea898c6ceafe87ed9133516bc0b5073def5ee01fd114e328e",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "0868123031a1e4c338fd2ad049517bb7c5aca0a0fee7bb573de6fcaa4eb18077",
+          "3f2aba3868176565efab330aeb4793bd4d52c11a3d8956f8afa3e9e867b898ed",
+          "4058cdca8372ed81e21beb8411c46e140dce2691556f2b77e2e3e61d60094d89"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listInvoiceRequests"
+        ],
+        "mcpTools": [
+          "fortnox_list_recurring_invoice_requests"
+        ],
+        "cliCommands": [
+          [
+            "recurrings",
+            "list-invoice-requests"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "recurring-api-recurringdeviations",
+      "tagHash": "35aa60c56166a8889cccf8147b41ef88b58785d5ecae1a5920bdd3b2d5917693",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "ba12f21ed06c11d4d52457a772af949c7013a28b84c9a94981cb4896b20decb6",
+          "e2d73bca0b107285c4f83afc16cf8c2285f52de2c48fe520c5d2eaf9cca420e5"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listRecurringDeviations"
+        ],
+        "mcpTools": [
+          "fortnox_list_recurring_deviations"
+        ],
+        "cliCommands": [
+          [
+            "recurrings",
+            "list-deviations"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "recurring-api-recurrings",
+      "tagHash": "ae64c89777c41c7a14083f9dc104ad0d5ce20f3a10d35d26d3479676737cf12d",
+      "classification": "complete",
+      "operations": {
+        "implemented": [
+          "52593ef71850d9b436158304fae213774d82402c45b4883b39e20e2610343090",
+          "83861b366428f20e0de087818df017b0a0ef9a4ff52a928355a62b6f97c13945",
+          "8d86e68fe8a54dcc9fc9a7b3b9e0f8abfd2a5bbdf88a0eb8e7c6dabd20b0a317",
+          "d49bdc7c67e1f3485e4f70d0f0fc09f81675397bd0a5d5866b47b6b9061197ce",
+          "ec6dbcb9485546bb853348e23ea4bb136a2f700315dd782743873003979e64cd"
+        ],
+        "missing": [],
+        "excluded": []
+      },
+      "evidence": {
+        "operationExports": [
+          "listRecurrings"
+        ],
+        "mcpTools": [
+          "fortnox_list_recurrings"
+        ],
+        "cliCommands": [
+          [
+            "recurrings",
+            "list"
+          ]
+        ]
+      }
+    },
+    {
+      "id": "time-reporting-articles",
+      "tagHash": "0a71591df6861dc08de6b60e74e6ec476238c30a82a62885a9aace3a64d7f548",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "1e64f65a15c553d2208deaec15419e4e5ad26af5ea5e7e9c3686b6691b7f668e"
+        ]
+      },
+      "rationale": "The separate time-reporting API is outside the initial payroll transaction boundary."
+    },
+    {
+      "id": "time-reporting-registrations",
+      "tagHash": "080ca683118c8f13228ba9c2efbe44f6e6ba1d32d7dcf597913754947bccd78a",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "fa7c732910540068984f88275cf7145b06991dfde5fc688450bbbfaf9e69a5b5"
+        ]
+      },
+      "rationale": "The separate time-reporting API is outside the initial payroll transaction boundary."
+    },
+    {
+      "id": "warehouse-customdocumenttype",
+      "tagHash": "6c0ffffd6486b7a22434ace28adf40c56cfe9da7815bb72e4dcc542ddc52ec0f",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "4948f6bf780cd6d507ee136f898ea678e0b7a3635cfde281bfbefdfd5357fa20",
+          "681c0ba6bb883ab3a0983082a09a298cf9cbb77133415020260bd5e5325fb8a2",
+          "f3eeee86c444d9617ad187b0584865cebfb03609e6d46e6d6a473ca4592fa878"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-custominbounddocument",
+      "tagHash": "935d427079ab103f60c8bb4f4f3c42343c7687b700be5e5a45c0fb19ead0199a",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "459e64e060c91d24c3abb17c9a15fbe51027f07e60cef206351fb1f03d857fe8",
+          "7562778e96c46f47c731f31e28a4484c7dd239ccd9a3efb1e91696d5c9433836",
+          "79683addcb3c7cb0dec203d2763ea09abbfb2388d5750154a053fe8f81149818",
+          "e62f553de399d5f58d09f50894240fd72ad8f5a3a021725a89390341a0803997"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-customoutbounddocument",
+      "tagHash": "3d649089c9aafcf1ab6a69b403b316a2c6ba76a5b111d6f46f3aceef36e35bda",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "0dceca0647d99bc28966da15772a1eaefe5bce1a03477ef7d177292b477f72a3",
+          "33a2c221338a574b0b5bccb1a2ecda3dd044429a57f0dcbefeb4b67f9c5059c5",
+          "b23a2fa4702f8ae01d4f65538c633d64872f0900a8c20ce181046e3876d1739b",
+          "b88f4edc69d76903b27bea41e1c4e74e342220f7b70a3e0fad6372604aec153d"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-incominggoods",
+      "tagHash": "612ddc82f7ed470dce1ccdd0295d8a2eacb8167d3a85495293fe45758f494414",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "25483b8ef8d3f25a29c7f894ea19fc08072cbb75e704d3d92547a2c00fc14e33",
+          "3ff5d2cbd292dba366e9ff333acb931a8bcd1d3fd29017b57f99b59efd6c1c24",
+          "4def7593b50f9860481e061a2da0b27439080e8c68933d7c44a7b06977103675",
+          "6000e89a7d10639a4dea9d1802f167b49931a057561bd9dad86d20af4f539130",
+          "79f2e028da9a4ce723b7a841cbb9305aac39a9df3c9951a92a2018091c076863",
+          "7dc36e3ca67aa4a57d3ae1464957450ebc1152c1d0853a29ffc3906faaeda2bf",
+          "d19e5345e9456d910a25bb3b4899ab678466fe4733330100f7ccaab73cf7ec20",
+          "e9046846269203030ce52f952835d36b89a94bf0973c1976369ef0843b133ad5"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualdocument",
+      "tagHash": "adacd04a28b5a0ab6898c577d666c3eda3decaa80d5b449240c3d7a732f2a1ce",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "6e163bc876a89739966a98e4e509c4a649d12d0b6c6e8b28593408710449cccc"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualinbounddocument",
+      "tagHash": "15b3ee2c17fad25259d9f605fac4740ef6d6f73bf4485d741f00fe0eee5c2596",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "148a1d9bce72d3fd720bb37e7a57baa54f1255e40ec5193904b79cdf3c1132b2",
+          "3097016d01a33953b9824e008401ec3154539752a71bd63972a09ae5e298a6e7",
+          "7845c60ecf06db0dc4663ac7468939627da9b008ed59da599413537762000e5e",
+          "82a6565c12271997f07f38d6d81d081c7342f3fbdc7ce10005fd7021e591ef29",
+          "9a772e30195ba1c6a0498322835018a8ea53eac9cf38898da99a2fe08d13a49a",
+          "fbcfc3ccd83c04c77c775650f61e25e3bf098817660b4d4f6f4be759e5a85256"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-manualoutbounddocument",
+      "tagHash": "6b064c4473fed4cf4a71be4903c0d85afbf86c4698aa5132bc2659789b9427a6",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "080e8ea583fc5cb5a3e6b69c1a422415c6d38b93b9240f68b85c032eae94f902",
+          "628fe5974520e416114eeeb0658e91857926bef270b7ebb0436be0153fedb58a",
+          "820821872fdcabc741ea4d68308e9d1d188b77a2355af29e3ace4330fc7f9a27",
+          "a4332ce64671801569633947e88b313580a9d8c0dec4ab0a43e493c245d68b02",
+          "e012ad8bb0651459508e9ec4bf7681275591754f28f051bc0383131522baf5e6",
+          "f8f656d95f2090bb51536506299bab4de5a7b0a8d159016b124dc1daa6898d12"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-productionorder",
+      "tagHash": "922bff42321990b14e7af7f10234a775c2e7aa68cdf9cfa4488655b636101810",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "3610f12ec0b40fb20950aa6ead55fa792f2c7e99f4a385d4d71322d546a4bdad",
+          "4a6e2c3bcd792255a9a5a92e40b734d85e7ee6a05080449442c0c02566d1a381",
+          "827dc1453399fb1b5c98bd214ab5de2e3aacff25ceb0d1fd93e70140ba3338ae",
+          "966caa7d08ada9d0f410fbe0642b9ca214593374ca92488968ddceee322aca96",
+          "a6d91da7f1991d0159f62de1797c24e19a2c18d0fe04990e8818a9ab69920c81",
+          "bb72f1860d682d2200b41690b1e90596f4dbc3cbf9a212da0b009a8e1bbecea1",
+          "dfd34a088c978c481dfcedc51a93b81b8ab7fe916a7c5537faa146876369e487",
+          "e9db8c56608fec12fa2267360558f90c17454ba935e78057bf9bf1e6fe217187"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-purchaseorder",
+      "tagHash": "b7839f8c70a4f0aea95baacbe5d4e3274c32dc676765d3fa1ee2dbfcf149dda2",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "0fb89e0e04ccdb28456c5d1e904d1c088109e7d856804077d1a714d76ab01dca",
+          "1103c615c725e214763f2c829ce90230e68f35dcb0e870abb93e831cf6041b5a",
+          "16295ae23e47772454a4bf02d356d5d919e18eb6e88dbffc8e498c48258db146",
+          "1c87d7ce8af4b75a8dc6f5b07cf94bce3c944c465a7731b028d4806f918963d0",
+          "3b7107eee8317973f90c6d83846f91ce8825c8319e69879a6db06f4c067f6eba",
+          "4180ef1e1c015e0e6f736288710947a797efd1076da8efcd3ca03d61a4b7dcf5",
+          "4af36cc5b112eb030220a977b60a91b77a9ab4caf27e7ac471de1a302877fbc2",
+          "580308fc3526dd355bbe56e323213f1f935a65589b60594ba076a91c706ebcc6",
+          "5c2eb509956323c1010f26860062df911c6ffedef6e4cda277ce3ce439141904",
+          "5dba23862956db27bfa0f660b08328a7d2a906ba43beb779817c330c5c16f57f",
+          "6309048440c495485e4b7883f77b1865265bde6398e3df0f277a2f77e3321d8c",
+          "66ed737b7a3b15325fea73724c46c7851cbb3f2b6067766ec339e99b97d330ad",
+          "773000b25e1322d74d30c0c158c9bbdc334d311f833bdc71b85cb0492c2c00b7",
+          "bfc5f8b765fc0fa90d998b3f082fc30d6e5f0b86cd078d488b51704ec61ab910",
+          "e5a60835c48ce19b32e6c8bf70d3204856cb5e60238433cc83c536e442394065"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stockpoint",
+      "tagHash": "3ea3931d32893888cb3ac3b213b919fb8f3c04fe98249f2ae7d3710221c3da8c",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "114e7ce689ba770a9c6f5d58a730be05073ce307c8751bf19edebe8cbc9aa4ff",
+          "1b39fb2ad5230dcccbfa288b90a61b30db74799cab4b2cafa0e7d099af3c4d38",
+          "37b0a07a0cef98f5e1733a30729befd9ac4c50dcf6502f832a85ea1c2b62c3c2",
+          "55b8a74c7a7e70800c76b0ad4d753082bf1e1e4bf7499623eee7b2b620aa3c6e",
+          "9e3af6bd031fe72e73186a40b5f912e73f38a936c8b499ac70a9720873983cac",
+          "acaa934a226e88c2bed6bbb77f4151e5065d8cac65183052871663814ea51ac4",
+          "cbf8a01f7f377605d16abffb5b040272810694cfb44a851912f74430bcfd146f",
+          "f245f484ddde820a601d3ce56ec7aa08028fa13d7930d255efbe0a2d2cfd1f13"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stockstatus",
+      "tagHash": "501e00cd261cb72e934a604dd97c57efbdd3981fa5915ad9f3f789d9956d3337",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "45c720e156174f4cf2692057651d6325b2b25546fc8af4763dcd99f6b6fefba0"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stocktaking",
+      "tagHash": "593a4c3c40e3e82fc864cec83c0c0819d6a38bf96d96fc1e92eb709564b3f219",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "03096c39b21f2572e1f6ae611668c61ba1d543622601c80ece5b313e5b30879e",
+          "1ddacca38c6093fb4991f1d8589c1b46262f09517477881ab97af53f1eda0725",
+          "2f7c6ab7192461105e2b12902df239b4040a86f67b45436e84e9d21887d14de2",
+          "599cc5b9c5a46556f68864ca8a31b85b741c5276db501c994bb5a5df12b5fd79",
+          "5ad11c90964bdb26d14a9767d2207f735e0fcf4f2988dd5450f8ff1eeb71b6dd",
+          "63f5e2ccdbac81c708830f15e2ad4d95b82e54ad9dd5588c155493c96181ae0b",
+          "816690d67a4e5b7b40ffbd24d5843704186f43347ad359097f31ee1063773728",
+          "9fd4f86093983633d5379a9221fad13a5051827e67f0ca35d4ec5970a1eefb5c",
+          "a9f30ab3e2504f1c53428c64c4ed84a1d21595237a26b1dc92434fe6865810ae",
+          "b0aba81f5f24d4800dba98edecad1a9ad7d638cb9ee5772b47fb3764eb31ae09",
+          "b5c358231fdb3a4fd4cfc2409f3831aad8b69b766cac36d8058eb7b7647f0269",
+          "bb4152d3b61fd9cf504bede6bb4a029cc25001fb9e1ea8e749e107acfdd817e1",
+          "ca8c71958ab1003ca6306e63cd95f37e34cb1e58ec38e3134ff29350c22cd113"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-stocktransfer",
+      "tagHash": "e1e9d0bb2a281016832de36a67e40331c0ea29a346212a28e29c82a004a395d0",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "49804322816cef01876faa1a5c306ee0de5b2e2d491c5cefae8583d625b32e1c",
+          "4d2a32116a4e7f18ede66d18ff26c2c2ece2b87e5520c754cc247d050ecfcf20",
+          "89e2eef42497bdcb19fa86b11944aa702cb975e19fa320292062274b72a9e0f0",
+          "8d33205c3f55cbbc07ce4305870e55c8f2663de3756a11186383b80126f90e61",
+          "af1f4051cd1f8f49766104c92923ce060d692e45bae549ae1aeb854f68745dad"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    },
+    {
+      "id": "warehouse-tenant",
+      "tagHash": "ccfa483740e67dbd17b1828c68c5766ebe4fd6602704d4882a45fa66c762b57d",
+      "classification": "excluded",
+      "operations": {
+        "implemented": [],
+        "missing": [],
+        "excluded": [
+          "fc731aef45f915142486439c35c32cbad2669f86b1007e9f1ce7a454c31e1ccf"
+        ]
+      },
+      "rationale": "Warehouse management is a separate product domain outside the core accounting boundary."
+    }
+  ]
+}

--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -164,13 +164,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
-        "constraint": 17,
+        "constraint": 15,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "7ba264823d4ad33f8dc01e943f19deeaa42206b354086474e4f80e6903287084"
+      "stateHash": "06dc1d69c6aca0b1d4dd5ef681bf861dc05beaf001891bf3b1ee510fc158db7b"
     },
     {
       "id": "contract-accrual-update",
@@ -183,13 +183,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
-        "constraint": 17,
+        "constraint": 15,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "8cff587090432f84ef613ca565296e78dcdb79d7cada3d092f3fe647c70650d6"
+      "stateHash": "9b35e6ff6dd06798fd24991180ce9b349d32d92e779ee5c66274a1110874bf6d"
     },
     {
       "id": "contract-create",
@@ -430,13 +430,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 0,
+        "enum": 1,
         "nullability": 0,
-        "constraint": 19,
+        "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "04e9e0a1fd75f9dc0266243db225c4941564da46704049296bc0f5bc54823d81"
+      "stateHash": "40df7f2250851d3375a27c72be34325f5d1780ac40abedfa2e80db5448c95fef"
     },
     {
       "id": "invoice-accrual-update",
@@ -449,13 +449,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 0,
+        "enum": 1,
         "nullability": 0,
-        "constraint": 19,
+        "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "a1109cc32febde78edb86e0159c46f6d0eb3363fa327f3dbbded404df760c008"
+      "stateHash": "531ed849aa2aa63abddd7dd8c03adc50352e1839c996584c78344798f437e112"
     },
     {
       "id": "invoice-create",
@@ -924,13 +924,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 0,
+        "enum": 1,
         "nullability": 0,
-        "constraint": 19,
+        "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "cadaa26ddb8b51e160488339e49ad77cb0a41cd5ea164b46e1e2cc7b292dcf12"
+      "stateHash": "e99ede559da1c32ce74235d4d798f9bf4d6ae2b1b2f2d04f068080bd3a449477"
     },
     {
       "id": "supplier-invoice-accrual-update",
@@ -943,13 +943,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 0,
+        "enum": 1,
         "nullability": 0,
-        "constraint": 19,
+        "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "fd3f44626e4fa59ea6a97b6389eabed5b54b1900885b422913d9e40a3ac87caa"
+      "stateHash": "a08eb714fafd0d51b41903e92b95b81203e5e9cf4a67020908e8af3d14b06f14"
     },
     {
       "id": "supplier-invoice-create",

--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -1,47 +1,1164 @@
 {
-  "formatVersion": 1,
+  "formatVersion": 2,
   "records": [
+    {
+      "id": "absence-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 8,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 9,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "1e118d92fd0627cb2f2a2779932ebc6479d5d8bd43659759ce1a9d5aaae4174e"
+    },
+    {
+      "id": "absence-update",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 8,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 9,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "625226bb21b50e539adc249717b8456f6850e903dc40c36ea46cfb552895e7f8"
+    },
+    {
+      "id": "account-create",
+      "declaredPropertyCount": 16,
+      "specificationPropertyCount": 13,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 17,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 10,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "b387e7cb15ad167e83cc72c4cdcbf3e058f668d95deacb02d77e0ec1d2188189"
+    },
+    {
+      "id": "account-update",
+      "declaredPropertyCount": 16,
+      "specificationPropertyCount": 13,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 16,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 9,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "8424b0af4187ba849a60d9371cb23eb71cbb8d8d3231d0db472742fd21bd3d1b"
+    },
+    {
+      "id": "article-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 44,
+      "missingPropertyCount": 36,
+      "checkedNodeCount": 9,
+      "issuesByDimension": {
+        "field": 36,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 9,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "80ed0f9830f005ab17dc278c60940be0fa56f3f4b4f0d4b287817b5a65d861ac"
+    },
+    {
+      "id": "article-update",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 44,
+      "missingPropertyCount": 37,
+      "checkedNodeCount": 8,
+      "issuesByDimension": {
+        "field": 37,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 8,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "ab4218827c08648d3819a4bea0796c8b2121d070f40ecfb4053b330be4ab07e5"
+    },
+    {
+      "id": "attendance-create",
+      "declaredPropertyCount": 9,
+      "specificationPropertyCount": 6,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 7,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 5,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "107b7cc096c91ec3fab24c1d9015fc08b663f5ab4c944774f30d9b36ef741182"
+    },
+    {
+      "id": "attendance-update",
+      "declaredPropertyCount": 10,
+      "specificationPropertyCount": 6,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 7,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 5,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "c4a92cf998bf965be9d059da730218ee20e92b32f14d37ebbcb97860db91f6f1"
+    },
+    {
+      "id": "contract-accrual-create",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 9,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 17,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 17,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "7ba264823d4ad33f8dc01e943f19deeaa42206b354086474e4f80e6903287084"
+    },
+    {
+      "id": "contract-accrual-update",
+      "declaredPropertyCount": 13,
+      "specificationPropertyCount": 9,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 17,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 17,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "8cff587090432f84ef613ca565296e78dcdb79d7cada3d092f3fe647c70650d6"
+    },
+    {
+      "id": "contract-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 34,
+      "missingPropertyCount": 40,
+      "checkedNodeCount": 17,
+      "issuesByDimension": {
+        "field": 40,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 12,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "b2ade189f80417e04121c7f098965ae2b758fe86cb9b828379085ddc98196ea6"
+    },
+    {
+      "id": "contract-update",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 49,
+      "missingPropertyCount": 56,
+      "checkedNodeCount": 16,
+      "issuesByDimension": {
+        "field": 56,
+        "nesting": 0,
+        "requiredness": 4,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 12,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "7f6c80e1afa2a7f1c585b823511d499c1488ee43b63a01010531d0df8ed85a3c"
+    },
+    {
+      "id": "cost-center-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 4,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "58b7ea5d2e021679eb7522fed9b8b017409a3ab5bf7700a41a9d5abdf9d19d33"
+    },
+    {
+      "id": "cost-center-update",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 4,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 4,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "0201c656857ba51dc24a1cb7c8f2b0f175cd9064e3ac41a90da27ff6982bcf69"
+    },
+    {
+      "id": "customer",
+      "declaredPropertyCount": 60,
+      "specificationPropertyCount": 63,
+      "missingPropertyCount": 6,
+      "checkedNodeCount": 58,
+      "issuesByDimension": {
+        "field": 6,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 52,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "4129eb4086e36fef65d42af2c4d90c775bd80c0b075b4f934fd9115a8140f544"
+    },
+    {
+      "id": "customer-update",
+      "declaredPropertyCount": 61,
+      "specificationPropertyCount": 63,
+      "missingPropertyCount": 6,
+      "checkedNodeCount": 58,
+      "issuesByDimension": {
+        "field": 6,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 52,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "0f29f53c8198e03fe7c8dfc3978e7d93d418e10a5a602827c0faab788a0ef661"
+    },
+    {
+      "id": "document-attachment-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 5,
+      "missingPropertyCount": 2,
+      "checkedNodeCount": 4,
+      "issuesByDimension": {
+        "field": 2,
+        "nesting": 0,
+        "requiredness": 2,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 1,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "420131936a39b38dc7f56dbcfd13c58521910cd7656342fb29862d56314fce89"
+    },
+    {
+      "id": "document-attachment-update",
+      "declaredPropertyCount": 9,
+      "specificationPropertyCount": 5,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 6,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "14dfdbf31381d90d04f38ae7cf047d552db3c063ce67b184e6f6df04169d7703"
+    },
+    {
+      "id": "document-attachment-validate-item",
+      "declaredPropertyCount": 5,
+      "specificationPropertyCount": 5,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 6,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "0b9854b31053672b04d8ffd6e50204cb4efd313d1194a87e0af0cc67957f8c49"
+    },
+    {
+      "id": "employee-create",
+      "declaredPropertyCount": 35,
+      "specificationPropertyCount": 109,
+      "missingPropertyCount": 77,
+      "checkedNodeCount": 33,
+      "issuesByDimension": {
+        "field": 77,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 5,
+        "nullability": 0,
+        "constraint": 8,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "0e33dd9a5230bdb76e15adcb829ab7aa518a197fa926f6a17a434fd284a47430"
+    },
+    {
+      "id": "employee-update",
+      "declaredPropertyCount": 35,
+      "specificationPropertyCount": 109,
+      "missingPropertyCount": 78,
+      "checkedNodeCount": 32,
+      "issuesByDimension": {
+        "field": 78,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 0,
+        "enum": 5,
+        "nullability": 0,
+        "constraint": 6,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "d6cbc35a669005f4d66c2f0be7c0634ea447872455231bb9ab860880df602509"
+    },
+    {
+      "id": "financial-year-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 5,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "ac907bc4dfcbb1d8f5219d29f5058154cc76a867f993399c900e821346a6c136"
+    },
+    {
+      "id": "invoice-accrual-create",
+      "declaredPropertyCount": 14,
+      "specificationPropertyCount": 11,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 19,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "04e9e0a1fd75f9dc0266243db225c4941564da46704049296bc0f5bc54823d81"
+    },
+    {
+      "id": "invoice-accrual-update",
+      "declaredPropertyCount": 15,
+      "specificationPropertyCount": 11,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 19,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "a1109cc32febde78edb86e0159c46f6d0eb3363fa327f3dbbded404df760c008"
+    },
+    {
+      "id": "invoice-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 52,
+      "missingPropertyCount": 44,
+      "checkedNodeCount": 28,
+      "issuesByDimension": {
+        "field": 44,
+        "nesting": 0,
+        "requiredness": 4,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 20,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "ccdc9a82f75494750ac0d2b70496a35a935badf8e65bd5d9659870974eeaae7c"
+    },
+    {
+      "id": "invoice-payment-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 23,
+      "missingPropertyCount": 19,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 19,
+        "nesting": 0,
+        "requiredness": 2,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "30f88eb32c5d8c384607d6b6acc0a7f1acc188098fa54124bb1768734a244997"
+    },
+    {
+      "id": "invoice-payment-update",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 23,
+      "missingPropertyCount": 19,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 19,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "42e4ef86d3198fc2c367fa0a756ef0a838159afcfb756a7959022af2c207bc39"
+    },
     {
       "id": "invoice-row",
       "declaredPropertyCount": 18,
       "specificationPropertyCount": 18,
       "missingPropertyCount": 0,
-      "stateHash": "c88088ad9b7760e55821ad2ff4d22076a4efdc2e2a9a2419d7fe67bf62978a08"
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 15,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "7effac25c5c7c1d4f08052a39b5c865d8419d08a2ccac6377e17ab2b5df0dfb3"
+    },
+    {
+      "id": "invoice-update",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 52,
+      "missingPropertyCount": 44,
+      "checkedNodeCount": 28,
+      "issuesByDimension": {
+        "field": 44,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 20,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "96648e54f2cdfc3f1c88247cc747de15cee8c2520f821844dfb3d8b24c1b739d"
+    },
+    {
+      "id": "offer-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 45,
+      "missingPropertyCount": 37,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 37,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 17,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "84cbfdad8ed8c862f84320b800147e8302a6f36aa373edf072536ec484dda0b2"
     },
     {
       "id": "offer-row",
       "declaredPropertyCount": 20,
       "specificationPropertyCount": 19,
       "missingPropertyCount": 0,
-      "stateHash": "ad10515787a657a7ca9f5bec5cd49d33e34e2861c5aa31da0925e05e86e54f96"
+      "checkedNodeCount": 20,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 2,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 15,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "2ba9c3a594429bae66928ecc16e125ee898d30d34632edf6b60f127bc046e48f"
+    },
+    {
+      "id": "offer-update",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 45,
+      "missingPropertyCount": 37,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 37,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 17,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "eb9d6c348a4d0577a4db7876f9a3fa9c23c5511e17208909c85dcfd035721266"
+    },
+    {
+      "id": "order-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 50,
+      "missingPropertyCount": 42,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 42,
+        "nesting": 0,
+        "requiredness": 4,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 18,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "390f2803c511d97beb99572dddadb9218946e0849a7fa73b7b47447d4ce529cf"
     },
     {
       "id": "order-row",
       "declaredPropertyCount": 19,
       "specificationPropertyCount": 19,
       "missingPropertyCount": 0,
-      "stateHash": "9e47e77be6ba95abf03aa8b1b67ebfff4d661ab69471a05954fa034e9a8fed9c"
+      "checkedNodeCount": 20,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 12,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "7f6fc87656c93631d90cba7383ce38ccf42386742a1068711f87c0d211acae56"
+    },
+    {
+      "id": "order-update",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 50,
+      "missingPropertyCount": 42,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 42,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 18,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "3b046c26717c58100bb1c83ef87a7fd61b11b6d13d86000af907ef192fa394f3"
+    },
+    {
+      "id": "price-create",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 6,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 6,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "5170522c298392f9c0ddaf29c12e5b26c8465e794cd8e5626f1fba872d5fdf98"
+    },
+    {
+      "id": "price-list-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 4,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "021ab0c1bcc4988951978f39d5027e932edc4e24bd06b4668b13ccf0316bc886"
+    },
+    {
+      "id": "price-list-update",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 4,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 4,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "d3cf7ec52466b29f0c461e75dcbd91c97ffddafc4372fb9c84b8f89a2015f1d3"
+    },
+    {
+      "id": "price-update",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 6,
+      "missingPropertyCount": 4,
+      "checkedNodeCount": 3,
+      "issuesByDimension": {
+        "field": 4,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "de52153322ee84ef53f5780dd21aa695f7de5d0d5965eaba8a1254e0bcf9bcde"
+    },
+    {
+      "id": "project-create",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 8,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 9,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 8,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "89f3ef3c2a06f95fb35f27b7b3a883a9b4dedf9f0097a51371ea5cc220823c53"
+    },
+    {
+      "id": "project-update",
+      "declaredPropertyCount": 11,
+      "specificationPropertyCount": 8,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 8,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 7,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "1c8222a3db8fc591e90ace497a42fdef91f9b97a0aa6e38c1a83d91ca5ce41b8"
+    },
+    {
+      "id": "recurring-invoice-request-create",
+      "declaredPropertyCount": 5,
+      "specificationPropertyCount": 1,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 1,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 0,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "e393e8c8aef96201423aa5ba5d51a39543f0960aa6b1e66f844c438114f96fe7"
+    },
+    {
+      "id": "recurring-patch-document",
+      "declaredPropertyCount": 0,
+      "specificationPropertyCount": 0,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "521f69c18c8427b133ac8da6ca1f1d3d6c421b72f381624c0a76e9ca0ff8919a"
+    },
+    {
+      "id": "salary-transaction-create",
+      "declaredPropertyCount": 14,
+      "specificationPropertyCount": 12,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 12,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "2105527548ea14b21069ed36ddd92831cc3439a536bab210d1b0db51f97896e3"
+    },
+    {
+      "id": "salary-transaction-update",
+      "declaredPropertyCount": 15,
+      "specificationPropertyCount": 12,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 12,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 3,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 3,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "e81713348966298d6862011f84a1338cd4da7fcd7508150dd9c8214042b20ca2"
+    },
+    {
+      "id": "schedule-time-reset",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 9,
+      "missingPropertyCount": 2,
+      "checkedNodeCount": 8,
+      "issuesByDimension": {
+        "field": 2,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 0,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "3a45fce918b4cf97880e2d5a65d9e1dd0c84e6950d861df9bc35fe86a48ad668"
+    },
+    {
+      "id": "schedule-time-update",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 9,
+      "missingPropertyCount": 2,
+      "checkedNodeCount": 8,
+      "issuesByDimension": {
+        "field": 2,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 0,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "31cd3d579a364a4e18f2450e006710e26d258fd0cc6cb67b60fce2aa8d39291c"
     },
     {
       "id": "supplier",
       "declaredPropertyCount": 44,
       "specificationPropertyCount": 41,
       "missingPropertyCount": 0,
-      "stateHash": "22830034d8b00b23ddb2594bc76450751c81a3a16aaa50a7f44c20f82b62a545"
+      "checkedNodeCount": 42,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 10,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "b659c1b3f3031abcd7b922b793b894921f6562055300a1d7dab8a151a65555cc"
+    },
+    {
+      "id": "supplier-invoice-accrual-create",
+      "declaredPropertyCount": 14,
+      "specificationPropertyCount": 11,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 19,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "cadaa26ddb8b51e160488339e49ad77cb0a41cd5ea164b46e1e2cc7b292dcf12"
+    },
+    {
+      "id": "supplier-invoice-accrual-update",
+      "declaredPropertyCount": 15,
+      "specificationPropertyCount": 11,
+      "missingPropertyCount": 0,
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 19,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "fd3f44626e4fa59ea6a97b6389eabed5b54b1900885b422913d9e40a3ac87caa"
+    },
+    {
+      "id": "supplier-invoice-create",
+      "declaredPropertyCount": 12,
+      "specificationPropertyCount": 26,
+      "missingPropertyCount": 17,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 17,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 14,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "5d90f65b5f9e1164687bb25b00d6137fac67dffa08c264559c94dd2bcc94779a"
+    },
+    {
+      "id": "supplier-invoice-file-connection-create",
+      "declaredPropertyCount": 5,
+      "specificationPropertyCount": 4,
+      "missingPropertyCount": 4,
+      "checkedNodeCount": 1,
+      "issuesByDimension": {
+        "field": 4,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 0,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "2551299e2d5cc959af553bc3d5cf0e5db6774a26964947f5367835180a16c904"
+    },
+    {
+      "id": "supplier-invoice-payment-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 21,
+      "missingPropertyCount": 17,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 17,
+        "nesting": 0,
+        "requiredness": 2,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "2b6ae2075a92a2d1adced606de8da0f9adda660d922bdf9622b8135da32d8b8d"
+    },
+    {
+      "id": "supplier-invoice-payment-update",
+      "declaredPropertyCount": 8,
+      "specificationPropertyCount": 21,
+      "missingPropertyCount": 17,
+      "checkedNodeCount": 5,
+      "issuesByDimension": {
+        "field": 17,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 1,
+        "nullability": 0,
+        "constraint": 2,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "b4d4e2a2ee38294d264a5b65d7ae1437541ca0f3651d775e8ebe818640da0e2a"
     },
     {
       "id": "supplier-invoice-row",
       "declaredPropertyCount": 19,
       "specificationPropertyCount": 18,
       "missingPropertyCount": 0,
-      "stateHash": "25c363c59fda47579aaf27c77e21c3af3fa7c239d23a2a0d01a18533c2e65d3f"
+      "checkedNodeCount": 19,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 10,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "fd478dca3f5c6f25609908341dd3c8ff5d4b9cc9b27f08d4a39cefc1e3769b72"
+    },
+    {
+      "id": "supplier-invoice-update",
+      "declaredPropertyCount": 13,
+      "specificationPropertyCount": 26,
+      "missingPropertyCount": 17,
+      "checkedNodeCount": 29,
+      "issuesByDimension": {
+        "field": 17,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 1,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 14,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "cc9b9e3e2072eb588a70a9ad55257c152ddc55bf1bbd22d17c689a78b94f625c"
+    },
+    {
+      "id": "supplier-update",
+      "declaredPropertyCount": 44,
+      "specificationPropertyCount": 41,
+      "missingPropertyCount": 1,
+      "checkedNodeCount": 41,
+      "issuesByDimension": {
+        "field": 1,
+        "nesting": 0,
+        "requiredness": 1,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 10,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "45e39d06dfb39a10c16adc3738e98f76b2053b6416ecfb62ae7e83c8f660e1c3"
+    },
+    {
+      "id": "tax-reduction-create",
+      "declaredPropertyCount": 9,
+      "specificationPropertyCount": 15,
+      "missingPropertyCount": 10,
+      "checkedNodeCount": 6,
+      "issuesByDimension": {
+        "field": 10,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "25a29353c6d697c15b337e36e9d6e20724dce52107128569c18eefc766c08a8a"
+    },
+    {
+      "id": "tax-reduction-update",
+      "declaredPropertyCount": 10,
+      "specificationPropertyCount": 15,
+      "missingPropertyCount": 10,
+      "checkedNodeCount": 6,
+      "issuesByDimension": {
+        "field": 10,
+        "nesting": 0,
+        "requiredness": 4,
+        "type": 0,
+        "enum": 0,
+        "nullability": 0,
+        "constraint": 4,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "341338fbd3f94f01a675538b6d0da1d059dd6f47fc999b630779ecd8707131af"
+    },
+    {
+      "id": "voucher-create",
+      "declaredPropertyCount": 7,
+      "specificationPropertyCount": 12,
+      "missingPropertyCount": 8,
+      "checkedNodeCount": 15,
+      "issuesByDimension": {
+        "field": 8,
+        "nesting": 0,
+        "requiredness": 2,
+        "type": 0,
+        "enum": 0,
+        "nullability": 1,
+        "constraint": 13,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "840f5efaf12f5f34b9b33aff7dde18831d186fc084a4e4662c8b9d92898f28c9"
     },
     {
       "id": "voucher-row",
       "declaredPropertyCount": 9,
       "specificationPropertyCount": 9,
       "missingPropertyCount": 0,
-      "stateHash": "d3d7fc08d35e0a5bdf4c2279bab5f5e2902cc070f2dff84e284e930e4a20d294"
+      "checkedNodeCount": 10,
+      "issuesByDimension": {
+        "field": 0,
+        "nesting": 0,
+        "requiredness": 0,
+        "type": 0,
+        "enum": 0,
+        "nullability": 1,
+        "constraint": 7,
+        "strictness": 0
+      },
+      "resultClass": "tracked-gap",
+      "stateHash": "0af843ab16ea80e0247b3f4ebbee4c3ac37dfb84103a02c76154d450cf0925b4"
     }
   ]
 }

--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -430,13 +430,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
         "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "40df7f2250851d3375a27c72be34325f5d1780ac40abedfa2e80db5448c95fef"
+      "stateHash": "c0d93bfd39333036b61815103e83435462a5b1b2a0a5c9784cb8e71a67b8fe76"
     },
     {
       "id": "invoice-accrual-update",
@@ -449,13 +449,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
         "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "531ed849aa2aa63abddd7dd8c03adc50352e1839c996584c78344798f437e112"
+      "stateHash": "52e1282304d96d9b4104ab4bc4f887ff3f0376ab9987588ba1afabbd209cffda"
     },
     {
       "id": "invoice-create",
@@ -924,13 +924,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
         "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "e99ede559da1c32ce74235d4d798f9bf4d6ae2b1b2f2d04f068080bd3a449477"
+      "stateHash": "5c4e05063d2c21dbdcaea6139c72ebe3f210b9d640b27879f7c400fda9623e82"
     },
     {
       "id": "supplier-invoice-accrual-update",
@@ -943,13 +943,13 @@
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
-        "enum": 1,
+        "enum": 0,
         "nullability": 0,
         "constraint": 17,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "a08eb714fafd0d51b41903e92b95b81203e5e9cf4a67020908e8af3d14b06f14"
+      "stateHash": "691426040493a256cecf7ea42286fae899e80a3ab93c63b44c75befb0cd6da16"
     },
     {
       "id": "supplier-invoice-create",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "version:check": "node scripts/version.mjs check",
     "version:set": "node scripts/version.mjs set",
     "verify": "npm run version:check && npm run lint && npm run format:check && npm run build && npm test",
-    "check:release": "npm run verify && npm audit --omit=dev && node scripts/check-embedded-consumer.mjs && npm pack --dry-run --ignore-scripts",
+    "check:release": "npm run verify && npm run audit:api-coverage:offline && npm audit --omit=dev && node scripts/check-embedded-consumer.mjs && npm pack --dry-run --ignore-scripts",
     "check:api": "bash scripts/check-api-changes.sh",
     "audit:schemas": "npm run build --silent && node scripts/audit-tool-schemas.mjs",
+    "audit:api-coverage": "npm run build --silent && node scripts/audit-api-coverage.mjs",
+    "audit:api-coverage:offline": "node scripts/audit-api-coverage.mjs --offline",
     "prepublishOnly": "npm run check:release",
     "prepare": "husky"
   },

--- a/scripts/audit-api-coverage.mjs
+++ b/scripts/audit-api-coverage.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../dist/index.js';
+import { defaultFortnoxOperations } from '../dist/operations/index.js';
+import {
+  calculateApiCoverage,
+  compareApiCoverageBaselines,
+  formatApiCoverageDetails,
+  formatApiCoverageSummary,
+  toApiCoverageBaseline,
+} from '../dist/api-coverage.js';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_DIR = path.dirname(SCRIPT_DIR);
+const DEFAULT_SPEC = path.join(REPO_DIR, 'api-spec', 'openapi.json');
+const DEFAULT_MAP = path.join(REPO_DIR, 'api-spec', 'api-implementation-map.json');
+const DEFAULT_BASELINE = path.join(REPO_DIR, 'api-spec', 'api-implementation-coverage.json');
+const HTTP_METHODS = new Set(['delete', 'get', 'patch', 'post', 'put']);
+
+const hash = (...parts) =>
+  createHash('sha256').update(parts.join('\0'), 'utf8').digest('hex');
+const tagIdentity = (tag) => hash('noxctl-api-family/v1', tag);
+const operationIdentity = (method, route, operationId) =>
+  hash('noxctl-api-operation/v1', method.toUpperCase(), route, operationId ?? '');
+
+function usage() {
+  return [
+    'Usage: node scripts/audit-api-coverage.mjs [options]',
+    '',
+    'Options:',
+    '  --offline            Verify committed mapping and implementation evidence without the local spec',
+    '  --update             Replace the opaque baseline with the current result',
+    '  --show-details       Print raw local API details; never writes a baseline',
+    '  --spec <path>        Read a different local OpenAPI document',
+    '  --map <path>         Read a different opaque implementation map',
+    '  --baseline <path>    Read or update a different opaque baseline',
+    '  --help               Show this help',
+    '',
+  ].join('\n');
+}
+
+function parseArgs(args) {
+  const options = {
+    offline: false,
+    update: false,
+    showDetails: false,
+    specPath: DEFAULT_SPEC,
+    mapPath: DEFAULT_MAP,
+    baselinePath: DEFAULT_BASELINE,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--offline') options.offline = true;
+    else if (arg === '--update') options.update = true;
+    else if (arg === '--show-details') options.showDetails = true;
+    else if (['--spec', '--map', '--baseline'].includes(arg)) {
+      const value = args[index + 1];
+      if (!value) throw new Error(`${arg} requires a path`);
+      options[`${arg.slice(2)}Path`] = path.resolve(value);
+      index += 1;
+    } else if (arg === '--help') {
+      process.stdout.write(usage());
+      process.exit(0);
+    } else throw new Error(`Unknown option: ${arg}`);
+  }
+  if (options.update && options.showDetails) {
+    throw new Error('--update and --show-details cannot be combined');
+  }
+  if (options.offline && options.showDetails) {
+    throw new Error('--offline and --show-details cannot be combined');
+  }
+  return options;
+}
+
+async function readJson(filePath, description) {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') throw new Error(`${description} not found at ${filePath}`);
+    throw new Error(`Could not read ${description}: ${error.message}`);
+  }
+}
+
+function inspectSpec(spec) {
+  const families = new Map();
+  for (const [route, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const [method, operation] of Object.entries(pathItem ?? {})) {
+      if (!HTTP_METHODS.has(method)) continue;
+      for (const tag of operation.tags ?? ['(untagged)']) {
+        const tagHash = tagIdentity(tag);
+        const family = families.get(tagHash) ?? { tag, operations: [] };
+        family.operations.push({
+          identity: operationIdentity(method, route, operation.operationId),
+          method: method.toUpperCase(),
+          route,
+          operationId: operation.operationId ?? '',
+        });
+        families.set(tagHash, family);
+      }
+    }
+  }
+  return families;
+}
+
+function mappingsFromDocument(document) {
+  if (document?.formatVersion !== 1 || !Array.isArray(document.families)) {
+    throw new Error('Implementation map has an unsupported format');
+  }
+  const tagHashes = new Set();
+  const ids = new Set();
+  return document.families.map((family) => {
+    if (!family.id || !family.tagHash || ids.has(family.id) || tagHashes.has(family.tagHash)) {
+      throw new Error('Implementation map has a missing or duplicate family identity');
+    }
+    ids.add(family.id);
+    tagHashes.add(family.tagHash);
+    return {
+      tagHash: family.tagHash,
+      mapping: {
+        id: family.id,
+        classification: family.classification,
+        publicOperationCount:
+          family.operations.implemented.length +
+          family.operations.missing.length +
+          family.operations.excluded.length,
+        implementedOperationIdentities: family.operations.implemented,
+        missingOperationIdentities: family.operations.missing,
+        excludedOperationIdentities: family.operations.excluded,
+        evidence: family.evidence,
+        rationale: family.rationale,
+      },
+    };
+  });
+}
+
+function verifySpecCoverage(mapped, inspected) {
+  const byTagHash = new Map(mapped.map((entry) => [entry.tagHash, entry]));
+  const unknown = [...inspected.keys()].filter((identity) => !byTagHash.has(identity));
+  const removed = [...byTagHash.keys()].filter((identity) => !inspected.has(identity));
+  if (unknown.length || removed.length) {
+    throw new Error(
+      `API family inventory drift: new=${unknown.length} removed=${removed.length}; use --show-details locally`,
+    );
+  }
+  for (const [tagHash, entry] of byTagHash) {
+    const actual = new Set(inspected.get(tagHash).operations.map(({ identity }) => identity));
+    const mappedOperations = [
+      ...entry.mapping.implementedOperationIdentities,
+      ...entry.mapping.missingOperationIdentities,
+      ...entry.mapping.excludedOperationIdentities,
+    ];
+    const stale = mappedOperations.filter((identity) => !actual.has(identity));
+    const unmapped = [...actual].filter((identity) => !mappedOperations.includes(identity));
+    if (stale.length || unmapped.length) {
+      throw new Error(
+        `API operation inventory drift for ${entry.mapping.id}: new=${unmapped.length} removed=${stale.length}; use --show-details locally`,
+      );
+    }
+  }
+}
+
+async function discoverTools() {
+  const server = createServer({
+    transport: async () => {
+      throw new Error('Coverage discovery must not make Fortnox requests');
+    },
+  });
+  const client = new Client({ name: 'noxctl-api-coverage-audit', version: '1' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return (await client.listTools()).tools.map(({ name }) => name);
+  } finally {
+    await Promise.allSettled([client.close(), server.close()]);
+  }
+}
+
+async function verifyEvidence(mapped) {
+  const operationExports = new Set(Object.keys(defaultFortnoxOperations));
+  const mcpTools = new Set(await discoverTools());
+  for (const { mapping } of mapped) {
+    const evidence = mapping.evidence;
+    for (const name of evidence?.operationExports ?? []) {
+      if (!operationExports.has(name)) throw new Error(`Missing operation evidence: ${mapping.id}`);
+    }
+    for (const name of evidence?.mcpTools ?? []) {
+      if (!mcpTools.has(name)) throw new Error(`Missing MCP evidence: ${mapping.id}`);
+    }
+    for (const command of evidence?.cliCommands ?? []) {
+      const outcome = spawnSync(process.execPath, [path.join(REPO_DIR, 'dist', 'cli.js'), ...command, '--help'], {
+        encoding: 'utf8',
+        env: { ...process.env, NOXCTL_PROFILE: 'default' },
+      });
+      if (outcome.status !== 0) throw new Error(`Missing CLI evidence: ${mapping.id}`);
+    }
+  }
+}
+
+function detailedInventory(mapped, inspected) {
+  const byHash = new Map(mapped.map((entry) => [entry.tagHash, entry]));
+  const lines = [];
+  for (const [tagHash, family] of inspected) {
+    const entry = byHash.get(tagHash);
+    lines.push(`${JSON.stringify(family.tag)} -> ${entry?.mapping.id ?? '(unmapped)'}`);
+    const states = entry
+      ? new Map([
+          ...entry.mapping.implementedOperationIdentities.map((identity) => [identity, 'implemented']),
+          ...entry.mapping.missingOperationIdentities.map((identity) => [identity, 'missing']),
+          ...entry.mapping.excludedOperationIdentities.map((identity) => [identity, 'excluded']),
+        ])
+      : new Map();
+    for (const operation of family.operations) {
+      lines.push(
+        `  ${states.get(operation.identity) ?? 'unmapped'} ${operation.method} ${JSON.stringify(operation.route)} ${JSON.stringify(operation.operationId)}`,
+      );
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function writeJsonAtomically(filePath, value) {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { flag: 'wx' });
+    await rename(temporaryPath, filePath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const document = await readJson(options.mapPath, 'Implementation map');
+  const mapped = mappingsFromDocument(document);
+  let inspected;
+  if (!options.offline) {
+    inspected = inspectSpec(await readJson(options.specPath, 'OpenAPI specification'));
+    verifySpecCoverage(mapped, inspected);
+  }
+  await verifyEvidence(mapped);
+  const results = calculateApiCoverage(mapped.map(({ mapping }) => mapping));
+  const current = toApiCoverageBaseline(results);
+
+  if (options.showDetails) {
+    process.stdout.write(detailedInventory(mapped, inspected));
+    process.stdout.write(formatApiCoverageDetails(results));
+    return;
+  }
+  if (options.update) {
+    await writeJsonAtomically(options.baselinePath, current);
+    process.stdout.write(formatApiCoverageSummary(results));
+    return;
+  }
+  const expected = await readJson(options.baselinePath, 'API coverage baseline');
+  const comparison = compareApiCoverageBaselines(expected, current);
+  process.stdout.write(formatApiCoverageSummary(results, comparison));
+  if (!comparison.matches) {
+    process.stderr.write(`Changed mappings: ${comparison.changedMappingIds.join(', ')}\n`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`API coverage audit failed: ${error.message}\n`);
+  process.exitCode = 2;
+});

--- a/scripts/audit-tool-schemas.mjs
+++ b/scripts/audit-tool-schemas.mjs
@@ -8,12 +8,13 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from '../dist/index.js';
 import {
   auditSchemaCoverage,
+  auditMutationInventory,
   compareAuditBaselines,
   formatAuditFields,
   formatAuditSummary,
   toAuditBaseline,
 } from '../dist/schema-audit.js';
-import { SCHEMA_AUDIT_MAPPINGS } from '../dist/schema-audit-mappings.js';
+import { SCHEMA_AUDIT_EXCEPTIONS, SCHEMA_AUDIT_MAPPINGS } from '../dist/schema-audit-mappings.js';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_DIR = path.dirname(SCRIPT_DIR);
@@ -120,9 +121,18 @@ async function main() {
     discoverTools(),
   ]);
   const results = auditSchemaCoverage(spec, tools, SCHEMA_AUDIT_MAPPINGS);
+  const inventory = auditMutationInventory(tools, SCHEMA_AUDIT_MAPPINGS, SCHEMA_AUDIT_EXCEPTIONS);
+  if (inventory.unmappedToolNames.length || inventory.staleExceptionIds.length) {
+    throw new Error(
+      `Mutation inventory drift: unmapped=${inventory.unmappedToolNames.length} stale-exceptions=${inventory.staleExceptionIds.length}`,
+    );
+  }
   const current = toAuditBaseline(results);
 
   if (options.showFields) {
+    process.stdout.write(
+      `Mutation inventory: discovered=${inventory.discoveredMutationCount} mapped=${inventory.mappedMutationCount} excepted=${inventory.exceptedMutationCount}\n`,
+    );
     process.stdout.write(formatAuditFields(results));
     return;
   }

--- a/src/api-coverage.ts
+++ b/src/api-coverage.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto';
+
+const HASH_DOMAIN = 'noxctl-api-coverage/v1';
+
+export type ApiCoverageClassification = 'complete' | 'partial' | 'excluded' | 'blocked';
+
+export interface ApiCoverageMapping {
+  id: string;
+  classification: ApiCoverageClassification;
+  publicOperationCount: number;
+  implementedOperationIdentities: readonly string[];
+  missingOperationIdentities: readonly string[];
+  rationale?: string;
+}
+
+export interface ApiCoverageResult extends ApiCoverageMapping {
+  implementedOperationIdentities: string[];
+  missingOperationIdentities: string[];
+  implementedCount: number;
+  missingCount: number;
+  stateHash: string;
+}
+
+export interface ApiCoverageBaselineRecord {
+  id: string;
+  classification: ApiCoverageClassification;
+  publicOperationCount: number;
+  implementedCount: number;
+  missingCount: number;
+  stateHash: string;
+  rationale?: string;
+}
+
+export interface ApiCoverageBaseline {
+  formatVersion: 1;
+  records: ApiCoverageBaselineRecord[];
+}
+
+export interface ApiCoverageComparison {
+  matches: boolean;
+  changedMappingIds: string[];
+}
+
+const compareText = (left: string, right: string): number => left.localeCompare(right, 'en');
+
+function assertUnique(values: readonly string[], label: string, id: string): void {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`Duplicate ${label} identities for mapping ${id}`);
+  }
+}
+
+function validateMapping(mapping: ApiCoverageMapping): void {
+  if (!['complete', 'partial', 'excluded', 'blocked'].includes(mapping.classification)) {
+    throw new Error(`Invalid classification for mapping ${mapping.id}`);
+  }
+  if (!Number.isInteger(mapping.publicOperationCount) || mapping.publicOperationCount < 0) {
+    throw new Error(`Invalid publicOperationCount for mapping ${mapping.id}`);
+  }
+
+  assertUnique(mapping.implementedOperationIdentities, 'implemented', mapping.id);
+  assertUnique(mapping.missingOperationIdentities, 'missing', mapping.id);
+  const implemented = new Set(mapping.implementedOperationIdentities);
+  if (mapping.missingOperationIdentities.some((identity) => implemented.has(identity))) {
+    throw new Error(`Operation appears as both implemented and missing for mapping ${mapping.id}`);
+  }
+
+  const accountedCount =
+    mapping.implementedOperationIdentities.length + mapping.missingOperationIdentities.length;
+  if (accountedCount !== mapping.publicOperationCount) {
+    throw new Error(
+      `Mapping ${mapping.id} accounts for ${accountedCount} of ${mapping.publicOperationCount} public operations`,
+    );
+  }
+  if (mapping.classification === 'complete' && mapping.missingOperationIdentities.length > 0) {
+    throw new Error(`Complete mapping ${mapping.id} has missing operations`);
+  }
+  if (mapping.classification === 'partial' && mapping.missingOperationIdentities.length === 0) {
+    throw new Error(`Partial mapping ${mapping.id} must have a missing operation`);
+  }
+  if (
+    (mapping.classification === 'excluded' || mapping.classification === 'blocked') &&
+    !mapping.rationale?.trim()
+  ) {
+    throw new Error(`${mapping.classification} mapping ${mapping.id} requires a rationale`);
+  }
+}
+
+function calculateStateHash(mapping: ApiCoverageMapping): string {
+  const canonical = JSON.stringify({
+    domain: HASH_DOMAIN,
+    id: mapping.id,
+    classification: mapping.classification,
+    publicOperationCount: mapping.publicOperationCount,
+    implemented: [...mapping.implementedOperationIdentities].sort(compareText),
+    missing: [...mapping.missingOperationIdentities].sort(compareText),
+    rationale: mapping.rationale,
+  });
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export function calculateApiCoverage(mappings: readonly ApiCoverageMapping[]): ApiCoverageResult[] {
+  const ids = new Set<string>();
+  return mappings
+    .map((mapping) => {
+      if (ids.has(mapping.id)) throw new Error(`Duplicate API coverage mapping id: ${mapping.id}`);
+      ids.add(mapping.id);
+      validateMapping(mapping);
+      return {
+        ...mapping,
+        implementedOperationIdentities: [...mapping.implementedOperationIdentities].sort(
+          compareText,
+        ),
+        missingOperationIdentities: [...mapping.missingOperationIdentities].sort(compareText),
+        implementedCount: mapping.implementedOperationIdentities.length,
+        missingCount: mapping.missingOperationIdentities.length,
+        stateHash: calculateStateHash(mapping),
+      };
+    })
+    .sort((left, right) => compareText(left.id, right.id));
+}
+
+export function toApiCoverageBaseline(results: readonly ApiCoverageResult[]): ApiCoverageBaseline {
+  return {
+    formatVersion: 1,
+    records: [...results]
+      .sort((left, right) => compareText(left.id, right.id))
+      .map(
+        ({
+          id,
+          classification,
+          publicOperationCount,
+          implementedCount,
+          missingCount,
+          stateHash,
+          rationale,
+        }) => ({
+          id,
+          classification,
+          publicOperationCount,
+          implementedCount,
+          missingCount,
+          stateHash,
+          ...(rationale ? { rationale } : {}),
+        }),
+      ),
+  };
+}
+
+export function compareApiCoverageBaselines(
+  expected: ApiCoverageBaseline,
+  current: ApiCoverageBaseline,
+): ApiCoverageComparison {
+  const expectedRecords = new Map(expected.records.map((record) => [record.id, record]));
+  const currentRecords = new Map(current.records.map((record) => [record.id, record]));
+  const ids = new Set([...expectedRecords.keys(), ...currentRecords.keys()]);
+  const changedMappingIds = [...ids]
+    .filter(
+      (id) => JSON.stringify(expectedRecords.get(id)) !== JSON.stringify(currentRecords.get(id)),
+    )
+    .sort(compareText);
+  if (expected.formatVersion !== current.formatVersion) changedMappingIds.unshift('$format');
+  return { matches: changedMappingIds.length === 0, changedMappingIds };
+}
+
+export function formatApiCoverageSummary(
+  results: readonly ApiCoverageResult[],
+  comparison?: ApiCoverageComparison,
+): string {
+  const status = comparison ? (comparison.matches ? 'ok' : 'drift') : 'generated';
+  const lines = [`API coverage: ${status}`];
+  for (const result of results) {
+    lines.push(
+      `${result.id}: ${result.classification} public=${result.publicOperationCount} implemented=${result.implementedCount} missing=${result.missingCount} state=${result.stateHash}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatApiCoverageDetails(results: readonly ApiCoverageResult[]): string {
+  const lines: string[] = [];
+  for (const result of results) {
+    lines.push(`${result.id}:`);
+    const identities = [...result.missingOperationIdentities].sort(compareText);
+    lines.push(
+      ...(identities.length
+        ? identities.map((identity) => `  - ${JSON.stringify(identity)}`)
+        : ['  (none)']),
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/src/api-coverage.ts
+++ b/src/api-coverage.ts
@@ -10,14 +10,22 @@ export interface ApiCoverageMapping {
   publicOperationCount: number;
   implementedOperationIdentities: readonly string[];
   missingOperationIdentities: readonly string[];
+  excludedOperationIdentities?: readonly string[];
+  evidence?: {
+    operationExports: readonly string[];
+    mcpTools: readonly string[];
+    cliCommands: readonly (readonly string[])[];
+  };
   rationale?: string;
 }
 
 export interface ApiCoverageResult extends ApiCoverageMapping {
   implementedOperationIdentities: string[];
   missingOperationIdentities: string[];
+  excludedOperationIdentities: string[];
   implementedCount: number;
   missingCount: number;
+  excludedCount: number;
   stateHash: string;
 }
 
@@ -27,6 +35,7 @@ export interface ApiCoverageBaselineRecord {
   publicOperationCount: number;
   implementedCount: number;
   missingCount: number;
+  excludedCount: number;
   stateHash: string;
   rationale?: string;
 }
@@ -59,13 +68,30 @@ function validateMapping(mapping: ApiCoverageMapping): void {
 
   assertUnique(mapping.implementedOperationIdentities, 'implemented', mapping.id);
   assertUnique(mapping.missingOperationIdentities, 'missing', mapping.id);
+  assertUnique(mapping.excludedOperationIdentities ?? [], 'excluded', mapping.id);
+  if (mapping.evidence) {
+    assertUnique(mapping.evidence.operationExports, 'operation-export evidence', mapping.id);
+    assertUnique(mapping.evidence.mcpTools, 'MCP-tool evidence', mapping.id);
+    assertUnique(
+      mapping.evidence.cliCommands.map((command) => JSON.stringify(command)),
+      'CLI-command evidence',
+      mapping.id,
+    );
+  }
   const implemented = new Set(mapping.implementedOperationIdentities);
   if (mapping.missingOperationIdentities.some((identity) => implemented.has(identity))) {
     throw new Error(`Operation appears as both implemented and missing for mapping ${mapping.id}`);
   }
+  const missing = new Set(mapping.missingOperationIdentities);
+  const excluded = mapping.excludedOperationIdentities ?? [];
+  if (excluded.some((identity) => implemented.has(identity) || missing.has(identity))) {
+    throw new Error(`Operation has more than one coverage state for mapping ${mapping.id}`);
+  }
 
   const accountedCount =
-    mapping.implementedOperationIdentities.length + mapping.missingOperationIdentities.length;
+    mapping.implementedOperationIdentities.length +
+    mapping.missingOperationIdentities.length +
+    excluded.length;
   if (accountedCount !== mapping.publicOperationCount) {
     throw new Error(
       `Mapping ${mapping.id} accounts for ${accountedCount} of ${mapping.publicOperationCount} public operations`,
@@ -78,7 +104,17 @@ function validateMapping(mapping: ApiCoverageMapping): void {
     throw new Error(`Partial mapping ${mapping.id} must have a missing operation`);
   }
   if (
-    (mapping.classification === 'excluded' || mapping.classification === 'blocked') &&
+    mapping.implementedOperationIdentities.length > 0 &&
+    (!mapping.evidence?.operationExports.length ||
+      !mapping.evidence.mcpTools.length ||
+      !mapping.evidence.cliCommands.length)
+  ) {
+    throw new Error(`Implemented mapping ${mapping.id} requires export, MCP, and CLI evidence`);
+  }
+  if (
+    (mapping.classification === 'excluded' ||
+      mapping.classification === 'blocked' ||
+      excluded.length > 0) &&
     !mapping.rationale?.trim()
   ) {
     throw new Error(`${mapping.classification} mapping ${mapping.id} requires a rationale`);
@@ -93,6 +129,16 @@ function calculateStateHash(mapping: ApiCoverageMapping): string {
     publicOperationCount: mapping.publicOperationCount,
     implemented: [...mapping.implementedOperationIdentities].sort(compareText),
     missing: [...mapping.missingOperationIdentities].sort(compareText),
+    excluded: [...(mapping.excludedOperationIdentities ?? [])].sort(compareText),
+    evidence: mapping.evidence
+      ? {
+          operationExports: [...mapping.evidence.operationExports].sort(compareText),
+          mcpTools: [...mapping.evidence.mcpTools].sort(compareText),
+          cliCommands: mapping.evidence.cliCommands
+            .map((command) => [...command])
+            .sort((left, right) => compareText(JSON.stringify(left), JSON.stringify(right))),
+        }
+      : undefined,
     rationale: mapping.rationale,
   });
   return createHash('sha256').update(canonical).digest('hex');
@@ -111,8 +157,12 @@ export function calculateApiCoverage(mappings: readonly ApiCoverageMapping[]): A
           compareText,
         ),
         missingOperationIdentities: [...mapping.missingOperationIdentities].sort(compareText),
+        excludedOperationIdentities: [...(mapping.excludedOperationIdentities ?? [])].sort(
+          compareText,
+        ),
         implementedCount: mapping.implementedOperationIdentities.length,
         missingCount: mapping.missingOperationIdentities.length,
+        excludedCount: mapping.excludedOperationIdentities?.length ?? 0,
         stateHash: calculateStateHash(mapping),
       };
     })
@@ -131,6 +181,7 @@ export function toApiCoverageBaseline(results: readonly ApiCoverageResult[]): Ap
           publicOperationCount,
           implementedCount,
           missingCount,
+          excludedCount,
           stateHash,
           rationale,
         }) => ({
@@ -139,6 +190,7 @@ export function toApiCoverageBaseline(results: readonly ApiCoverageResult[]): Ap
           publicOperationCount,
           implementedCount,
           missingCount,
+          excludedCount,
           stateHash,
           ...(rationale ? { rationale } : {}),
         }),
@@ -167,11 +219,31 @@ export function formatApiCoverageSummary(
   comparison?: ApiCoverageComparison,
 ): string {
   const status = comparison ? (comparison.matches ? 'ok' : 'drift') : 'generated';
-  const lines = [`API coverage: ${status}`];
-  for (const result of results) {
-    lines.push(
-      `${result.id}: ${result.classification} public=${result.publicOperationCount} implemented=${result.implementedCount} missing=${result.missingCount} state=${result.stateHash}`,
-    );
+  const totals = results.reduce(
+    (value, result) => ({
+      ...value,
+      [result.classification]: value[result.classification] + 1,
+      public: value.public + result.publicOperationCount,
+      implemented: value.implemented + result.implementedCount,
+      excludedOperations: value.excludedOperations + result.excludedCount,
+      missing: value.missing + result.missingCount,
+    }),
+    {
+      complete: 0,
+      partial: 0,
+      excluded: 0,
+      blocked: 0,
+      public: 0,
+      implemented: 0,
+      excludedOperations: 0,
+      missing: 0,
+    },
+  );
+  const lines = [
+    `API coverage: ${status} families=${results.length} complete=${totals.complete} partial=${totals.partial} excluded=${totals.excluded} blocked=${totals.blocked} public=${totals.public} implemented=${totals.implemented} excluded-operations=${totals.excludedOperations} missing=${totals.missing}`,
+  ];
+  if (comparison && !comparison.matches) {
+    lines.push(`Changed mappings: ${comparison.changedMappingIds.join(', ')}`);
   }
   return `${lines.join('\n')}\n`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1885,7 +1885,7 @@ customers
     'after',
     `
 Examples:
-  echo '{"Email":"new@acme.se","Phone":"08-123456"}' | noxctl customers update 25 --input - --yes`,
+  echo '{"Email":"new@acme.se","Phone1":"08-123456"}' | noxctl customers update 25 --input - --yes`,
   )
   .action(
     async (customerNumber: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1807,6 +1807,71 @@ accounts
     outputList(data.Accounts ?? [], accountListColumns, json(), data, data.MetaInformation);
   });
 
+accounts
+  .command('get <number>')
+  .description('Get one account')
+  .action(async (number: string) => {
+    const { getAccount } = await import('./operations/accounts.js');
+    const data = await getAccount(Number(number));
+    outputDetail(data, accountListColumns, json(), 'Account');
+  });
+
+accounts
+  .command('create')
+  .description('Create an account')
+  .requiredOption('--number <number>', 'Account number', parseInt)
+  .requiredOption('--description <text>', 'Account description')
+  .option('--input <file>', 'Additional account data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (opts) => {
+    const { createAccount } = await import('./operations/accounts.js');
+    const extra = opts.input
+      ? (JSON.parse(
+          opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8'),
+        ) as Record<string, unknown>)
+      : {};
+    const fields = { ...extra, Number: opts.number, Description: opts.description };
+    if (!(await confirmMutation(`Create account ${opts.number}`, opts, { Account: fields })))
+      return;
+    const data = await createAccount(fields);
+    outputDetail(data, accountListColumns, json(), 'Account');
+  });
+
+accounts
+  .command('update <number>')
+  .description('Update an account')
+  .requiredOption('--input <file>', 'Account data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (number: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateAccount } = await import('./operations/accounts.js');
+    const fields = JSON.parse(
+      opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8'),
+    ) as Record<string, unknown>;
+    if (!(await confirmMutation(`Update account ${number}`, opts, { Account: fields }))) return;
+    const data = await updateAccount(Number(number), fields);
+    outputDetail(data, accountListColumns, json(), 'Account');
+  });
+
+accounts
+  .command('delete <number>')
+  .description('Delete an account')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (number: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { deleteAccount } = await import('./operations/accounts.js');
+    if (!(await confirmMutation(`Delete account ${number}`, opts))) return;
+    await deleteAccount(Number(number));
+    outputConfirmation(
+      `Account ${number} deleted.`,
+      json(),
+      { Number: Number(number), deleted: true },
+      undefined,
+      'Account',
+    );
+  });
+
 // --- customers ---
 const customers = program.command('customers').description('Customer operations');
 
@@ -1903,6 +1968,24 @@ Examples:
     },
   );
 
+customers
+  .command('delete <customerNumber>')
+  .description('Delete a customer')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (customerNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { deleteCustomer } = await import('./operations/customers.js');
+    if (!(await confirmMutation(`Delete customer ${customerNumber}`, opts))) return;
+    await deleteCustomer(customerNumber);
+    outputConfirmation(
+      `Customer ${customerNumber} deleted.`,
+      json(),
+      { CustomerNumber: customerNumber, deleted: true },
+      undefined,
+      'Customer',
+    );
+  });
+
 // --- articles ---
 const articles = program.command('articles').description('Article operations');
 
@@ -1994,6 +2077,24 @@ Examples:
       outputDetail(data as Record<string, unknown>, articleDetailColumns, json(), 'Article');
     },
   );
+
+articles
+  .command('delete <articleNumber>')
+  .description('Delete an article')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (articleNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { deleteArticle } = await import('./operations/articles.js');
+    if (!(await confirmMutation(`Delete article ${articleNumber}`, opts))) return;
+    await deleteArticle(articleNumber);
+    outputConfirmation(
+      `Article ${articleNumber} deleted.`,
+      json(),
+      { ArticleNumber: articleNumber, deleted: true },
+      undefined,
+      'Article',
+    );
+  });
 
 // --- suppliers ---
 const suppliers = program.command('suppliers').description('Supplier operations');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ import {
   supplierInvoiceListColumns,
   supplierInvoiceDetailColumns,
   supplierInvoiceConfirmColumns,
+  supplierInvoiceAttachmentColumns,
   invoicePaymentListColumns,
   invoicePaymentDetailColumns,
   supplierInvoicePaymentListColumns,
@@ -2201,6 +2202,78 @@ supplierInvoices
       data,
       supplierInvoiceConfirmColumns,
       'SupplierInvoice',
+    );
+  });
+
+supplierInvoices
+  .command('attachments <givenNumber>')
+  .description(
+    'List files (e.g. the scanned/received invoice) attached to a supplier invoice — works for unbooked/authorizepending invoices too',
+  )
+  .action(async (givenNumber: string) => {
+    const { listSupplierInvoiceAttachments } = await import('./operations/supplier-invoices.js');
+    const attachments = await listSupplierInvoiceAttachments(givenNumber);
+    if (json()) {
+      console.log(JSON.stringify({ Attachments: attachments }, null, 2));
+    } else {
+      outputList(
+        attachments as unknown as Record<string, unknown>[],
+        supplierInvoiceAttachmentColumns,
+        false,
+        attachments,
+      );
+    }
+  });
+
+supplierInvoices
+  .command('file <fileId>')
+  .description(
+    'Download a file attached to a supplier invoice (get the fileId from "supplier-invoices attachments")',
+  )
+  .option(
+    '-f, --file <path>',
+    'Write the file here (- for stdout; default: supplier-invoice-file-<fileId><ext>)',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  noxctl supplier-invoices attachments 1
+  noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63
+  noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63 --file invoice-scan.pdf`,
+  )
+  .action(async (fileId: string, opts: { file?: string }) => {
+    const { getSupplierInvoiceFile } = await import('./operations/supplier-invoices.js');
+    const { extensionForMime } = await import('./operations/vouchers.js');
+    const toStdout = opts.file === '-';
+
+    if (toStdout && program.opts().output === 'json') {
+      throw new Error(
+        '--file - writes raw file bytes to stdout and cannot be combined with --output json.',
+      );
+    }
+
+    const file = await getSupplierInvoiceFile(fileId);
+
+    if (toStdout) {
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(file.buffer, (err) => (err ? reject(err) : resolve()));
+      });
+      return;
+    }
+
+    const path =
+      opts.file ?? `supplier-invoice-file-${fileId}${extensionForMime(file.contentType)}`;
+    writeFileSync(path, file.buffer);
+    outputConfirmation(
+      `File saved to ${path} (${file.contentType}, ${file.buffer.length} bytes).`,
+      json(),
+      {
+        FileId: fileId,
+        Path: path,
+        ContentType: file.contentType,
+        Bytes: file.buffer.length,
+      },
     );
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,8 +52,10 @@ import {
   supplierInvoicePaymentDetailColumns,
   offerListColumns,
   offerDetailColumns,
+  offerConfirmColumns,
   orderListColumns,
   orderDetailColumns,
+  orderConfirmColumns,
   projectListColumns,
   projectDetailColumns,
   costCenterListColumns,
@@ -85,6 +87,7 @@ import {
   absenceTransactionListColumns,
   absenceTransactionDetailColumns,
   scheduleTimeDetailColumns,
+  referenceDataColumns,
 } from './views.js';
 
 const program = new Command();
@@ -1468,6 +1471,65 @@ invoices
     },
   );
 
+for (const action of [
+  { command: 'cancel', label: 'Cancel', exportName: 'cancelInvoice' },
+  { command: 'eprint', label: 'Send via e-print', exportName: 'eprintInvoice' },
+  {
+    command: 'external-print',
+    label: 'Mark as externally printed',
+    exportName: 'externalPrintInvoice',
+  },
+] as const) {
+  invoices
+    .command(`${action.command} <documentNumber>`)
+    .description(`${action.label} an invoice`)
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the action without sending it')
+    .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+      const operations = await import('./operations/invoices.js');
+      if (!(await confirmMutation(`${action.label} invoice ${documentNumber}`, opts))) return;
+      const data = await operations[action.exportName](documentNumber);
+      outputConfirmation(
+        `Invoice ${documentNumber}: ${action.command} completed.`,
+        json(),
+        data,
+        invoiceConfirmColumns,
+        'Invoice',
+      );
+    });
+}
+
+invoices
+  .command('reminder-pdf <documentNumber>')
+  .description('Print an invoice reminder and save the returned PDF')
+  .option('-f, --file <path>', 'Write the PDF here')
+  .option('--overwrite', 'Allow replacing an existing regular file')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts) => {
+    const { getInvoiceReminderPdf } = await import('./operations/invoices.js');
+    if (!(await confirmMutation(`Print reminder for invoice ${documentNumber}`, opts))) return;
+    const pdf = await getInvoiceReminderPdf(documentNumber);
+    if (!pdf) {
+      outputConfirmation(
+        `Invoice reminder ${documentNumber} printed without a PDF response.`,
+        json(),
+        {},
+      );
+      return;
+    }
+    const { writeBinaryFile } = await import('./safe-file-output.js');
+    const path = writeBinaryFile(
+      opts.file ?? `invoice-reminder-${documentNumber}.pdf`,
+      pdf,
+      opts.overwrite,
+    );
+    outputConfirmation(`Invoice reminder saved to ${path}.`, json(), {
+      Path: path,
+      Bytes: pdf.length,
+    });
+  });
+
 invoices
   .command('pdf <documentNumber>')
   .description('Download an invoice as a PDF')
@@ -2307,6 +2369,59 @@ supplierInvoices
   });
 
 supplierInvoices
+  .command('update <givenNumber>')
+  .description('Update a supplier invoice')
+  .requiredOption('--input <file>', 'Invoice data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (givenNumber: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateSupplierInvoice } = await import('./operations/supplier-invoices.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      !(await confirmMutation(`Update supplier invoice ${givenNumber}`, opts, {
+        SupplierInvoice: fields,
+      }))
+    )
+      return;
+    const data = await updateSupplierInvoice(givenNumber, fields);
+    outputDetail(data, supplierInvoiceDetailColumns, json(), 'SupplierInvoice');
+  });
+
+for (const action of [
+  {
+    command: 'approval-bookkeep',
+    label: 'Approval-bookkeep',
+    exportName: 'approvalBookkeepSupplierInvoice',
+  },
+  {
+    command: 'approval-payment',
+    label: 'Payment-approve',
+    exportName: 'approvalPaymentSupplierInvoice',
+  },
+  { command: 'cancel', label: 'Cancel', exportName: 'cancelSupplierInvoice' },
+  { command: 'credit', label: 'Credit', exportName: 'creditSupplierInvoice' },
+] as const) {
+  supplierInvoices
+    .command(`${action.command} <givenNumber>`)
+    .description(`${action.label} a supplier invoice`)
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the action without sending it')
+    .action(async (givenNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+      const operations = await import('./operations/supplier-invoices.js');
+      if (!(await confirmMutation(`${action.label} supplier invoice ${givenNumber}`, opts))) return;
+      const data = await operations[action.exportName](givenNumber);
+      outputConfirmation(
+        `Supplier invoice ${givenNumber}: ${action.command} completed.`,
+        json(),
+        data,
+        supplierInvoiceConfirmColumns,
+        'SupplierInvoice',
+      );
+    });
+}
+
+supplierInvoices
   .command('attachments <givenNumber>')
   .description(
     'List files (e.g. the scanned/received invoice) attached to a supplier invoice — works for unbooked/authorizepending invoices too',
@@ -2595,6 +2710,71 @@ Examples:
     );
   });
 
+vouchers
+  .command('connection <fileId>')
+  .description('Get voucher file-connection metadata')
+  .action(async (fileId: string) => {
+    const { getVoucherFileConnection } = await import('./operations/vouchers.js');
+    const result = await getVoucherFileConnection(fileId);
+    outputDetail(result, voucherAttachmentColumns, json(), 'VoucherFileConnection');
+  });
+vouchers
+  .command('detach <fileId>')
+  .description('Detach a file from its voucher')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without detaching')
+  .action(async (fileId: string, opts) => {
+    const { deleteVoucherFileConnection } = await import('./operations/vouchers.js');
+    if (!(await confirmMutation(`Delete voucher file connection ${fileId}`, opts))) return;
+    await deleteVoucherFileConnection(fileId);
+    outputConfirmation(`Voucher file connection ${fileId} deleted.`, json(), {
+      FileId: fileId,
+      detached: true,
+    });
+  });
+
+supplierInvoices
+  .command('connection <fileId>')
+  .description('Get supplier-invoice file-connection metadata')
+  .action(async (fileId: string) => {
+    const { getSupplierInvoiceFileConnection } = await import('./operations/supplier-invoices.js');
+    const result = await getSupplierInvoiceFileConnection(fileId);
+    outputDetail(result, supplierInvoiceAttachmentColumns, json(), 'SupplierInvoiceFileConnection');
+  });
+supplierInvoices
+  .command('connect-file <givenNumber> <fileId>')
+  .description('Connect an existing inbox file to a supplier invoice')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview exact payload')
+  .action(async (givenNumber: string, fileId: string, opts) => {
+    const payload = { SupplierInvoiceNumber: givenNumber, FileId: fileId };
+    if (
+      !(await confirmMutation(`Connect file ${fileId} to supplier invoice ${givenNumber}`, opts, {
+        SupplierInvoiceFileConnection: payload,
+      }))
+    )
+      return;
+    const { createSupplierInvoiceFileConnection } =
+      await import('./operations/supplier-invoices.js');
+    const result = await createSupplierInvoiceFileConnection(givenNumber, fileId);
+    outputDetail(result, supplierInvoiceAttachmentColumns, json(), 'SupplierInvoiceFileConnection');
+  });
+supplierInvoices
+  .command('detach-file <fileId>')
+  .description('Detach a file from a supplier invoice')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without detaching')
+  .action(async (fileId: string, opts) => {
+    const { deleteSupplierInvoiceFileConnection } =
+      await import('./operations/supplier-invoices.js');
+    if (!(await confirmMutation(`Delete supplier invoice file connection ${fileId}`, opts))) return;
+    await deleteSupplierInvoiceFileConnection(fileId);
+    outputConfirmation(`Supplier invoice file connection ${fileId} deleted.`, json(), {
+      FileId: fileId,
+      detached: true,
+    });
+  });
+
 // --- invoice-payments ---
 const invoicePayments = program
   .command('invoice-payments')
@@ -2725,6 +2905,28 @@ invoicePayments
     );
   });
 
+invoicePayments
+  .command('update <paymentNumber>')
+  .description('Update an invoice payment')
+  .requiredOption('--input <file>', 'Payment data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(
+    async (paymentNumber: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+      const { updateInvoicePayment } = await import('./operations/invoice-payments.js');
+      const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+      const fields = JSON.parse(raw) as Record<string, unknown>;
+      if (
+        !(await confirmMutation(`Update invoice payment ${paymentNumber}`, opts, {
+          InvoicePayment: fields,
+        }))
+      )
+        return;
+      const data = await updateInvoicePayment(paymentNumber, fields);
+      outputDetail(data, invoicePaymentDetailColumns, json(), 'InvoicePayment');
+    },
+  );
+
 // --- supplier-invoice-payments ---
 const supplierInvoicePayments = program
   .command('supplier-invoice-payments')
@@ -2831,6 +3033,49 @@ supplierInvoicePayments
       `Supplier invoice payment ${paymentNumber} deleted.`,
       json(),
       { Number: paymentNumber, deleted: true },
+      undefined,
+      'SupplierInvoicePayment',
+    );
+  });
+
+supplierInvoicePayments
+  .command('update <paymentNumber>')
+  .description('Update a supplier invoice payment')
+  .requiredOption('--input <file>', 'Payment data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(
+    async (paymentNumber: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+      const { updateSupplierInvoicePayment } =
+        await import('./operations/supplier-invoice-payments.js');
+      const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+      const fields = JSON.parse(raw) as Record<string, unknown>;
+      if (
+        !(await confirmMutation(`Update supplier invoice payment ${paymentNumber}`, opts, {
+          SupplierInvoicePayment: fields,
+        }))
+      )
+        return;
+      const data = await updateSupplierInvoicePayment(paymentNumber, fields);
+      outputDetail(data, supplierInvoicePaymentDetailColumns, json(), 'SupplierInvoicePayment');
+    },
+  );
+
+supplierInvoicePayments
+  .command('bookkeep <paymentNumber>')
+  .description('Bookkeep a supplier invoice payment')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (paymentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { bookkeepSupplierInvoicePayment } =
+      await import('./operations/supplier-invoice-payments.js');
+    if (!(await confirmMutation(`Bookkeep supplier invoice payment ${paymentNumber}`, opts)))
+      return;
+    const data = await bookkeepSupplierInvoicePayment(paymentNumber);
+    outputConfirmation(
+      `Supplier invoice payment ${paymentNumber} bookkeept.`,
+      json(),
+      data,
       undefined,
       'SupplierInvoicePayment',
     );
@@ -2967,6 +3212,62 @@ offers
     );
   });
 
+for (const action of [
+  { command: 'cancel', label: 'Cancel', exportName: 'cancelOffer' },
+  { command: 'email', label: 'Email', exportName: 'emailOffer' },
+  {
+    command: 'external-print',
+    label: 'Mark as externally printed',
+    exportName: 'externalPrintOffer',
+  },
+] as const) {
+  offers
+    .command(`${action.command} <documentNumber>`)
+    .description(`${action.label} an offer`)
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the action without sending it')
+    .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+      const operations = await import('./operations/offers.js');
+      if (!(await confirmMutation(`${action.label} offer ${documentNumber}`, opts))) return;
+      const data = await operations[action.exportName](documentNumber);
+      outputConfirmation(
+        `Offer ${documentNumber}: ${action.command} completed.`,
+        json(),
+        data,
+        offerConfirmColumns,
+        'Offer',
+      );
+    });
+}
+
+offers
+  .command('pdf <documentNumber>')
+  .description('Download or print an offer as PDF')
+  .option('-f, --file <path>', 'Write the PDF here')
+  .option('--print', 'Use the state-changing Fortnox print action')
+  .option('--overwrite', 'Allow replacing an existing regular file')
+  .option('-y, --yes', 'Skip confirmation prompt (required with --print)')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts) => {
+    const mode = opts.print ? 'print' : 'preview';
+    if (opts.print || opts.dryRun) {
+      if (!(await confirmMutation(`${mode} offer ${documentNumber} as PDF`, opts))) return;
+    }
+    const { getOfferPdf } = await import('./operations/offers.js');
+    const pdf = await getOfferPdf(documentNumber, mode);
+    if (!pdf) {
+      outputConfirmation(`Offer ${documentNumber} printed without a PDF response.`, json(), {});
+      return;
+    }
+    const { writeBinaryFile } = await import('./safe-file-output.js');
+    const path = writeBinaryFile(opts.file ?? `offer-${documentNumber}.pdf`, pdf, opts.overwrite);
+    outputConfirmation(`Offer PDF saved to ${path}.`, json(), {
+      Path: path,
+      Bytes: pdf.length,
+      Mode: mode,
+    });
+  });
+
 // --- orders ---
 const orders = program.command('orders').description('Order operations (ordrar)');
 
@@ -3078,6 +3379,62 @@ orders
     );
   });
 
+for (const action of [
+  { command: 'cancel', label: 'Cancel', exportName: 'cancelOrder' },
+  { command: 'email', label: 'Email', exportName: 'emailOrder' },
+  {
+    command: 'external-print',
+    label: 'Mark as externally printed',
+    exportName: 'externalPrintOrder',
+  },
+] as const) {
+  orders
+    .command(`${action.command} <documentNumber>`)
+    .description(`${action.label} an order`)
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the action without sending it')
+    .action(async (documentNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+      const operations = await import('./operations/orders.js');
+      if (!(await confirmMutation(`${action.label} order ${documentNumber}`, opts))) return;
+      const data = await operations[action.exportName](documentNumber);
+      outputConfirmation(
+        `Order ${documentNumber}: ${action.command} completed.`,
+        json(),
+        data,
+        orderConfirmColumns,
+        'Order',
+      );
+    });
+}
+
+orders
+  .command('pdf <documentNumber>')
+  .description('Download or print an order as PDF')
+  .option('-f, --file <path>', 'Write the PDF here')
+  .option('--print', 'Use the state-changing Fortnox print action')
+  .option('--overwrite', 'Allow replacing an existing regular file')
+  .option('-y, --yes', 'Skip confirmation prompt (required with --print)')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (documentNumber: string, opts) => {
+    const mode = opts.print ? 'print' : 'preview';
+    if (opts.print || opts.dryRun) {
+      if (!(await confirmMutation(`${mode} order ${documentNumber} as PDF`, opts))) return;
+    }
+    const { getOrderPdf } = await import('./operations/orders.js');
+    const pdf = await getOrderPdf(documentNumber, mode);
+    if (!pdf) {
+      outputConfirmation(`Order ${documentNumber} printed without a PDF response.`, json(), {});
+      return;
+    }
+    const { writeBinaryFile } = await import('./safe-file-output.js');
+    const path = writeBinaryFile(opts.file ?? `order-${documentNumber}.pdf`, pdf, opts.overwrite);
+    outputConfirmation(`Order PDF saved to ${path}.`, json(), {
+      Path: path,
+      Bytes: pdf.length,
+      Mode: mode,
+    });
+  });
+
 // --- projects ---
 const projects = program.command('projects').description('Project operations');
 
@@ -3156,6 +3513,21 @@ projects
       outputDetail(data as Record<string, unknown>, projectDetailColumns, json(), 'Project');
     },
   );
+
+projects
+  .command('delete <projectNumber>')
+  .description('Delete a project')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (projectNumber: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { deleteProject } = await import('./operations/projects.js');
+    if (!(await confirmMutation(`Delete project ${projectNumber}`, opts))) return;
+    await deleteProject(projectNumber);
+    outputConfirmation(`Project ${projectNumber} deleted.`, json(), {
+      ProjectNumber: projectNumber,
+      deleted: true,
+    });
+  });
 
 // --- cost centers ---
 const costcenters = program.command('costcenters').description('Cost center operations');
@@ -3477,6 +3849,26 @@ salarytransactions
     );
   });
 
+salarytransactions
+  .command('update <salaryRow>')
+  .description('Update a salary transaction')
+  .requiredOption('--input <file>', 'Transaction data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (salaryRow: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateSalaryTransaction } = await import('./operations/salarytransactions.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      !(await confirmMutation(`Update salary transaction ${salaryRow}`, opts, {
+        SalaryTransaction: fields,
+      }))
+    )
+      return;
+    const data = await updateSalaryTransaction(salaryRow, fields);
+    outputDetail(data, salaryTransactionDetailColumns, json(), 'SalaryTransaction');
+  });
+
 // --- attendance transactions (närvaro / Lön) ---
 const attendancetransactions = program
   .command('attendance-transactions')
@@ -3515,9 +3907,17 @@ attendancetransactions
 attendancetransactions
   .command('get <id>')
   .description('Get a single attendance transaction')
-  .action(async (id: string) => {
-    const { getAttendanceTransaction } = await import('./operations/attendancetransactions.js');
-    const data = await getAttendanceTransaction(id);
+  .option('--date <date>', 'Date for the composite Fortnox key (YYYY-MM-DD)')
+  .option('--code <code>', 'Cause code for the composite Fortnox key')
+  .action(async (id: string, opts: { date?: string; code?: string }) => {
+    const { getAttendanceTransaction, getAttendanceTransactionByDateCode } =
+      await import('./operations/attendancetransactions.js');
+    if ((opts.date && !opts.code) || (opts.code && !opts.date))
+      throw new Error('--date and --code must be supplied together');
+    const data =
+      opts.date && opts.code
+        ? await getAttendanceTransactionByDateCode(id, opts.date, opts.code)
+        : await getAttendanceTransaction(id);
     outputDetail(
       data as Record<string, unknown>,
       attendanceTransactionDetailColumns,
@@ -3586,6 +3986,26 @@ attendancetransactions
     );
   });
 
+attendancetransactions
+  .command('update <id>')
+  .description('Update an attendance transaction')
+  .requiredOption('--input <file>', 'Transaction data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (id: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateAttendanceTransaction } = await import('./operations/attendancetransactions.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      !(await confirmMutation(`Update attendance transaction ${id}`, opts, {
+        AttendanceTransaction: fields,
+      }))
+    )
+      return;
+    const data = await updateAttendanceTransaction(id, fields);
+    outputDetail(data, attendanceTransactionDetailColumns, json(), 'AttendanceTransaction');
+  });
+
 // --- absence transactions (frånvaro / Lön) ---
 const absencetransactions = program
   .command('absence-transactions')
@@ -3624,9 +4044,17 @@ absencetransactions
 absencetransactions
   .command('get <id>')
   .description('Get a single absence transaction')
-  .action(async (id: string) => {
-    const { getAbsenceTransaction } = await import('./operations/absencetransactions.js');
-    const data = await getAbsenceTransaction(id);
+  .option('--date <date>', 'Date for the composite Fortnox key (YYYY-MM-DD)')
+  .option('--code <code>', 'Cause code for the composite Fortnox key')
+  .action(async (id: string, opts: { date?: string; code?: string }) => {
+    const { getAbsenceTransaction, getAbsenceTransactionByDateCode } =
+      await import('./operations/absencetransactions.js');
+    if ((opts.date && !opts.code) || (opts.code && !opts.date))
+      throw new Error('--date and --code must be supplied together');
+    const data =
+      opts.date && opts.code
+        ? await getAbsenceTransactionByDateCode(id, opts.date, opts.code)
+        : await getAbsenceTransaction(id);
     outputDetail(
       data as Record<string, unknown>,
       absenceTransactionDetailColumns,
@@ -3695,6 +4123,26 @@ absencetransactions
       undefined,
       'AbsenceTransaction',
     );
+  });
+
+absencetransactions
+  .command('update <id>')
+  .description('Update an absence transaction')
+  .requiredOption('--input <file>', 'Transaction data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (id: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateAbsenceTransaction } = await import('./operations/absencetransactions.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      !(await confirmMutation(`Update absence transaction ${id}`, opts, {
+        AbsenceTransaction: fields,
+      }))
+    )
+      return;
+    const data = await updateAbsenceTransaction(id, fields);
+    outputDetail(data, absenceTransactionDetailColumns, json(), 'AbsenceTransaction');
   });
 
 // --- schedule times (schematider / Lön) ---
@@ -3873,6 +4321,35 @@ taxreductions
     );
   });
 
+taxreductions
+  .command('update <id>')
+  .description('Update a tax reduction')
+  .requiredOption('--input <file>', 'Tax reduction data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (id: string, opts: { input: string; yes?: boolean; dryRun?: boolean }) => {
+    const { updateTaxReduction } = await import('./operations/taxreductions.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    const numericId = parseInt(id, 10);
+    if (!(await confirmMutation(`Update tax reduction ${id}`, opts, { TaxReduction: fields })))
+      return;
+    const data = await updateTaxReduction(numericId, fields);
+    outputDetail(data, taxReductionDetailColumns, json(), 'TaxReduction');
+  });
+
+taxreductions
+  .command('delete <id>')
+  .description('Delete a tax reduction')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (id: string, opts: { yes?: boolean; dryRun?: boolean }) => {
+    const { deleteTaxReduction } = await import('./operations/taxreductions.js');
+    if (!(await confirmMutation(`Delete tax reduction ${id}`, opts))) return;
+    await deleteTaxReduction(parseInt(id, 10));
+    outputConfirmation(`Tax reduction ${id} deleted.`, json(), { Id: Number(id), deleted: true });
+  });
+
 // --- price lists ---
 const pricelists = program.command('pricelists').description('Price list operations');
 
@@ -3961,7 +4438,7 @@ const prices = program.command('prices').description('Price operations within pr
 prices
   .command('list')
   .description('List prices in a price list')
-  .requiredOption('--pricelist <code>', 'Price list code')
+  .option('--pricelist <code>', 'Price list code (omit to list all prices)')
   .option('--article <number>', 'Filter by article number')
   .option('--page <number>', 'Page number', parseInt)
   .option('--limit <number>', 'Results per page', parseInt)
@@ -3993,6 +4470,29 @@ prices
   });
 
 prices
+  .command('create')
+  .description('Create a price')
+  .requiredOption('--pricelist <code>', 'Price list code')
+  .requiredOption('--article <number>', 'Article number')
+  .requiredOption('--input <file>', 'Price data as JSON file (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (opts) => {
+    const { createPrice } = await import('./operations/pricelists.js');
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const input = JSON.parse(raw) as Record<string, unknown>;
+    const fields = { ...input, PriceList: opts.pricelist, ArticleNumber: opts.article };
+    if (
+      !(await confirmMutation(`Create price ${opts.pricelist}/${opts.article}`, opts, {
+        Price: fields,
+      }))
+    )
+      return;
+    const data = await createPrice(fields);
+    outputDetail(data, priceDetailColumns, json(), 'Price');
+  });
+
+prices
   .command('update')
   .description('Update a price')
   .requiredOption('--pricelist <code>', 'Price list code')
@@ -4014,6 +4514,22 @@ prices
     }
     const data = await updatePrice(opts.pricelist, opts.article, fields, opts.fromQuantity);
     outputDetail(data as Record<string, unknown>, priceDetailColumns, json(), 'Price');
+  });
+
+prices
+  .command('delete')
+  .description('Delete a quantity-aware price')
+  .requiredOption('--pricelist <code>', 'Price list code')
+  .requiredOption('--article <number>', 'Article number')
+  .requiredOption('--from-quantity <number>', 'From quantity', parseInt)
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the action without sending it')
+  .action(async (opts) => {
+    const { deletePrice } = await import('./operations/pricelists.js');
+    const target = `${opts.pricelist}/${opts.article}/${opts.fromQuantity}`;
+    if (!(await confirmMutation(`Delete price ${target}`, opts))) return;
+    await deletePrice(opts.pricelist, opts.article, opts.fromQuantity);
+    outputConfirmation(`Price ${target} deleted.`, json(), { deleted: true });
   });
 
 // --- contracts ---
@@ -4356,6 +4872,25 @@ financialYears
   });
 
 financialYears
+  .command('create')
+  .description('Create a financial year')
+  .requiredOption('--from <date>', 'Start date (YYYY-MM-DD)')
+  .requiredOption('--to <date>', 'End date (YYYY-MM-DD)')
+  .option('--accounting-method <method>', 'Accounting method (ACCRUAL or CASH)')
+  .option('--account-chart <type>', 'Account chart type')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview the request without sending it')
+  .action(async (opts) => {
+    const { createFinancialYear } = await import('./operations/financial-years.js');
+    const fields: Record<string, unknown> = { FromDate: opts.from, ToDate: opts.to };
+    if (opts.accountingMethod) fields.AccountingMethod = opts.accountingMethod;
+    if (opts.accountChart) fields.AccountChartType = opts.accountChart;
+    if (!(await confirmMutation('Create financial year', opts, { FinancialYear: fields }))) return;
+    const data = await createFinancialYear(fields);
+    outputDetail(data, financialYearDetailColumns, json(), 'FinancialYear');
+  });
+
+financialYears
   .command('locked-period')
   .description('Show the locked period (bokföring låst t.o.m.)')
   .action(async () => {
@@ -4371,6 +4906,434 @@ financialYears
     }
     outputDetail(data, lockedPeriodDetailColumns, false);
   });
+
+const archive = program.command('archive').description('Fortnox archive operations');
+archive
+  .command('list')
+  .option('--path <path>', 'Archive path')
+  .option('--file-id <id>', 'File ID')
+  .action(async (opts) => {
+    const { listArchive } = await import('./operations/files.js');
+    const raw = await listArchive({ path: opts.path, fileId: opts.fileId });
+    const folder = (raw.Folder ?? {}) as Record<string, unknown>;
+    const items = [
+      ...((folder.Folders ?? []) as Record<string, unknown>[]),
+      ...((folder.Files ?? []) as Record<string, unknown>[]),
+    ];
+    outputList(items, referenceDataColumns, json(), raw);
+  });
+archive
+  .command('get <id>')
+  .option('--path <path>', 'Archive path')
+  .option('--file-id <fileId>', 'File ID')
+  .action(async (id: string, opts) => {
+    const { getArchiveEntry } = await import('./operations/files.js');
+    const raw = await getArchiveEntry(id, opts);
+    outputDetail(
+      (raw.Folder ?? raw) as Record<string, unknown>,
+      referenceDataColumns,
+      json(),
+      'Archive',
+    );
+  });
+archive
+  .command('upload <file>')
+  .option('--folder-id <id>', 'Target folder ID')
+  .option('--path <path>', 'Target archive path')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without reading or uploading the file')
+  .action(async (file: string, opts) => {
+    const { uploadArchiveFile } = await import('./operations/files.js');
+    if (
+      !(await confirmMutation(`Upload ${file} to archive`, opts, {
+        folderId: opts.folderId,
+        path: opts.path,
+      }))
+    )
+      return;
+    const raw = await uploadArchiveFile(file, { folderId: opts.folderId, path: opts.path });
+    outputDetail(
+      (raw.File ?? raw) as Record<string, unknown>,
+      referenceDataColumns,
+      json(),
+      'File',
+    );
+  });
+archive
+  .command('delete-path <path>')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without deleting')
+  .action(async (path: string, opts) => {
+    const { deleteArchivePath } = await import('./operations/files.js');
+    if (!(await confirmMutation(`Delete archive path ${JSON.stringify(path)}`, opts))) return;
+    await deleteArchivePath(path);
+    outputConfirmation(`Archive path ${JSON.stringify(path)} deleted.`, json(), {
+      path,
+      deleted: true,
+    });
+  });
+archive
+  .command('delete <id>')
+  .option('--path <path>', 'Archive path')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without deleting')
+  .action(async (id: string, opts) => {
+    const { deleteArchiveEntry } = await import('./operations/files.js');
+    if (!(await confirmMutation(`Delete archive entry ${id}`, opts, { path: opts.path }))) return;
+    await deleteArchiveEntry(id, opts.path);
+    outputConfirmation(`Archive entry ${id} deleted.`, json(), { Id: id, deleted: true });
+  });
+
+const inbox = program.command('inbox').description('Fortnox inbox operations');
+inbox.command('list').action(async () => {
+  const { listInbox } = await import('./operations/files.js');
+  const raw = await listInbox();
+  const folder = (raw.Folder ?? {}) as Record<string, unknown>;
+  const items = [
+    ...((folder.Folders ?? []) as Record<string, unknown>[]),
+    ...((folder.Files ?? []) as Record<string, unknown>[]),
+  ];
+  outputList(items, referenceDataColumns, json(), raw);
+});
+inbox
+  .command('upload <file>')
+  .option('--folder-id <id>', 'Target folder ID')
+  .option('--path <path>', 'Target inbox path')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without reading or uploading the file')
+  .action(async (file: string, opts) => {
+    const { uploadInboxEntry } = await import('./operations/files.js');
+    if (
+      !(await confirmMutation(`Upload ${file} to inbox`, opts, {
+        folderId: opts.folderId,
+        path: opts.path,
+      }))
+    )
+      return;
+    const raw = await uploadInboxEntry(file, { folderId: opts.folderId, path: opts.path });
+    outputDetail(
+      (raw.File ?? raw) as Record<string, unknown>,
+      referenceDataColumns,
+      json(),
+      'File',
+    );
+  });
+inbox
+  .command('file <id>')
+  .option('-f, --file <path>', 'Write the file here')
+  .option('--overwrite', 'Allow replacing an existing regular file')
+  .action(async (id: string, opts) => {
+    const { getInboxFile } = await import('./operations/files.js');
+    const { writeBinaryFile } = await import('./safe-file-output.js');
+    const file = await getInboxFile(id);
+    const path = writeBinaryFile(opts.file ?? `inbox-${id}`, file.buffer, opts.overwrite);
+    outputConfirmation(`Inbox file ${id} saved to ${path}.`, json(), {
+      Path: path,
+      Bytes: file.buffer.length,
+    });
+  });
+inbox
+  .command('delete <id>')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without deleting')
+  .action(async (id: string, opts) => {
+    const { deleteInboxEntry } = await import('./operations/files.js');
+    if (!(await confirmMutation(`Delete inbox entry ${id}`, opts))) return;
+    await deleteInboxEntry(id);
+    outputConfirmation(`Inbox entry ${id} deleted.`, json(), { Id: id, deleted: true });
+  });
+
+const attachments = program
+  .command('attachments')
+  .description('Cross-document attachment operations');
+attachments
+  .command('attach <entityType> <documentNumber> <fileId>')
+  .option('--exclude-on-send', 'Do not include the attachment when the document is sent')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without attaching')
+  .action(async (entityType: string, documentNumber: string, fileId: string, opts) => {
+    if (!['F', 'OF', 'O', 'C'].includes(entityType))
+      throw new Error('entityType must be F, OF, O, or C');
+    const body = {
+      documentNumber,
+      entityType,
+      fileId,
+      includeOnSend: !opts.excludeOnSend,
+    };
+    if (
+      !(await confirmMutation(
+        `Attach archive file ${fileId} to ${entityType} ${documentNumber}`,
+        opts,
+        body,
+      ))
+    )
+      return;
+    const { createDocumentAttachment } = await import('./operations/invoices.js');
+    const result = await createDocumentAttachment(
+      documentNumber,
+      entityType as 'F' | 'OF' | 'O' | 'C',
+      fileId,
+      !opts.excludeOnSend,
+    );
+    outputDetail(result, invoiceAttachmentListColumns, json(), 'Attachment');
+  });
+attachments
+  .command('list <entityType> <documentNumber>')
+  .description('List attachments for OF (offer), O (order), or C (contract)')
+  .action(async (entityType: string, documentNumber: string) => {
+    if (!['OF', 'O', 'C'].includes(entityType)) throw new Error('entityType must be OF, O, or C');
+    const { listDocumentAttachments } = await import('./operations/invoices.js');
+    const rows = await listDocumentAttachments(documentNumber, entityType as 'OF' | 'O' | 'C');
+    outputList(rows, invoiceAttachmentListColumns, json(), rows);
+  });
+attachments
+  .command('counts <entityType> <entityIds...>')
+  .action(async (entityType: string, entityIds: string[]) => {
+    if (!['F', 'OF', 'O', 'C'].includes(entityType))
+      throw new Error('entityType must be F, OF, O, or C');
+    const { getAttachmentCounts } = await import('./operations/invoices.js');
+    const result = await getAttachmentCounts(
+      entityIds.map(Number),
+      entityType as 'F' | 'OF' | 'O' | 'C',
+    );
+    outputDetail(result, invoiceAttachmentListColumns, json(), 'AttachmentCounts');
+  });
+attachments
+  .command('validate')
+  .requiredOption('--input <file>', 'Attachment array as JSON (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview exact payload')
+  .action(async (opts) => {
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const rows = JSON.parse(raw) as Record<string, unknown>[];
+    if (!Array.isArray(rows)) throw new Error('Attachment input must be an array');
+    if (!(await confirmMutation('Validate attachments included on send', opts, rows))) return;
+    const { validateAttachmentsOnSend } = await import('./operations/invoices.js');
+    await validateAttachmentsOnSend(rows);
+    outputConfirmation('Attachment validation accepted.', json(), {});
+  });
+attachments
+  .command('update <attachmentId>')
+  .requiredOption('--input <file>', 'Attachment fields as JSON (or - for stdin)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview exact payload')
+  .action(async (attachmentId: string, opts) => {
+    const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+    const fields = JSON.parse(raw) as Record<string, unknown>;
+    if (!(await confirmMutation(`Update attachment ${attachmentId}`, opts, fields))) return;
+    const { updateDocumentAttachment } = await import('./operations/invoices.js');
+    const result = await updateDocumentAttachment(attachmentId, fields);
+    outputDetail(result, invoiceAttachmentListColumns, json(), 'Attachment');
+  });
+attachments
+  .command('detach <attachmentId>')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--dry-run', 'Preview without detaching')
+  .action(async (attachmentId: string, opts) => {
+    if (!(await confirmMutation(`Detach attachment ${attachmentId}`, opts))) return;
+    const { detachDocumentAttachment } = await import('./operations/invoices.js');
+    await detachDocumentAttachment(attachmentId);
+    outputConfirmation(`Attachment ${attachmentId} detached.`, json(), {
+      AttachmentId: attachmentId,
+      detached: true,
+    });
+  });
+
+const accrualResources = [
+  {
+    command: 'invoice-accruals',
+    envelope: 'InvoiceAccrual',
+    list: 'listInvoiceAccruals',
+    get: 'getInvoiceAccrual',
+    create: 'createInvoiceAccrual',
+    update: 'updateInvoiceAccrual',
+    delete: 'deleteInvoiceAccrual',
+  },
+  {
+    command: 'supplier-invoice-accruals',
+    envelope: 'SupplierInvoiceAccrual',
+    list: 'listSupplierInvoiceAccruals',
+    get: 'getSupplierInvoiceAccrual',
+    create: 'createSupplierInvoiceAccrual',
+    update: 'updateSupplierInvoiceAccrual',
+    delete: 'deleteSupplierInvoiceAccrual',
+  },
+  {
+    command: 'contract-accruals',
+    envelope: 'ContractAccrual',
+    list: 'listContractAccruals',
+    get: 'getContractAccrual',
+    create: 'createContractAccrual',
+    update: 'updateContractAccrual',
+    delete: 'deleteContractAccrual',
+  },
+] as const;
+
+for (const definition of accrualResources) {
+  const resource = program
+    .command(definition.command)
+    .description('Fortnox-native accrual operations');
+  resource.command('list').action(async () => {
+    const operations = await import('./operations/accruals.js');
+    const result = await operations[definition.list]();
+    outputList(
+      result.items,
+      referenceDataColumns,
+      json(),
+      result.raw,
+      result.raw.MetaInformation as Record<string, unknown> | undefined,
+    );
+  });
+  resource.command('get <documentNumber>').action(async (documentNumber: string) => {
+    const operations = await import('./operations/accruals.js');
+    const result = await operations[definition.get](documentNumber);
+    outputDetail(result, referenceDataColumns, json(), definition.envelope);
+  });
+  resource
+    .command('create')
+    .requiredOption('--input <file>', 'Complete accrual JSON data (or - for stdin)')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the exact payload without sending it')
+    .action(async (opts) => {
+      const operations = await import('./operations/accruals.js');
+      const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+      const fields = JSON.parse(raw) as Record<string, unknown>;
+      if (
+        !(await confirmMutation(`Create ${definition.command}`, opts, {
+          [definition.envelope]: fields,
+        }))
+      )
+        return;
+      const result = await operations[definition.create](fields);
+      outputDetail(result, referenceDataColumns, json(), definition.envelope);
+    });
+  resource
+    .command('update <documentNumber>')
+    .requiredOption('--input <file>', 'Complete accrual JSON data (or - for stdin)')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the exact payload without sending it')
+    .action(async (documentNumber: string, opts) => {
+      const operations = await import('./operations/accruals.js');
+      const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
+      const fields = JSON.parse(raw) as Record<string, unknown>;
+      if (
+        !(await confirmMutation(`Update ${definition.command} ${documentNumber}`, opts, {
+          [definition.envelope]: fields,
+        }))
+      )
+        return;
+      const result = await operations[definition.update](documentNumber, fields);
+      outputDetail(result, referenceDataColumns, json(), definition.envelope);
+    });
+  resource
+    .command('delete <documentNumber>')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--dry-run', 'Preview the action without sending it')
+    .action(async (documentNumber: string, opts) => {
+      const operations = await import('./operations/accruals.js');
+      if (!(await confirmMutation(`Delete ${definition.command} ${documentNumber}`, opts))) return;
+      await operations[definition.delete](documentNumber);
+      outputConfirmation(`${definition.envelope} ${documentNumber} deleted.`, json(), {
+        DocumentNumber: documentNumber,
+        deleted: true,
+      });
+    });
+}
+
+const referenceResources = [
+  {
+    command: 'currencies',
+    description: 'Currency reference data',
+    list: 'listCurrencies',
+    get: 'getCurrency',
+  },
+  { command: 'units', description: 'Unit reference data', list: 'listUnits', get: 'getUnit' },
+  {
+    command: 'modes-of-payments',
+    description: 'Payment mode reference data',
+    list: 'listModesOfPayments',
+    get: 'getModeOfPayment',
+  },
+  {
+    command: 'terms-of-deliveries',
+    description: 'Delivery term reference data',
+    list: 'listTermsOfDeliveries',
+    get: 'getTermOfDelivery',
+  },
+  {
+    command: 'terms-of-payments',
+    description: 'Payment term reference data',
+    list: 'listTermsOfPayments',
+    get: 'getTermOfPayment',
+  },
+  {
+    command: 'ways-of-delivery',
+    description: 'Delivery way reference data',
+    list: 'listWaysOfDelivery',
+    get: 'getWayOfDelivery',
+  },
+  {
+    command: 'voucher-series',
+    description: 'Voucher series setup data',
+    list: 'listVoucherSeries',
+    get: 'getVoucherSeries',
+  },
+  {
+    command: 'predefined-voucher-series',
+    description: 'Predefined voucher series',
+    list: 'listPredefinedVoucherSeries',
+    get: 'getPredefinedVoucherSeries',
+  },
+  {
+    command: 'account-charts',
+    description: 'Available account chart types',
+    list: 'listAccountCharts',
+  },
+  {
+    command: 'predefined-accounts',
+    description: 'Predefined account setup',
+    list: 'listPredefinedAccounts',
+    get: 'getPredefinedAccount',
+  },
+  {
+    command: 'customer-references',
+    description: 'Customer reference data',
+    list: 'listCustomerReferences',
+    get: 'getCustomerReference',
+  },
+] as const;
+
+for (const definition of referenceResources) {
+  const resource = program.command(definition.command).description(definition.description);
+  resource
+    .command('list')
+    .option('--page <number>', 'Page number', parseInt)
+    .option('--limit <number>', 'Results per page', parseInt)
+    .option('-a, --all', 'Fetch all pages')
+    .action(async (opts) => {
+      const operations = await import('./operations/reference-data.js');
+      const list = operations[definition.list];
+      const result = await list({ page: opts.page, limit: opts.limit, all: opts.all });
+      outputList(
+        result.items,
+        referenceDataColumns,
+        json(),
+        result.raw,
+        result.raw.MetaInformation as Record<string, unknown> | undefined,
+      );
+    });
+  if ('get' in definition) {
+    resource
+      .command('get <identifier>')
+      .description(`Get one ${definition.command} entry`)
+      .action(async (identifier: string) => {
+        const operations = await import('./operations/reference-data.js');
+        const get = operations[definition.get];
+        const result = await get(identifier);
+        outputDetail(result.item, referenceDataColumns, json(), definition.command);
+      });
+  }
+}
 
 // --- analytics ---
 const analytics = program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4926,15 +4926,23 @@ archive
   .command('get <id>')
   .option('--path <path>', 'Archive path')
   .option('--file-id <fileId>', 'File ID')
+  .option('-o, --output <file>', 'Output file (default: private temporary directory)')
+  .option('--overwrite', 'Overwrite an existing regular file')
   .action(async (id: string, opts) => {
     const { getArchiveEntry } = await import('./operations/files.js');
-    const raw = await getArchiveEntry(id, opts);
-    outputDetail(
-      (raw.Folder ?? raw) as Record<string, unknown>,
-      referenceDataColumns,
-      json(),
-      'Archive',
+    const { privateOutputPath, writeBinaryFile } = await import('./safe-file-output.js');
+    const file = await getArchiveEntry(id, { path: opts.path, fileId: opts.fileId });
+    const target = writeBinaryFile(
+      opts.output ?? privateOutputPath('noxctl-', `archive-${id}`),
+      file.buffer,
+      opts.overwrite,
     );
+    outputConfirmation(`Archive file ${id} saved to ${target}.`, json(), {
+      Id: id,
+      File: target,
+      Bytes: file.buffer.length,
+      ContentType: file.contentType,
+    });
   });
 archive
   .command('upload <file>')
@@ -5024,9 +5032,13 @@ inbox
   .option('--overwrite', 'Allow replacing an existing regular file')
   .action(async (id: string, opts) => {
     const { getInboxFile } = await import('./operations/files.js');
-    const { writeBinaryFile } = await import('./safe-file-output.js');
+    const { privateOutputPath, writeBinaryFile } = await import('./safe-file-output.js');
     const file = await getInboxFile(id);
-    const path = writeBinaryFile(opts.file ?? `inbox-${id}`, file.buffer, opts.overwrite);
+    const path = writeBinaryFile(
+      opts.file ?? privateOutputPath('noxctl-', `inbox-${id}`),
+      file.buffer,
+      opts.overwrite,
+    );
     outputConfirmation(`Inbox file ${id} saved to ${path}.`, json(), {
       Path: path,
       Bytes: file.buffer.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ import { registerSalaryTransactionTools } from './tools/salarytransactions.js';
 import { registerAttendanceTransactionTools } from './tools/attendancetransactions.js';
 import { registerAbsenceTransactionTools } from './tools/absencetransactions.js';
 import { registerScheduleTimeTools } from './tools/scheduletimes.js';
+import { registerReferenceDataTools } from './tools/reference-data.js';
+import { registerAccrualTools } from './tools/accruals.js';
+import { registerFileTools } from './tools/files.js';
 import { createStrictMcpServer } from './strict-mcp-server.js';
 
 export interface CreateServerOptions {
@@ -79,6 +82,9 @@ export function createServer(options: CreateServerOptions = {}): McpServer {
   registerAttendanceTransactionTools(server, operations);
   registerAbsenceTransactionTools(server, operations);
   registerScheduleTimeTools(server, operations);
+  registerReferenceDataTools(server, operations);
+  registerAccrualTools(server, operations);
+  registerFileTools(server, operations);
 
   return server;
 }

--- a/src/operations/absencetransactions.ts
+++ b/src/operations/absencetransactions.ts
@@ -51,6 +51,17 @@ export function createAbsenceTransactionOperations(transport: FortnoxTransport) 
     return data.AbsenceTransaction;
   }
 
+  async function getAbsenceTransactionByDateCode(
+    id: string,
+    date: string,
+    code: string,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<AbsenceTransactionResponse>(
+      `absencetransactions/${encodeURIComponent(id)}/${encodeURIComponent(date)}/${encodeURIComponent(code)}`,
+    );
+    return data.AbsenceTransaction;
+  }
+
   async function createAbsenceTransaction(
     params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
@@ -67,10 +78,23 @@ export function createAbsenceTransactionOperations(transport: FortnoxTransport) 
     });
   }
 
+  async function updateAbsenceTransaction(
+    id: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<AbsenceTransactionResponse>(
+      `absencetransactions/${encodeURIComponent(id)}`,
+      { method: 'PUT', body: { AbsenceTransaction: params } },
+    );
+    return data.AbsenceTransaction;
+  }
+
   return {
     listAbsenceTransactions,
     getAbsenceTransaction,
+    getAbsenceTransactionByDateCode,
     createAbsenceTransaction,
+    updateAbsenceTransaction,
     deleteAbsenceTransaction,
   };
 }
@@ -78,6 +102,8 @@ export function createAbsenceTransactionOperations(transport: FortnoxTransport) 
 export const {
   listAbsenceTransactions,
   getAbsenceTransaction,
+  getAbsenceTransactionByDateCode,
   createAbsenceTransaction,
+  updateAbsenceTransaction,
   deleteAbsenceTransaction,
 } = createAbsenceTransactionOperations(defaultFortnoxTransport);

--- a/src/operations/accounts.ts
+++ b/src/operations/accounts.ts
@@ -13,6 +13,10 @@ export interface ListAccountsParams {
   all?: boolean;
 }
 
+interface AccountResponse {
+  Account: Record<string, unknown>;
+}
+
 export function createAccountOperations(transport: FortnoxTransport) {
   async function listAccounts(params: ListAccountsParams = {}): Promise<AccountsResponse> {
     const queryParams: Record<string, string | number | undefined> = {
@@ -51,7 +55,37 @@ export function createAccountOperations(transport: FortnoxTransport) {
     return data;
   }
 
-  return { listAccounts };
+  async function getAccount(number: number): Promise<Record<string, unknown>> {
+    const data = await transport.request<AccountResponse>(`accounts/${number}`);
+    return data.Account;
+  }
+
+  async function createAccount(fields: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const data = await transport.request<AccountResponse>('accounts', {
+      method: 'POST',
+      body: { Account: fields },
+    });
+    return data.Account;
+  }
+
+  async function updateAccount(
+    number: number,
+    fields: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const { Number: _, ...body } = fields;
+    const data = await transport.request<AccountResponse>(`accounts/${number}`, {
+      method: 'PUT',
+      body: { Account: body },
+    });
+    return data.Account;
+  }
+
+  async function deleteAccount(number: number): Promise<void> {
+    await transport.request(`accounts/${number}`, { method: 'DELETE' });
+  }
+
+  return { listAccounts, getAccount, createAccount, updateAccount, deleteAccount };
 }
 
-export const { listAccounts } = createAccountOperations(defaultFortnoxTransport);
+export const { listAccounts, getAccount, createAccount, updateAccount, deleteAccount } =
+  createAccountOperations(defaultFortnoxTransport);

--- a/src/operations/accruals.ts
+++ b/src/operations/accruals.ts
@@ -1,0 +1,106 @@
+import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
+import { documentSegment } from '../identifiers.js';
+
+interface AccrualDefinition {
+  endpoint: string;
+  listKey: string;
+  singleKey: string;
+}
+
+function createAccrualResourceOperations(
+  transport: FortnoxTransport,
+  definition: AccrualDefinition,
+) {
+  async function list() {
+    const raw = await transport.request<Record<string, unknown>>(definition.endpoint);
+    return {
+      items: (raw[definition.listKey] ?? []) as Record<string, unknown>[],
+      raw,
+    };
+  }
+
+  async function get(documentNumber: string) {
+    const raw = await transport.request<Record<string, unknown>>(
+      `${definition.endpoint}/${documentSegment(documentNumber)}`,
+    );
+    return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
+  }
+
+  async function create(fields: Record<string, unknown>) {
+    const raw = await transport.request<Record<string, unknown>>(definition.endpoint, {
+      method: 'POST',
+      body: { [definition.singleKey]: fields },
+    });
+    return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
+  }
+
+  async function update(documentNumber: string, fields: Record<string, unknown>) {
+    const raw = await transport.request<Record<string, unknown>>(
+      `${definition.endpoint}/${documentSegment(documentNumber)}`,
+      { method: 'PUT', body: { [definition.singleKey]: fields } },
+    );
+    return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
+  }
+
+  async function remove(documentNumber: string): Promise<void> {
+    await transport.request(`${definition.endpoint}/${documentSegment(documentNumber)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  return { list, get, create, update, remove };
+}
+
+export function createAccrualOperations(transport: FortnoxTransport) {
+  const invoices = createAccrualResourceOperations(transport, {
+    endpoint: 'invoiceaccruals',
+    listKey: 'InvoiceAccruals',
+    singleKey: 'InvoiceAccrual',
+  });
+  const supplierInvoices = createAccrualResourceOperations(transport, {
+    endpoint: 'supplierinvoiceaccruals',
+    listKey: 'SupplierInvoiceAccruals',
+    singleKey: 'SupplierInvoiceAccrual',
+  });
+  const contracts = createAccrualResourceOperations(transport, {
+    endpoint: 'contractaccruals',
+    listKey: 'ContractAccruals',
+    singleKey: 'ContractAccrual',
+  });
+  return {
+    listInvoiceAccruals: invoices.list,
+    getInvoiceAccrual: invoices.get,
+    createInvoiceAccrual: invoices.create,
+    updateInvoiceAccrual: invoices.update,
+    deleteInvoiceAccrual: invoices.remove,
+    listSupplierInvoiceAccruals: supplierInvoices.list,
+    getSupplierInvoiceAccrual: supplierInvoices.get,
+    createSupplierInvoiceAccrual: supplierInvoices.create,
+    updateSupplierInvoiceAccrual: supplierInvoices.update,
+    deleteSupplierInvoiceAccrual: supplierInvoices.remove,
+    listContractAccruals: contracts.list,
+    getContractAccrual: contracts.get,
+    createContractAccrual: contracts.create,
+    updateContractAccrual: contracts.update,
+    deleteContractAccrual: contracts.remove,
+  };
+}
+
+export const accrualOperations = createAccrualOperations(defaultFortnoxTransport);
+export const {
+  listInvoiceAccruals,
+  getInvoiceAccrual,
+  createInvoiceAccrual,
+  updateInvoiceAccrual,
+  deleteInvoiceAccrual,
+  listSupplierInvoiceAccruals,
+  getSupplierInvoiceAccrual,
+  createSupplierInvoiceAccrual,
+  updateSupplierInvoiceAccrual,
+  deleteSupplierInvoiceAccrual,
+  listContractAccruals,
+  getContractAccrual,
+  createContractAccrual,
+  updateContractAccrual,
+  deleteContractAccrual,
+} = accrualOperations;

--- a/src/operations/articles.ts
+++ b/src/operations/articles.ts
@@ -69,8 +69,14 @@ export function createArticleOperations(transport: FortnoxTransport) {
     return data.Article;
   }
 
-  return { listArticles, getArticle, createArticle, updateArticle };
+  async function deleteArticle(articleNumber: string): Promise<void> {
+    await transport.request(`articles/${encodeURIComponent(articleNumber)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  return { listArticles, getArticle, createArticle, updateArticle, deleteArticle };
 }
 
-export const { listArticles, getArticle, createArticle, updateArticle } =
+export const { listArticles, getArticle, createArticle, updateArticle, deleteArticle } =
   createArticleOperations(defaultFortnoxTransport);

--- a/src/operations/attendancetransactions.ts
+++ b/src/operations/attendancetransactions.ts
@@ -55,6 +55,17 @@ export function createAttendanceTransactionOperations(transport: FortnoxTranspor
     return data.AttendanceTransaction;
   }
 
+  async function getAttendanceTransactionByDateCode(
+    id: string,
+    date: string,
+    code: string,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<AttendanceTransactionResponse>(
+      `attendancetransactions/${encodeURIComponent(id)}/${encodeURIComponent(date)}/${encodeURIComponent(code)}`,
+    );
+    return data.AttendanceTransaction;
+  }
+
   async function createAttendanceTransaction(
     params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
@@ -71,10 +82,23 @@ export function createAttendanceTransactionOperations(transport: FortnoxTranspor
     });
   }
 
+  async function updateAttendanceTransaction(
+    id: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<AttendanceTransactionResponse>(
+      `attendancetransactions/${encodeURIComponent(id)}`,
+      { method: 'PUT', body: { AttendanceTransaction: params } },
+    );
+    return data.AttendanceTransaction;
+  }
+
   return {
     listAttendanceTransactions,
     getAttendanceTransaction,
+    getAttendanceTransactionByDateCode,
     createAttendanceTransaction,
+    updateAttendanceTransaction,
     deleteAttendanceTransaction,
   };
 }
@@ -82,6 +106,8 @@ export function createAttendanceTransactionOperations(transport: FortnoxTranspor
 export const {
   listAttendanceTransactions,
   getAttendanceTransaction,
+  getAttendanceTransactionByDateCode,
   createAttendanceTransaction,
+  updateAttendanceTransaction,
   deleteAttendanceTransaction,
 } = createAttendanceTransactionOperations(defaultFortnoxTransport);

--- a/src/operations/customers.ts
+++ b/src/operations/customers.ts
@@ -81,8 +81,14 @@ export function createCustomerOperations(transport: FortnoxTransport) {
     return data.Customer;
   }
 
-  return { listCustomers, getCustomer, createCustomer, updateCustomer };
+  async function deleteCustomer(customerNumber: string): Promise<void> {
+    await transport.request(`customers/${customerSegment(customerNumber)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  return { listCustomers, getCustomer, createCustomer, updateCustomer, deleteCustomer };
 }
 
-export const { listCustomers, getCustomer, createCustomer, updateCustomer } =
+export const { listCustomers, getCustomer, createCustomer, updateCustomer, deleteCustomer } =
   createCustomerOperations(defaultFortnoxTransport);

--- a/src/operations/files.ts
+++ b/src/operations/files.ts
@@ -1,0 +1,117 @@
+import { basename, extname } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.xml': 'application/xml',
+};
+
+function uploadForm(filePath: string): FormData {
+  if (!existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+  if (!statSync(filePath).isFile()) throw new Error(`Not a regular file: ${filePath}`);
+  const buffer = readFileSync(filePath);
+  const form = new FormData();
+  form.append(
+    'file',
+    new Blob([buffer], {
+      type: MIME_BY_EXTENSION[extname(filePath).toLowerCase()] ?? 'application/octet-stream',
+    }),
+    basename(filePath),
+  );
+  return form;
+}
+
+export function createFileOperations(transport: FortnoxTransport) {
+  async function listArchive(params: { path?: string; fileId?: string } = {}) {
+    return transport.request<Record<string, unknown>>('archive', {
+      params: { path: params.path, fileid: params.fileId },
+    });
+  }
+
+  async function getArchiveEntry(id: string, params: { path?: string; fileId?: string } = {}) {
+    return transport.request<Record<string, unknown>>(`archive/${encodeURIComponent(id)}`, {
+      params: { path: params.path, fileid: params.fileId },
+    });
+  }
+
+  async function uploadArchiveFile(
+    filePath: string,
+    params: { folderId?: string; path?: string } = {},
+  ) {
+    return transport.request<Record<string, unknown>>('archive', {
+      method: 'POST',
+      params: { folderid: params.folderId, path: params.path },
+      rawBody: uploadForm(filePath),
+    });
+  }
+
+  async function deleteArchivePath(path: string): Promise<void> {
+    await transport.request('archive', { method: 'DELETE', params: { path } });
+  }
+
+  async function deleteArchiveEntry(id: string, path?: string): Promise<void> {
+    await transport.request(`archive/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      params: { path },
+    });
+  }
+
+  async function listInbox() {
+    return transport.request<Record<string, unknown>>('inbox');
+  }
+
+  async function uploadInboxEntry(
+    filePath: string,
+    params: { folderId?: string; path?: string } = {},
+  ) {
+    return transport.request<Record<string, unknown>>('inbox', {
+      method: 'POST',
+      params: { folderId: params.folderId, path: params.path },
+      rawBody: uploadForm(filePath),
+    });
+  }
+
+  async function getInboxFile(id: string) {
+    const { buffer, contentType } = await transport.requestFile(`inbox/${encodeURIComponent(id)}`);
+    return { id, buffer, contentType };
+  }
+
+  async function deleteInboxEntry(id: string): Promise<void> {
+    await transport.request(`inbox/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  }
+
+  return {
+    listArchive,
+    getArchiveEntry,
+    uploadArchiveFile,
+    deleteArchivePath,
+    deleteArchiveEntry,
+    listInbox,
+    uploadInboxEntry,
+    getInboxFile,
+    deleteInboxEntry,
+  };
+}
+
+export const fileOperations = createFileOperations(defaultFortnoxTransport);
+export const {
+  listArchive,
+  getArchiveEntry,
+  uploadArchiveFile,
+  deleteArchivePath,
+  deleteArchiveEntry,
+  listInbox,
+  uploadInboxEntry,
+  getInboxFile,
+  deleteInboxEntry,
+} = fileOperations;

--- a/src/operations/files.ts
+++ b/src/operations/files.ts
@@ -39,9 +39,13 @@ export function createFileOperations(transport: FortnoxTransport) {
   }
 
   async function getArchiveEntry(id: string, params: { path?: string; fileId?: string } = {}) {
-    return transport.request<Record<string, unknown>>(`archive/${encodeURIComponent(id)}`, {
-      params: { path: params.path, fileid: params.fileId },
-    });
+    const { buffer, contentType } = await transport.requestFile(
+      `archive/${encodeURIComponent(id)}`,
+      {
+        params: { path: params.path, fileid: params.fileId },
+      },
+    );
+    return { id, buffer, contentType };
   }
 
   async function uploadArchiveFile(

--- a/src/operations/financial-years.ts
+++ b/src/operations/financial-years.ts
@@ -45,6 +45,16 @@ export function createFinancialYearOperations(transport: FortnoxTransport) {
     return data.FinancialYear;
   }
 
+  async function createFinancialYear(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<FinancialYearResponse>('financialyears', {
+      method: 'POST',
+      body: { FinancialYear: params },
+    });
+    return data.FinancialYear;
+  }
+
   // The locked period (bokföring låst t.o.m.). An empty object means no period
   // is locked. Useful as context before voucher/invoice writes to avoid
   // "period is locked" API errors.
@@ -53,8 +63,8 @@ export function createFinancialYearOperations(transport: FortnoxTransport) {
     return data.LockedPeriod ?? {};
   }
 
-  return { listFinancialYears, getFinancialYear, getLockedPeriod };
+  return { listFinancialYears, getFinancialYear, createFinancialYear, getLockedPeriod };
 }
 
-export const { listFinancialYears, getFinancialYear, getLockedPeriod } =
+export const { listFinancialYears, getFinancialYear, createFinancialYear, getLockedPeriod } =
   createFinancialYearOperations(defaultFortnoxTransport);

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,5 +1,6 @@
 import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
 import { createAbsenceTransactionOperations } from './absencetransactions.js';
+import { createAccrualOperations } from './accruals.js';
 import { createAccountOperations } from './accounts.js';
 import { createAnalyticsOperations } from './analytics.js';
 import { createArticleOperations } from './articles.js';
@@ -11,6 +12,7 @@ import { createCustomerOperations } from './customers.js';
 import { createEmployeeOperations } from './employees.js';
 import { createFinancialReportOperations } from './financial-reports.js';
 import { createFinancialYearOperations } from './financial-years.js';
+import { createFileOperations } from './files.js';
 import { createInvoicePaymentOperations } from './invoice-payments.js';
 import { createInvoiceOperations } from './invoices.js';
 import { createOfferOperations } from './offers.js';
@@ -18,6 +20,7 @@ import { createOrderOperations } from './orders.js';
 import { createPriceListOperations, createPriceOperations } from './pricelists.js';
 import { createProjectOperations } from './projects.js';
 import { createRecurringOperations } from './recurrings.js';
+import { createReferenceDataOperations } from './reference-data.js';
 import { createSalaryTransactionOperations } from './salarytransactions.js';
 import { createScheduleTimeOperations } from './scheduletimes.js';
 import { createSupplierInvoicePaymentOperations } from './supplier-invoice-payments.js';
@@ -31,6 +34,7 @@ import { createVoucherOperations } from './vouchers.js';
 export function createFortnoxOperations(transport: FortnoxTransport) {
   return Object.freeze({
     ...createAbsenceTransactionOperations(transport),
+    ...createAccrualOperations(transport),
     ...createAccountOperations(transport),
     ...createAnalyticsOperations(transport),
     ...createArticleOperations(transport),
@@ -42,6 +46,7 @@ export function createFortnoxOperations(transport: FortnoxTransport) {
     ...createEmployeeOperations(transport),
     ...createFinancialReportOperations(transport),
     ...createFinancialYearOperations(transport),
+    ...createFileOperations(transport),
     ...createInvoicePaymentOperations(transport),
     ...createInvoiceOperations(transport),
     ...createOfferOperations(transport),
@@ -50,6 +55,7 @@ export function createFortnoxOperations(transport: FortnoxTransport) {
     ...createPriceOperations(transport),
     ...createProjectOperations(transport),
     ...createRecurringOperations(transport),
+    ...createReferenceDataOperations(transport),
     ...createSalaryTransactionOperations(transport),
     ...createScheduleTimeOperations(transport),
     ...createSupplierInvoicePaymentOperations(transport),

--- a/src/operations/invoice-payments.ts
+++ b/src/operations/invoice-payments.ts
@@ -65,6 +65,17 @@ export function createInvoicePaymentOperations(transport: FortnoxTransport) {
     });
   }
 
+  async function updateInvoicePayment(
+    paymentNumber: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<InvoicePaymentResponse>(
+      `invoicepayments/${documentSegment(paymentNumber)}`,
+      { method: 'PUT', body: { InvoicePayment: params } },
+    );
+    return data.InvoicePayment;
+  }
+
   async function bookkeepInvoicePayment(paymentNumber: string): Promise<Record<string, unknown>> {
     const data = await transport.request<InvoicePaymentResponse>(
       `invoicepayments/${documentSegment(paymentNumber)}/bookkeep`,
@@ -79,6 +90,7 @@ export function createInvoicePaymentOperations(transport: FortnoxTransport) {
     listInvoicePayments,
     getInvoicePayment,
     createInvoicePayment,
+    updateInvoicePayment,
     deleteInvoicePayment,
     bookkeepInvoicePayment,
   };
@@ -88,6 +100,7 @@ export const {
   listInvoicePayments,
   getInvoicePayment,
   createInvoicePayment,
+  updateInvoicePayment,
   deleteInvoicePayment,
   bookkeepInvoicePayment,
 } = createInvoicePaymentOperations(defaultFortnoxTransport);

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -56,6 +56,8 @@ export interface InvoiceAttachment {
   includeOnSend: boolean;
 }
 
+export type AttachmentEntityType = 'F' | 'OF' | 'O' | 'C';
+
 export interface AttachInvoiceFilesParams {
   documentNumber: string;
   filePaths: string[];
@@ -233,6 +235,35 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     return data?.Invoice || {};
   }
 
+  async function runInvoiceAction(
+    documentNumber: string,
+    action: 'cancel' | 'externalprint',
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<InvoiceResponse>(
+      `invoices/${documentSegment(documentNumber)}/${action}`,
+      { method: 'PUT' },
+    );
+    return data.Invoice ?? {};
+  }
+
+  const cancelInvoice = (documentNumber: string) => runInvoiceAction(documentNumber, 'cancel');
+  const externalPrintInvoice = (documentNumber: string) =>
+    runInvoiceAction(documentNumber, 'externalprint');
+
+  async function eprintInvoice(documentNumber: string): Promise<Record<string, unknown>> {
+    const data = await transport.request<InvoiceResponse>(
+      `invoices/${documentSegment(documentNumber)}/eprint`,
+      { mutation: true },
+    );
+    return data.Invoice ?? {};
+  }
+
+  async function getInvoiceReminderPdf(documentNumber: string): Promise<Buffer | undefined> {
+    return transport.requestPdfFromMutation(
+      `invoices/${documentSegment(documentNumber)}/printreminder`,
+    );
+  }
+
   const MIME_BY_EXT: Record<string, string> = {
     '.pdf': 'application/pdf',
     '.png': 'image/png',
@@ -293,26 +324,70 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
   }
 
   async function listInvoiceAttachments(documentNumber: string): Promise<InvoiceAttachment[]> {
-    return transport.request<InvoiceAttachment[]>('/api/fileattachments/attachments-v1', {
-      params: { entityid: documentNumber, entitytype: 'F' },
+    return (await listDocumentAttachments(documentNumber, 'F')) as unknown as InvoiceAttachment[];
+  }
+
+  async function listDocumentAttachments(
+    documentNumber: string,
+    entityType: AttachmentEntityType,
+  ): Promise<Record<string, unknown>[]> {
+    return transport.request<Record<string, unknown>[]>('/api/fileattachments/attachments-v1', {
+      params: { entityid: documentNumber, entitytype: entityType },
     });
   }
 
-  async function createInvoiceAttachment(
+  async function getAttachmentCounts(
+    entityIds: number[],
+    entityType: AttachmentEntityType,
+  ): Promise<Record<string, unknown>> {
+    return transport.request<Record<string, unknown>>(
+      '/api/fileattachments/attachments-v1/numberofattachments',
+      { params: { entityids: entityIds.join(','), entitytype: entityType } },
+    );
+  }
+
+  async function validateAttachmentsOnSend(attachments: Record<string, unknown>[]): Promise<void> {
+    await transport.request('/api/fileattachments/attachments-v1/validateincludedonsend', {
+      method: 'POST',
+      body: attachments,
+    });
+  }
+
+  async function updateDocumentAttachment(
+    attachmentId: string,
+    fields: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return transport.request<Record<string, unknown>>(
+      `/api/fileattachments/attachments-v1/${encodeURIComponent(attachmentId)}`,
+      { method: 'PUT', body: fields },
+    );
+  }
+
+  async function detachDocumentAttachment(attachmentId: string): Promise<void> {
+    await transport.request(
+      `/api/fileattachments/attachments-v1/${encodeURIComponent(attachmentId)}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  async function createDocumentAttachment(
     documentNumber: string,
+    entityType: AttachmentEntityType,
     fileId: string,
     includeOnSend: boolean,
-  ): Promise<InvoiceAttachment> {
-    const data = await transport.request<InvoiceAttachment[]>(
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<Record<string, unknown>[]>(
       '/api/fileattachments/attachments-v1',
       {
         method: 'POST',
-        body: [{ entityId: Number(documentNumber), entityType: 'F', fileId, includeOnSend }],
+        body: [{ entityId: Number(documentNumber), entityType, fileId, includeOnSend }],
       },
     );
     const attachment = data[0];
     if (!attachment) {
-      throw new Error(`Fortnox did not return an attachment record for invoice ${documentNumber}.`);
+      throw new Error(
+        `Fortnox did not return an attachment record for document ${documentNumber}.`,
+      );
     }
     return attachment;
   }
@@ -330,11 +405,12 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     for (const filePath of params.filePaths) {
       try {
         const file = await uploadForInvoiceAttachment(filePath);
-        const attachment = await createInvoiceAttachment(
+        const attachment = (await createDocumentAttachment(
           params.documentNumber,
+          'F',
           file.ArchiveFileId,
           includeOnSend,
-        );
+        )) as unknown as InvoiceAttachment;
         results.push({
           fileName: file.Name,
           fileId: attachment.fileId,
@@ -362,8 +438,18 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     markInvoicePrinted,
     bookkeepInvoice,
     creditInvoice,
+    cancelInvoice,
+    externalPrintInvoice,
+    eprintInvoice,
+    getInvoiceReminderPdf,
     attachInvoiceFiles,
     listInvoiceAttachments,
+    createDocumentAttachment,
+    listDocumentAttachments,
+    getAttachmentCounts,
+    validateAttachmentsOnSend,
+    updateDocumentAttachment,
+    detachDocumentAttachment,
   };
 }
 
@@ -377,6 +463,16 @@ export const {
   markInvoicePrinted,
   bookkeepInvoice,
   creditInvoice,
+  cancelInvoice,
+  externalPrintInvoice,
+  eprintInvoice,
+  getInvoiceReminderPdf,
   attachInvoiceFiles,
   listInvoiceAttachments,
+  createDocumentAttachment,
+  listDocumentAttachments,
+  getAttachmentCounts,
+  validateAttachmentsOnSend,
+  updateDocumentAttachment,
+  detachDocumentAttachment,
 } = createInvoiceOperations(defaultFortnoxTransport);

--- a/src/operations/invoices.ts
+++ b/src/operations/invoices.ts
@@ -376,11 +376,15 @@ export function createInvoiceOperations(transport: FortnoxTransport) {
     fileId: string,
     includeOnSend: boolean,
   ): Promise<Record<string, unknown>> {
+    const entityId = Number(documentNumber);
+    if (!/^\d+$/.test(documentNumber) || !Number.isSafeInteger(entityId)) {
+      throw new Error(`Invalid document number: ${documentNumber}`);
+    }
     const data = await transport.request<Record<string, unknown>[]>(
       '/api/fileattachments/attachments-v1',
       {
         method: 'POST',
-        body: [{ entityId: Number(documentNumber), entityType, fileId, includeOnSend }],
+        body: [{ entityId, entityType, fileId, includeOnSend }],
       },
     );
     const attachment = data[0];

--- a/src/operations/offers.ts
+++ b/src/operations/offers.ts
@@ -92,6 +92,37 @@ export function createOfferOperations(transport: FortnoxTransport) {
     return data.Order;
   }
 
+  async function runOfferAction(
+    documentNumber: string,
+    action: 'cancel' | 'externalprint',
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<OfferResponse>(
+      `offers/${documentSegment(documentNumber)}/${action}`,
+      { method: 'PUT' },
+    );
+    return data.Offer ?? {};
+  }
+
+  const cancelOffer = (documentNumber: string) => runOfferAction(documentNumber, 'cancel');
+  const externalPrintOffer = (documentNumber: string) =>
+    runOfferAction(documentNumber, 'externalprint');
+
+  async function emailOffer(documentNumber: string): Promise<Record<string, unknown>> {
+    const data = await transport.request<OfferResponse>(
+      `offers/${documentSegment(documentNumber)}/email`,
+      { mutation: true },
+    );
+    return data.Offer ?? {};
+  }
+
+  async function getOfferPdf(
+    documentNumber: string,
+    mode: 'preview' | 'print' = 'preview',
+  ): Promise<Buffer | undefined> {
+    const path = `offers/${documentSegment(documentNumber)}/${mode}`;
+    return mode === 'print' ? transport.requestPdfFromMutation(path) : transport.requestPdf(path);
+  }
+
   return {
     listOffers,
     getOffer,
@@ -99,6 +130,10 @@ export function createOfferOperations(transport: FortnoxTransport) {
     updateOffer,
     createInvoiceFromOffer,
     createOrderFromOffer,
+    cancelOffer,
+    emailOffer,
+    externalPrintOffer,
+    getOfferPdf,
   };
 }
 
@@ -109,4 +144,8 @@ export const {
   updateOffer,
   createInvoiceFromOffer,
   createOrderFromOffer,
+  cancelOffer,
+  emailOffer,
+  externalPrintOffer,
+  getOfferPdf,
 } = createOfferOperations(defaultFortnoxTransport);

--- a/src/operations/orders.ts
+++ b/src/operations/orders.ts
@@ -84,8 +84,58 @@ export function createOrderOperations(transport: FortnoxTransport) {
     return data.Invoice;
   }
 
-  return { listOrders, getOrder, createOrder, updateOrder, createInvoiceFromOrder };
+  async function runOrderAction(
+    documentNumber: string,
+    action: 'cancel' | 'externalprint',
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<OrderResponse>(
+      `orders/${documentSegment(documentNumber)}/${action}`,
+      { method: 'PUT' },
+    );
+    return data.Order ?? {};
+  }
+
+  const cancelOrder = (documentNumber: string) => runOrderAction(documentNumber, 'cancel');
+  const externalPrintOrder = (documentNumber: string) =>
+    runOrderAction(documentNumber, 'externalprint');
+
+  async function emailOrder(documentNumber: string): Promise<Record<string, unknown>> {
+    const data = await transport.request<OrderResponse>(
+      `orders/${documentSegment(documentNumber)}/email`,
+      { mutation: true },
+    );
+    return data.Order ?? {};
+  }
+
+  async function getOrderPdf(
+    documentNumber: string,
+    mode: 'preview' | 'print' = 'preview',
+  ): Promise<Buffer | undefined> {
+    const path = `orders/${documentSegment(documentNumber)}/${mode}`;
+    return mode === 'print' ? transport.requestPdfFromMutation(path) : transport.requestPdf(path);
+  }
+
+  return {
+    listOrders,
+    getOrder,
+    createOrder,
+    updateOrder,
+    createInvoiceFromOrder,
+    cancelOrder,
+    emailOrder,
+    externalPrintOrder,
+    getOrderPdf,
+  };
 }
 
-export const { listOrders, getOrder, createOrder, updateOrder, createInvoiceFromOrder } =
-  createOrderOperations(defaultFortnoxTransport);
+export const {
+  listOrders,
+  getOrder,
+  createOrder,
+  updateOrder,
+  createInvoiceFromOrder,
+  cancelOrder,
+  emailOrder,
+  externalPrintOrder,
+  getOrderPdf,
+} = createOrderOperations(defaultFortnoxTransport);

--- a/src/operations/pricelists.ts
+++ b/src/operations/pricelists.ts
@@ -85,7 +85,7 @@ export interface PricesResponse {
 }
 
 export interface ListPricesParams {
-  priceListCode: string;
+  priceListCode?: string;
   articleNumber?: string;
   page?: number;
   limit?: number;
@@ -93,9 +93,11 @@ export interface ListPricesParams {
 
 export function createPriceOperations(transport: FortnoxTransport) {
   async function listPrices(params: ListPricesParams): Promise<PricesResponse> {
-    const endpoint = params.articleNumber
-      ? `prices/sublist/${encodeURIComponent(params.priceListCode)}/${encodeURIComponent(params.articleNumber)}`
-      : `prices/sublist/${encodeURIComponent(params.priceListCode)}`;
+    const endpoint = !params.priceListCode
+      ? 'prices'
+      : params.articleNumber
+        ? `prices/sublist/${encodeURIComponent(params.priceListCode)}/${encodeURIComponent(params.articleNumber)}`
+        : `prices/sublist/${encodeURIComponent(params.priceListCode)}`;
 
     return transport.request<PricesResponse>(endpoint, {
       params: { page: params.page || 1, limit: params.limit || 100 },
@@ -105,10 +107,11 @@ export function createPriceOperations(transport: FortnoxTransport) {
   async function getPrice(
     priceListCode: string,
     articleNumber: string,
-    fromQuantity = 0,
+    fromQuantity?: number,
   ): Promise<Record<string, unknown>> {
+    const quantitySegment = fromQuantity === undefined ? '' : `/${fromQuantity}`;
     const data = await transport.request<PriceResponse>(
-      `prices/${encodeURIComponent(priceListCode)}/${encodeURIComponent(articleNumber)}/${fromQuantity}`,
+      `prices/${encodeURIComponent(priceListCode)}/${encodeURIComponent(articleNumber)}${quantitySegment}`,
     );
     return data.Price;
   }
@@ -117,10 +120,11 @@ export function createPriceOperations(transport: FortnoxTransport) {
     priceListCode: string,
     articleNumber: string,
     fields: Record<string, unknown>,
-    fromQuantity = 0,
+    fromQuantity?: number,
   ): Promise<Record<string, unknown>> {
+    const quantitySegment = fromQuantity === undefined ? '' : `/${fromQuantity}`;
     const data = await transport.request<PriceResponse>(
-      `prices/${encodeURIComponent(priceListCode)}/${encodeURIComponent(articleNumber)}/${fromQuantity}`,
+      `prices/${encodeURIComponent(priceListCode)}/${encodeURIComponent(articleNumber)}${quantitySegment}`,
       {
         method: 'PUT',
         body: { Price: fields },
@@ -129,7 +133,27 @@ export function createPriceOperations(transport: FortnoxTransport) {
     return data.Price;
   }
 
-  return { listPrices, getPrice, updatePrice };
+  async function createPrice(fields: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const data = await transport.request<PriceResponse>('prices', {
+      method: 'POST',
+      body: { Price: fields },
+    });
+    return data.Price;
+  }
+
+  async function deletePrice(
+    priceListCode: string,
+    articleNumber: string,
+    fromQuantity: number,
+  ): Promise<void> {
+    await transport.request(
+      `prices/${encodeURIComponent(priceListCode)}/${encodeURIComponent(articleNumber)}/${fromQuantity}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  return { listPrices, getPrice, createPrice, updatePrice, deletePrice };
 }
 
-export const { listPrices, getPrice, updatePrice } = createPriceOperations(defaultFortnoxTransport);
+export const { listPrices, getPrice, createPrice, updatePrice, deletePrice } =
+  createPriceOperations(defaultFortnoxTransport);

--- a/src/operations/projects.ts
+++ b/src/operations/projects.ts
@@ -63,8 +63,12 @@ export function createProjectOperations(transport: FortnoxTransport) {
     return data.Project;
   }
 
-  return { listProjects, getProject, createProject, updateProject };
+  async function deleteProject(projectNumber: string): Promise<void> {
+    await transport.request(`projects/${encodeURIComponent(projectNumber)}`, { method: 'DELETE' });
+  }
+
+  return { listProjects, getProject, createProject, updateProject, deleteProject };
 }
 
-export const { listProjects, getProject, createProject, updateProject } =
+export const { listProjects, getProject, createProject, updateProject, deleteProject } =
   createProjectOperations(defaultFortnoxTransport);

--- a/src/operations/reference-data.ts
+++ b/src/operations/reference-data.ts
@@ -1,0 +1,156 @@
+import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
+
+export interface ListReferenceParams {
+  page?: number;
+  limit?: number;
+  all?: boolean;
+}
+
+interface ReferenceDefinition {
+  endpoint: string;
+  listKey: string;
+  singleKey?: string;
+}
+
+function createReferenceReader(transport: FortnoxTransport, definition: ReferenceDefinition) {
+  async function list(params: ListReferenceParams = {}) {
+    if (params.all) {
+      const { items, totalResources } = await transport.fetchAllPages<Record<string, unknown>>(
+        definition.endpoint,
+        definition.listKey,
+      );
+      return {
+        items,
+        raw: {
+          [definition.listKey]: items,
+          MetaInformation: {
+            '@TotalResources': totalResources,
+            '@TotalPages': 1,
+            '@CurrentPage': 1,
+          },
+        },
+      };
+    }
+    const raw = await transport.request<Record<string, unknown>>(definition.endpoint, {
+      params: { page: params.page || 1, limit: params.limit || 100 },
+    });
+    const value = raw[definition.listKey];
+    return { items: Array.isArray(value) ? value : value ? [value] : [], raw };
+  }
+
+  async function get(identifier: string) {
+    if (!definition.singleKey) throw new Error(`${definition.endpoint} has no get operation`);
+    const raw = await transport.request<Record<string, unknown>>(
+      `${definition.endpoint}/${encodeURIComponent(identifier)}`,
+    );
+    return { item: (raw[definition.singleKey] ?? {}) as Record<string, unknown>, raw };
+  }
+
+  return { list, get };
+}
+
+export function createReferenceDataOperations(transport: FortnoxTransport) {
+  const currencies = createReferenceReader(transport, {
+    endpoint: 'currencies',
+    listKey: 'Currencies',
+    singleKey: 'Currency',
+  });
+  const units = createReferenceReader(transport, {
+    endpoint: 'units',
+    listKey: 'Units',
+    singleKey: 'Unit',
+  });
+  const modesOfPayments = createReferenceReader(transport, {
+    endpoint: 'modesofpayments',
+    listKey: 'ModesOfPayments',
+    singleKey: 'ModeOfPayment',
+  });
+  const termsOfDeliveries = createReferenceReader(transport, {
+    endpoint: 'termsofdeliveries',
+    listKey: 'TermsOfDeliveries',
+    singleKey: 'TermsOfDelivery',
+  });
+  const termsOfPayments = createReferenceReader(transport, {
+    endpoint: 'termsofpayments',
+    listKey: 'TermsOfPayments',
+    singleKey: 'TermsOfPayment',
+  });
+  const waysOfDelivery = createReferenceReader(transport, {
+    endpoint: 'wayofdeliveries',
+    listKey: 'WayOfDeliveries',
+    singleKey: 'WayOfDelivery',
+  });
+  const voucherSeries = createReferenceReader(transport, {
+    endpoint: 'voucherseries',
+    listKey: 'VoucherSeriesCollection',
+    singleKey: 'VoucherSeries',
+  });
+  const predefinedVoucherSeries = createReferenceReader(transport, {
+    endpoint: 'predefinedvoucherseries',
+    listKey: 'PreDefinedVoucherSeriesCollection',
+    singleKey: 'PreDefinedVoucherSeries',
+  });
+  const accountCharts = createReferenceReader(transport, {
+    endpoint: 'accountcharts',
+    listKey: 'AccountCharts',
+  });
+  const predefinedAccounts = createReferenceReader(transport, {
+    endpoint: 'predefinedaccounts',
+    listKey: 'PreDefinedAccounts',
+    singleKey: 'PreDefinedAccount',
+  });
+  const customerReferences = createReferenceReader(transport, {
+    endpoint: 'customerreferences',
+    listKey: 'CustomerReference',
+    singleKey: 'CustomerReference',
+  });
+
+  return {
+    listCurrencies: currencies.list,
+    getCurrency: currencies.get,
+    listUnits: units.list,
+    getUnit: units.get,
+    listModesOfPayments: modesOfPayments.list,
+    getModeOfPayment: modesOfPayments.get,
+    listTermsOfDeliveries: termsOfDeliveries.list,
+    getTermOfDelivery: termsOfDeliveries.get,
+    listTermsOfPayments: termsOfPayments.list,
+    getTermOfPayment: termsOfPayments.get,
+    listWaysOfDelivery: waysOfDelivery.list,
+    getWayOfDelivery: waysOfDelivery.get,
+    listVoucherSeries: voucherSeries.list,
+    getVoucherSeries: voucherSeries.get,
+    listPredefinedVoucherSeries: predefinedVoucherSeries.list,
+    getPredefinedVoucherSeries: predefinedVoucherSeries.get,
+    listAccountCharts: accountCharts.list,
+    listPredefinedAccounts: predefinedAccounts.list,
+    getPredefinedAccount: predefinedAccounts.get,
+    listCustomerReferences: customerReferences.list,
+    getCustomerReference: customerReferences.get,
+  };
+}
+
+export const referenceDataOperations = createReferenceDataOperations(defaultFortnoxTransport);
+export const {
+  listCurrencies,
+  getCurrency,
+  listUnits,
+  getUnit,
+  listModesOfPayments,
+  getModeOfPayment,
+  listTermsOfDeliveries,
+  getTermOfDelivery,
+  listTermsOfPayments,
+  getTermOfPayment,
+  listWaysOfDelivery,
+  getWayOfDelivery,
+  listVoucherSeries,
+  getVoucherSeries,
+  listPredefinedVoucherSeries,
+  getPredefinedVoucherSeries,
+  listAccountCharts,
+  listPredefinedAccounts,
+  getPredefinedAccount,
+  listCustomerReferences,
+  getCustomerReference,
+} = referenceDataOperations;

--- a/src/operations/salarytransactions.ts
+++ b/src/operations/salarytransactions.ts
@@ -65,10 +65,22 @@ export function createSalaryTransactionOperations(transport: FortnoxTransport) {
     });
   }
 
+  async function updateSalaryTransaction(
+    salaryRow: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SalaryTransactionResponse>(
+      `salarytransactions/${encodeURIComponent(String(salaryRow))}`,
+      { method: 'PUT', body: { SalaryTransaction: params } },
+    );
+    return data.SalaryTransaction;
+  }
+
   return {
     listSalaryTransactions,
     getSalaryTransaction,
     createSalaryTransaction,
+    updateSalaryTransaction,
     deleteSalaryTransaction,
   };
 }
@@ -77,5 +89,6 @@ export const {
   listSalaryTransactions,
   getSalaryTransaction,
   createSalaryTransaction,
+  updateSalaryTransaction,
   deleteSalaryTransaction,
 } = createSalaryTransactionOperations(defaultFortnoxTransport);

--- a/src/operations/supplier-invoice-payments.ts
+++ b/src/operations/supplier-invoice-payments.ts
@@ -70,11 +70,34 @@ export function createSupplierInvoicePaymentOperations(transport: FortnoxTranspo
     });
   }
 
+  async function updateSupplierInvoicePayment(
+    paymentNumber: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoicePaymentResponse>(
+      `supplierinvoicepayments/${documentSegment(paymentNumber)}`,
+      { method: 'PUT', body: { SupplierInvoicePayment: params } },
+    );
+    return data.SupplierInvoicePayment;
+  }
+
+  async function bookkeepSupplierInvoicePayment(
+    paymentNumber: string,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoicePaymentResponse>(
+      `supplierinvoicepayments/${documentSegment(paymentNumber)}/bookkeep`,
+      { method: 'PUT' },
+    );
+    return data.SupplierInvoicePayment ?? {};
+  }
+
   return {
     listSupplierInvoicePayments,
     getSupplierInvoicePayment,
     createSupplierInvoicePayment,
+    updateSupplierInvoicePayment,
     deleteSupplierInvoicePayment,
+    bookkeepSupplierInvoicePayment,
   };
 }
 
@@ -82,5 +105,7 @@ export const {
   listSupplierInvoicePayments,
   getSupplierInvoicePayment,
   createSupplierInvoicePayment,
+  updateSupplierInvoicePayment,
   deleteSupplierInvoicePayment,
+  bookkeepSupplierInvoicePayment,
 } = createSupplierInvoicePaymentOperations(defaultFortnoxTransport);

--- a/src/operations/supplier-invoices.ts
+++ b/src/operations/supplier-invoices.ts
@@ -77,6 +77,37 @@ export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
     return data.SupplierInvoice;
   }
 
+  async function updateSupplierInvoice(
+    givenNumber: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoiceResponse>(
+      `supplierinvoices/${encodeURIComponent(givenNumber)}`,
+      { method: 'PUT', body: { SupplierInvoice: params } },
+    );
+    return data.SupplierInvoice;
+  }
+
+  async function runSupplierInvoiceAction(
+    givenNumber: string,
+    action: 'approvalbookkeep' | 'approvalpayment' | 'cancel' | 'credit',
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoiceResponse>(
+      `supplierinvoices/${encodeURIComponent(givenNumber)}/${action}`,
+      { method: 'PUT' },
+    );
+    return data.SupplierInvoice;
+  }
+
+  const approvalBookkeepSupplierInvoice = (givenNumber: string) =>
+    runSupplierInvoiceAction(givenNumber, 'approvalbookkeep');
+  const approvalPaymentSupplierInvoice = (givenNumber: string) =>
+    runSupplierInvoiceAction(givenNumber, 'approvalpayment');
+  const cancelSupplierInvoice = (givenNumber: string) =>
+    runSupplierInvoiceAction(givenNumber, 'cancel');
+  const creditSupplierInvoice = (givenNumber: string) =>
+    runSupplierInvoiceAction(givenNumber, 'credit');
+
   async function bookkeepSupplierInvoice(givenNumber: string): Promise<Record<string, unknown>> {
     const data = await transport.request<SupplierInvoiceResponse>(
       `supplierinvoices/${encodeURIComponent(givenNumber)}/bookkeep`,
@@ -87,6 +118,43 @@ export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
 
   interface SupplierInvoiceFileConnectionListResponse {
     SupplierInvoiceFileConnections: Record<string, unknown>[];
+  }
+  interface SupplierInvoiceFileConnectionResponse {
+    SupplierInvoiceFileConnection: Record<string, unknown>;
+  }
+
+  async function getSupplierInvoiceFileConnection(
+    fileId: string,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoiceFileConnectionResponse>(
+      `supplierinvoicefileconnections/${encodeURIComponent(fileId)}`,
+    );
+    return data.SupplierInvoiceFileConnection;
+  }
+
+  async function createSupplierInvoiceFileConnection(
+    givenNumber: string,
+    fileId: string,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<SupplierInvoiceFileConnectionResponse>(
+      'supplierinvoicefileconnections',
+      {
+        method: 'POST',
+        body: {
+          SupplierInvoiceFileConnection: {
+            SupplierInvoiceNumber: givenNumber,
+            FileId: fileId,
+          },
+        },
+      },
+    );
+    return data.SupplierInvoiceFileConnection;
+  }
+
+  async function deleteSupplierInvoiceFileConnection(fileId: string): Promise<void> {
+    await transport.request(`supplierinvoicefileconnections/${encodeURIComponent(fileId)}`, {
+      method: 'DELETE',
+    });
   }
 
   // List the files attached to a supplier invoice — the read counterpart that
@@ -126,8 +194,16 @@ export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
     listSupplierInvoices,
     getSupplierInvoice,
     createSupplierInvoice,
+    updateSupplierInvoice,
     bookkeepSupplierInvoice,
+    approvalBookkeepSupplierInvoice,
+    approvalPaymentSupplierInvoice,
+    cancelSupplierInvoice,
+    creditSupplierInvoice,
     listSupplierInvoiceAttachments,
+    getSupplierInvoiceFileConnection,
+    createSupplierInvoiceFileConnection,
+    deleteSupplierInvoiceFileConnection,
     getSupplierInvoiceFile,
   };
 }
@@ -136,7 +212,15 @@ export const {
   listSupplierInvoices,
   getSupplierInvoice,
   createSupplierInvoice,
+  updateSupplierInvoice,
   bookkeepSupplierInvoice,
+  approvalBookkeepSupplierInvoice,
+  approvalPaymentSupplierInvoice,
+  cancelSupplierInvoice,
+  creditSupplierInvoice,
   listSupplierInvoiceAttachments,
+  getSupplierInvoiceFileConnection,
+  createSupplierInvoiceFileConnection,
+  deleteSupplierInvoiceFileConnection,
   getSupplierInvoiceFile,
 } = createSupplierInvoiceOperations(defaultFortnoxTransport);

--- a/src/operations/supplier-invoices.ts
+++ b/src/operations/supplier-invoices.ts
@@ -19,6 +19,18 @@ export interface ListSupplierInvoicesParams {
   all?: boolean;
 }
 
+export interface SupplierInvoiceAttachment {
+  fileName: string;
+  fileId: string;
+  supplierInvoiceNumber: string;
+}
+
+export interface SupplierInvoiceFileContent {
+  fileId: string;
+  contentType: string;
+  buffer: Buffer;
+}
+
 export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
   async function listSupplierInvoices(
     params: ListSupplierInvoicesParams = {},
@@ -73,11 +85,50 @@ export function createSupplierInvoiceOperations(transport: FortnoxTransport) {
     return data.SupplierInvoice;
   }
 
+  interface SupplierInvoiceFileConnectionListResponse {
+    SupplierInvoiceFileConnections: Record<string, unknown>[];
+  }
+
+  // List the files attached to a supplier invoice — the read counterpart that
+  // was missing: vouchers and customer invoices both had a read path, but a
+  // supplier invoice's original document (the scanned/emailed invoice itself)
+  // was only reachable once the invoice was bookkept into a voucher. This
+  // reaches it directly, so it works for `unbooked`/`authorizepending`
+  // invoices too — server-side filtered by `supplierinvoicenumber`, unlike
+  // voucherfileconnections which has no matching filter for vouchers.
+  async function listSupplierInvoiceAttachments(
+    givenNumber: string,
+  ): Promise<SupplierInvoiceAttachment[]> {
+    const data = await transport.request<SupplierInvoiceFileConnectionListResponse>(
+      'supplierinvoicefileconnections',
+      { params: { supplierinvoicenumber: givenNumber } },
+    );
+    return (data.SupplierInvoiceFileConnections ?? []).map((c) => ({
+      fileName: String(c.Name ?? ''),
+      fileId: String(c.FileId),
+      supplierInvoiceNumber: String(c.SupplierInvoiceNumber ?? givenNumber),
+    }));
+  }
+
+  // Download the actual bytes of a file attached to a supplier invoice.
+  // Fortnox serves it the same way as a voucher attachment — GET inbox/{fileId}
+  // under the connectfile scope — no archive scope needed (that's only for
+  // customer invoices, which have no *invoicefileconnections* resource; see the
+  // ARCHIVE_SCOPE comment in auth.ts).
+  async function getSupplierInvoiceFile(fileId: string): Promise<SupplierInvoiceFileContent> {
+    const { buffer, contentType } = await transport.requestFile(
+      `inbox/${encodeURIComponent(fileId)}`,
+    );
+    return { fileId, contentType, buffer };
+  }
+
   return {
     listSupplierInvoices,
     getSupplierInvoice,
     createSupplierInvoice,
     bookkeepSupplierInvoice,
+    listSupplierInvoiceAttachments,
+    getSupplierInvoiceFile,
   };
 }
 
@@ -86,4 +137,6 @@ export const {
   getSupplierInvoice,
   createSupplierInvoice,
   bookkeepSupplierInvoice,
+  listSupplierInvoiceAttachments,
+  getSupplierInvoiceFile,
 } = createSupplierInvoiceOperations(defaultFortnoxTransport);

--- a/src/operations/taxreductions.ts
+++ b/src/operations/taxreductions.ts
@@ -56,8 +56,34 @@ export function createTaxReductionOperations(transport: FortnoxTransport) {
     return data.TaxReduction;
   }
 
-  return { listTaxReductions, getTaxReduction, createTaxReduction };
+  async function updateTaxReduction(
+    id: number,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const data = await transport.request<TaxReductionResponse>(`taxreductions/${id}`, {
+      method: 'PUT',
+      body: { TaxReduction: params },
+    });
+    return data.TaxReduction;
+  }
+
+  async function deleteTaxReduction(id: number): Promise<void> {
+    await transport.request(`taxreductions/${id}`, { method: 'DELETE' });
+  }
+
+  return {
+    listTaxReductions,
+    getTaxReduction,
+    createTaxReduction,
+    updateTaxReduction,
+    deleteTaxReduction,
+  };
 }
 
-export const { listTaxReductions, getTaxReduction, createTaxReduction } =
-  createTaxReductionOperations(defaultFortnoxTransport);
+export const {
+  listTaxReductions,
+  getTaxReduction,
+  createTaxReduction,
+  updateTaxReduction,
+  deleteTaxReduction,
+} = createTaxReductionOperations(defaultFortnoxTransport);

--- a/src/operations/vouchers.ts
+++ b/src/operations/vouchers.ts
@@ -182,6 +182,19 @@ export function createVoucherOperations(transport: FortnoxTransport) {
     return data.VoucherFileConnection;
   }
 
+  async function getVoucherFileConnection(fileId: string): Promise<Record<string, unknown>> {
+    const data = await transport.request<VoucherFileConnectionResponse>(
+      `voucherfileconnections/${encodeURIComponent(fileId)}`,
+    );
+    return data.VoucherFileConnection;
+  }
+
+  async function deleteVoucherFileConnection(fileId: string): Promise<void> {
+    await transport.request(`voucherfileconnections/${encodeURIComponent(fileId)}`, {
+      method: 'DELETE',
+    });
+  }
+
   // Resolve the financial year from the voucher's transaction date when not given.
   // Throws (rather than silently leaving the year undefined) when it can't be
   // determined, so the user knows to pass --year explicitly — e.g. for a voucher
@@ -296,6 +309,8 @@ export function createVoucherOperations(transport: FortnoxTransport) {
     createVoucher,
     uploadInboxFile,
     createVoucherFileConnection,
+    getVoucherFileConnection,
+    deleteVoucherFileConnection,
     attachVoucherFiles,
     listVoucherAttachments,
     getVoucherFile,
@@ -309,6 +324,8 @@ export const {
   createVoucher,
   uploadInboxFile,
   createVoucherFileConnection,
+  getVoucherFileConnection,
+  deleteVoucherFileConnection,
   attachVoucherFiles,
   listVoucherAttachments,
   getVoucherFile,

--- a/src/safe-file-output.ts
+++ b/src/safe-file-output.ts
@@ -7,10 +7,13 @@ import {
   writeSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 
 export function privateOutputPath(prefix: string, fileName: string): string {
-  return join(mkdtempSync(join(tmpdir(), prefix)), fileName);
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  const candidate = basename(fileName);
+  const safeName = !candidate || candidate === '.' || candidate === '..' ? 'download' : candidate;
+  return join(directory, safeName);
 }
 
 export function writeBinaryFile(targetPath: string, data: Buffer, overwrite = false): string {

--- a/src/safe-file-output.ts
+++ b/src/safe-file-output.ts
@@ -1,0 +1,48 @@
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function privateOutputPath(prefix: string, fileName: string): string {
+  return join(mkdtempSync(join(tmpdir(), prefix)), fileName);
+}
+
+export function writeBinaryFile(targetPath: string, data: Buffer, overwrite = false): string {
+  const target = resolve(targetPath);
+  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
+  const flags = overwrite
+    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
+    : O_WRONLY | O_CREAT | O_EXCL;
+
+  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    throw new Error(`${target} is a symbolic link. Refusing to write through it.`);
+  }
+
+  try {
+    const descriptor = openSync(target, flags, 0o600);
+    try {
+      let written = 0;
+      while (written < data.length) {
+        written += writeSync(descriptor, data, written, data.length - written);
+      }
+    } finally {
+      closeSync(descriptor);
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      throw new Error(`${target} already exists. Choose another path or set overwrite: true.`);
+    }
+    if (code === 'ELOOP') {
+      throw new Error(`${target} is a symbolic link. Refusing to write through it.`);
+    }
+    throw error;
+  }
+  return target;
+}

--- a/src/schema-audit-mappings.ts
+++ b/src/schema-audit-mappings.ts
@@ -1,12 +1,193 @@
-import type { SchemaAuditMapping } from './schema-audit.js';
+import type { MutationAuditException, SchemaAuditMapping } from './schema-audit.js';
+
+const root = (id: string, toolName: string, specSchemaName: string): SchemaAuditMapping => ({
+  id,
+  toolName,
+  toolSchemaPointer: '',
+  specSchemaName,
+});
 
 /**
- * First-wave write-schema coverage mappings.
- *
- * Component names are already part of the committed opaque API fingerprint. The
- * OpenAPI document and its property names remain in the git-ignored local cache.
+ * Reviewed structured mutation contracts. Component identifiers are already
+ * represented in the committed opaque API fingerprint; property inventories
+ * and raw diagnostics remain confined to the ignored local OpenAPI cache.
  */
 export const SCHEMA_AUDIT_MAPPINGS: readonly SchemaAuditMapping[] = [
+  root(
+    'absence-create',
+    'fortnox_create_absencetransaction',
+    'fortnox_Lon_AbsenceTransactionsSinglePayloadItem',
+  ),
+  root(
+    'absence-update',
+    'fortnox_update_absencetransaction',
+    'fortnox_Lon_AbsenceTransactionsSinglePayloadItem',
+  ),
+  root('account-create', 'fortnox_create_account', 'fortnox_Bf_AccountSinglePayloadItem'),
+  root('account-update', 'fortnox_update_account', 'fortnox_Bf_AccountSinglePayloadItem'),
+  root('article-create', 'fortnox_create_article', 'fortnox_ArticleSinglePayloadItem'),
+  root('article-update', 'fortnox_update_article', 'fortnox_ArticleSinglePayloadItem'),
+  root(
+    'attendance-create',
+    'fortnox_create_attendancetransaction',
+    'fortnox_Lon_AttendanceTransactionsSinglePayloadItem',
+  ),
+  root(
+    'attendance-update',
+    'fortnox_update_attendancetransaction',
+    'fortnox_Lon_AttendanceTransactionsSinglePayloadItem',
+  ),
+  root(
+    'contract-accrual-create',
+    'fortnox_create_contract_accrual',
+    'fortnox_ContractInvoice_ContractAccrualSinglePayloadItem',
+  ),
+  root(
+    'contract-accrual-update',
+    'fortnox_update_contract_accrual',
+    'fortnox_ContractInvoice_ContractAccrualSinglePayloadItem',
+  ),
+  root(
+    'contract-create',
+    'fortnox_create_contract',
+    'fortnox_ContractInvoice_ContractCreatePayload',
+  ),
+  root(
+    'contract-update',
+    'fortnox_update_contract',
+    'fortnox_ContractInvoice_ContractUpdatePayload',
+  ),
+  root('cost-center-create', 'fortnox_create_costcenter', 'fortnox_CostCenterSinglePayloadItem'),
+  root('cost-center-update', 'fortnox_update_costcenter', 'fortnox_CostCenterSinglePayloadItem'),
+  root('customer', 'fortnox_create_customer', 'fortnox_Kf_CustomerSinglePayloadItem'),
+  root('customer-update', 'fortnox_update_customer', 'fortnox_Kf_CustomerSinglePayloadItem'),
+  root('employee-create', 'fortnox_create_employee', 'fortnox_Lon_EmployeeSinglePayloadItem'),
+  root('employee-update', 'fortnox_update_employee', 'fortnox_Lon_EmployeeSinglePayloadItem'),
+  root(
+    'financial-year-create',
+    'fortnox_create_financialyear',
+    'fortnox_Bf_FinancialYearSinglePayloadItem',
+  ),
+  root(
+    'invoice-accrual-create',
+    'fortnox_create_invoice_accrual',
+    'fortnox_Kf_InvoiceAccrualSinglePayloadItem',
+  ),
+  root(
+    'invoice-accrual-update',
+    'fortnox_update_invoice_accrual',
+    'fortnox_Kf_InvoiceAccrualSinglePayloadItem',
+  ),
+  root('invoice-create', 'fortnox_create_invoice', 'fortnox_Kf_InvoiceSinglePayloadItem'),
+  root('invoice-update', 'fortnox_update_invoice', 'fortnox_Kf_InvoiceSinglePayloadItem'),
+  root(
+    'invoice-payment-create',
+    'fortnox_create_invoice_payment',
+    'fortnox_Kf_InvoicePaymentSinglePayloadItem',
+  ),
+  root(
+    'invoice-payment-update',
+    'fortnox_update_invoice_payment',
+    'fortnox_Kf_InvoicePaymentSinglePayloadItem',
+  ),
+  root('offer-create', 'fortnox_create_offer', 'fortnox_Offer_OfferSinglePayloadItem'),
+  root('offer-update', 'fortnox_update_offer', 'fortnox_Offer_OfferSinglePayloadItem'),
+  root('order-create', 'fortnox_create_order', 'fortnox_Order_OrderSinglePayloadItem'),
+  root('order-update', 'fortnox_update_order', 'fortnox_Order_OrderSinglePayloadItem'),
+  root('price-create', 'fortnox_create_price', 'fortnox_PriceSinglePayloadItem'),
+  root('price-update', 'fortnox_update_price', 'fortnox_PriceSinglePayloadItem'),
+  root('price-list-create', 'fortnox_create_pricelist', 'fortnox_PriceListSinglePayloadItem'),
+  root('price-list-update', 'fortnox_update_pricelist', 'fortnox_PriceListSinglePayloadItem'),
+  root('project-create', 'fortnox_create_project', 'fortnox_Project_ProjectSinglePayloadItem'),
+  root('project-update', 'fortnox_update_project', 'fortnox_Project_ProjectSinglePayloadItem'),
+  root(
+    'salary-transaction-create',
+    'fortnox_create_salarytransaction',
+    'fortnox_Lon_SalaryTransactionsSinglePayloadItem',
+  ),
+  root(
+    'salary-transaction-update',
+    'fortnox_update_salarytransaction',
+    'fortnox_Lon_SalaryTransactionsSinglePayloadItem',
+  ),
+  root(
+    'schedule-time-update',
+    'fortnox_update_scheduletime',
+    'fortnox_Lon_ScheduleTimeSinglePayloadItem',
+  ),
+  root(
+    'schedule-time-reset',
+    'fortnox_reset_scheduletime_day',
+    'fortnox_Lon_ScheduleTimeSinglePayloadItem',
+  ),
+  root('supplier', 'fortnox_create_supplier', 'fortnox_Lf_SupplierSinglePayloadItem'),
+  root('supplier-update', 'fortnox_update_supplier', 'fortnox_Lf_SupplierSinglePayloadItem'),
+  root(
+    'supplier-invoice-create',
+    'fortnox_create_supplier_invoice',
+    'fortnox_Lf_SupplierInvoiceSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-update',
+    'fortnox_update_supplier_invoice',
+    'fortnox_Lf_SupplierInvoiceSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-accrual-create',
+    'fortnox_create_supplier_invoice_accrual',
+    'fortnox_Lf_SupplierInvoiceAccrualSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-accrual-update',
+    'fortnox_update_supplier_invoice_accrual',
+    'fortnox_Lf_SupplierInvoiceAccrualSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-payment-create',
+    'fortnox_create_supplier_invoice_payment',
+    'fortnox_Lf_SupplierInvoicePaymentSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-payment-update',
+    'fortnox_update_supplier_invoice_payment',
+    'fortnox_Lf_SupplierInvoicePaymentSinglePayloadItem',
+  ),
+  root(
+    'supplier-invoice-file-connection-create',
+    'fortnox_create_supplier_invoice_file_connection',
+    'fortnox_Da_SupplierInvoiceFileConnectionSinglePayloadItem',
+  ),
+  root('tax-reduction-create', 'fortnox_create_taxreduction', 'fortnox_TaxReductionCreatePayload'),
+  root('tax-reduction-update', 'fortnox_update_taxreduction', 'fortnox_TaxReductionUpdatePayload'),
+  root('voucher-create', 'fortnox_create_voucher', 'fortnox_Bf_VoucherSinglePayloadItem'),
+  root(
+    'document-attachment-create',
+    'fortnox_create_document_attachment',
+    'fileattachments_Attachment',
+  ),
+  root(
+    'document-attachment-update',
+    'fortnox_update_document_attachment',
+    'fileattachments_Attachment',
+  ),
+  root(
+    'recurring-invoice-request-create',
+    'fortnox_create_recurring_invoice_request',
+    'Recurring-API_CreateInvoiceRequest',
+  ),
+  {
+    id: 'document-attachment-validate-item',
+    toolName: 'fortnox_validate_attachments_on_send',
+    toolSchemaPointer: '/properties/attachments/items',
+    specSchemaName: 'fileattachments_Attachment',
+  },
+  {
+    id: 'recurring-patch-document',
+    toolName: 'fortnox_patch_recurring',
+    toolSchemaPointer: '/properties/operations',
+    specSchemaName: 'Recurring-API_JsonPatchDocument',
+  },
+  // Preserve the original high-risk nested mapping IDs and their history.
   {
     id: 'invoice-row',
     toolName: 'fortnox_create_invoice',
@@ -26,12 +207,6 @@ export const SCHEMA_AUDIT_MAPPINGS: readonly SchemaAuditMapping[] = [
     specSchemaName: 'fortnox_Order_OrderRowSinglePayloadItem',
   },
   {
-    id: 'supplier',
-    toolName: 'fortnox_create_supplier',
-    toolSchemaPointer: '',
-    specSchemaName: 'fortnox_Lf_SupplierSinglePayloadItem',
-  },
-  {
     id: 'supplier-invoice-row',
     toolName: 'fortnox_create_supplier_invoice',
     toolSchemaPointer: '/properties/SupplierInvoiceRows/items',
@@ -43,4 +218,212 @@ export const SCHEMA_AUDIT_MAPPINGS: readonly SchemaAuditMapping[] = [
     toolSchemaPointer: '/properties/VoucherRows/items',
     specSchemaName: 'fortnox_Bf_VoucherRowSinglePayloadItem',
   },
+];
+
+const action = (id: string, toolName: string, rationale: string): MutationAuditException => ({
+  id,
+  toolName,
+  kind: 'no-structured-body',
+  rationale,
+});
+
+const fileAction = (id: string, toolName: string, rationale: string): MutationAuditException => ({
+  id,
+  toolName,
+  kind: 'binary-or-local-file',
+  rationale,
+});
+
+/** Reviewed non-schema exceptions. Every passthrough names its preservation test. */
+export const SCHEMA_AUDIT_EXCEPTIONS: readonly MutationAuditException[] = [
+  action(
+    'supplier-invoice-approval-bookkeep',
+    'fortnox_approval_bookkeep_supplier_invoice',
+    'Identifier-only workflow transition; no JSON request object is accepted.',
+  ),
+  action(
+    'supplier-invoice-approval-payment',
+    'fortnox_approval_payment_supplier_invoice',
+    'Identifier-only workflow transition; no JSON request object is accepted.',
+  ),
+  fileAction(
+    'invoice-file-orchestration',
+    'fortnox_attach_invoice_files',
+    'Local file upload plus attachment orchestration is covered by binary-safety and payload-preservation tests.',
+  ),
+  fileAction(
+    'voucher-file-orchestration',
+    'fortnox_attach_voucher_files',
+    'Local file upload plus voucher connection orchestration is covered by binary-safety and payload-preservation tests.',
+  ),
+  action('invoice-bookkeep', 'fortnox_bookkeep_invoice', 'Identifier-only workflow transition.'),
+  action(
+    'invoice-payment-bookkeep',
+    'fortnox_bookkeep_invoice_payment',
+    'Identifier-only workflow transition.',
+  ),
+  action(
+    'supplier-invoice-bookkeep',
+    'fortnox_bookkeep_supplier_invoice',
+    'Identifier-only workflow transition.',
+  ),
+  action(
+    'supplier-payment-bookkeep',
+    'fortnox_bookkeep_supplier_invoice_payment',
+    'Identifier-only workflow transition.',
+  ),
+  action('invoice-cancel', 'fortnox_cancel_invoice', 'Identifier-only workflow transition.'),
+  action('offer-cancel', 'fortnox_cancel_offer', 'Identifier-only workflow transition.'),
+  action('order-cancel', 'fortnox_cancel_order', 'Identifier-only workflow transition.'),
+  action(
+    'supplier-invoice-cancel',
+    'fortnox_cancel_supplier_invoice',
+    'Identifier-only workflow transition.',
+  ),
+  action(
+    'invoice-from-contract',
+    'fortnox_create_invoice_from_contract',
+    'Identifier-only conversion action.',
+  ),
+  action(
+    'invoice-from-offer',
+    'fortnox_create_invoice_from_offer',
+    'Identifier-only conversion action.',
+  ),
+  action(
+    'invoice-from-order',
+    'fortnox_create_invoice_from_order',
+    'Identifier-only conversion action.',
+  ),
+  action(
+    'order-from-offer',
+    'fortnox_create_order_from_offer',
+    'Identifier-only conversion action.',
+  ),
+  {
+    id: 'recurring-create-passthrough',
+    toolName: 'fortnox_create_recurring',
+    kind: 'passthrough',
+    rationale:
+      'The modern recurring provider contract is intentionally passed through unchanged and guarded by ETag workflow tests.',
+    preservationTest: 'tests/tools/recurrings.test.ts:create preserves provider payload',
+  },
+  {
+    id: 'recurring-replace-passthrough',
+    toolName: 'fortnox_replace_recurring',
+    kind: 'passthrough',
+    rationale:
+      'The modern recurring provider contract is intentionally passed through unchanged and guarded by ETag workflow tests.',
+    preservationTest: 'tests/tools/recurrings.test.ts:replace preserves provider payload',
+  },
+  action('invoice-credit', 'fortnox_credit_invoice', 'Identifier-only workflow transition.'),
+  action(
+    'supplier-invoice-credit',
+    'fortnox_credit_supplier_invoice',
+    'Identifier-only workflow transition.',
+  ),
+  action('absence-delete', 'fortnox_delete_absencetransaction', 'Identifier-only delete.'),
+  action('account-delete', 'fortnox_delete_account', 'Identifier-only delete.'),
+  action('archive-entry-delete', 'fortnox_delete_archive_entry', 'Identifier/path-only delete.'),
+  action('archive-path-delete', 'fortnox_delete_archive_path', 'Path-only delete.'),
+  action('article-delete', 'fortnox_delete_article', 'Identifier-only delete.'),
+  action('attendance-delete', 'fortnox_delete_attendancetransaction', 'Identifier-only delete.'),
+  action('contract-accrual-delete', 'fortnox_delete_contract_accrual', 'Identifier-only delete.'),
+  action('cost-center-delete', 'fortnox_delete_costcenter', 'Identifier-only delete.'),
+  action('customer-delete', 'fortnox_delete_customer', 'Identifier-only delete.'),
+  action('inbox-entry-delete', 'fortnox_delete_inbox_entry', 'Identifier-only delete.'),
+  action('invoice-accrual-delete', 'fortnox_delete_invoice_accrual', 'Identifier-only delete.'),
+  action('invoice-payment-delete', 'fortnox_delete_invoice_payment', 'Identifier-only delete.'),
+  action('price-delete', 'fortnox_delete_price', 'Composite-identifier-only delete.'),
+  action('project-delete', 'fortnox_delete_project', 'Identifier-only delete.'),
+  action(
+    'salary-transaction-delete',
+    'fortnox_delete_salarytransaction',
+    'Identifier-only delete.',
+  ),
+  action(
+    'supplier-invoice-accrual-delete',
+    'fortnox_delete_supplier_invoice_accrual',
+    'Identifier-only delete.',
+  ),
+  action(
+    'supplier-invoice-file-delete',
+    'fortnox_delete_supplier_invoice_file_connection',
+    'Identifier-only delete.',
+  ),
+  action(
+    'supplier-invoice-payment-delete',
+    'fortnox_delete_supplier_invoice_payment',
+    'Identifier-only delete.',
+  ),
+  action('tax-reduction-delete', 'fortnox_delete_taxreduction', 'Identifier-only delete.'),
+  action(
+    'voucher-file-delete',
+    'fortnox_delete_voucher_file_connection',
+    'Identifier-only delete.',
+  ),
+  action(
+    'document-attachment-delete',
+    'fortnox_detach_document_attachment',
+    'Identifier-only delete.',
+  ),
+  action('offer-email', 'fortnox_email_offer', 'Identifier-only delivery action.'),
+  action('order-email', 'fortnox_email_order', 'Identifier-only delivery action.'),
+  action('invoice-eprint', 'fortnox_eprint_invoice', 'Identifier-only delivery action.'),
+  action(
+    'invoice-external-print',
+    'fortnox_external_print_invoice',
+    'Identifier-only delivery action.',
+  ),
+  action(
+    'offer-external-print',
+    'fortnox_external_print_offer',
+    'Identifier-only delivery action.',
+  ),
+  action(
+    'order-external-print',
+    'fortnox_external_print_order',
+    'Identifier-only delivery action.',
+  ),
+  action('contract-finish', 'fortnox_finish_contract', 'Identifier-only workflow transition.'),
+  action(
+    'contract-increase-count',
+    'fortnox_increase_contract_invoice_count',
+    'Identifier-only workflow transition.',
+  ),
+  action(
+    'invoice-send',
+    'fortnox_send_invoice',
+    'Delivery options are query parameters rather than a Fortnox JSON request contract.',
+  ),
+  fileAction(
+    'invoice-pdf',
+    'fortnox_invoice_pdf',
+    'Binary preview/print workflow; mutation controls and file bytes are covered by PDF safety tests.',
+  ),
+  fileAction(
+    'invoice-reminder-pdf',
+    'fortnox_invoice_reminder_pdf',
+    'Binary reminder-print workflow; mutation controls and file bytes are covered by PDF safety tests.',
+  ),
+  fileAction(
+    'offer-pdf',
+    'fortnox_offer_pdf',
+    'Binary preview/print workflow; mutation controls and file bytes are covered by PDF safety tests.',
+  ),
+  fileAction(
+    'order-pdf',
+    'fortnox_order_pdf',
+    'Binary preview/print workflow; mutation controls and file bytes are covered by PDF safety tests.',
+  ),
+  fileAction(
+    'archive-upload',
+    'fortnox_upload_archive_file',
+    'Multipart binary upload; verified by file operation and safety tests.',
+  ),
+  fileAction(
+    'inbox-upload',
+    'fortnox_upload_inbox_file',
+    'Multipart binary upload; verified by file operation and safety tests.',
+  ),
 ];

--- a/src/schema-audit.ts
+++ b/src/schema-audit.ts
@@ -18,6 +18,31 @@ export interface SchemaAuditMapping {
   /** Component name under components.schemas in the local OpenAPI cache. */
   specSchemaName: string;
   ignoredProperties?: readonly string[];
+  /** Opaque, reviewed exceptions for compatibility differences that are intentional. */
+  compatibilityExceptions?: readonly SchemaAuditCompatibilityException[];
+}
+
+export type SchemaAuditDimension =
+  | 'field'
+  | 'nesting'
+  | 'requiredness'
+  | 'type'
+  | 'enum'
+  | 'nullability'
+  | 'constraint'
+  | 'strictness';
+
+export interface SchemaAuditCompatibilityException {
+  issueHash: string;
+  rationale: string;
+}
+
+export interface MutationAuditException {
+  id: string;
+  toolName: string;
+  kind: 'no-structured-body' | 'binary-or-local-file' | 'passthrough';
+  rationale: string;
+  preservationTest?: string;
 }
 
 export interface SchemaAuditResult {
@@ -26,6 +51,10 @@ export interface SchemaAuditResult {
   specificationPropertyCount: number;
   ignoredProperties: string[];
   missingProperties: string[];
+  checkedNodeCount: number;
+  compatibilityIssueCount: number;
+  resultClass: 'compatible' | 'tracked-gap';
+  issuesByDimension: Record<SchemaAuditDimension, string[]>;
   stateHash: string;
 }
 
@@ -34,12 +63,23 @@ export interface SchemaAuditBaselineRecord {
   declaredPropertyCount: number;
   specificationPropertyCount: number;
   missingPropertyCount: number;
+  checkedNodeCount: number;
+  issuesByDimension: Record<SchemaAuditDimension, number>;
+  resultClass: 'compatible' | 'tracked-gap';
   stateHash: string;
 }
 
 export interface SchemaAuditBaseline {
-  formatVersion: 1;
+  formatVersion: 2;
   records: SchemaAuditBaselineRecord[];
+}
+
+export interface MutationInventoryResult {
+  discoveredMutationCount: number;
+  mappedMutationCount: number;
+  exceptedMutationCount: number;
+  unmappedToolNames: string[];
+  staleExceptionIds: string[];
 }
 
 export interface SchemaAuditComparison {
@@ -82,18 +122,283 @@ function resolvePointer(root: unknown, pointer: string, description: string): un
 
 function sortedPropertyNames(schema: unknown, description: string): string[] {
   const object = asObject(schema, description);
+  if (object['properties'] === undefined) return [];
   const properties = asObject(object['properties'], `${description} properties`);
   return Object.keys(properties).sort(compareText);
 }
 
-function stateHash(mappingId: string, ignored: string[], missing: string[]): string {
+const DIMENSIONS: readonly SchemaAuditDimension[] = [
+  'field',
+  'nesting',
+  'requiredness',
+  'type',
+  'enum',
+  'nullability',
+  'constraint',
+  'strictness',
+];
+
+function issueHash(dimension: SchemaAuditDimension, detail: string): string {
+  return createHash('sha256')
+    .update(`${HASH_DOMAIN}/issue\0${dimension}\0${detail}`, 'utf8')
+    .digest('hex');
+}
+
+function stateHash(
+  mappingId: string,
+  ignored: string[],
+  issuesByDimension: Record<SchemaAuditDimension, string[]>,
+): string {
   const canonical = JSON.stringify({
     domain: HASH_DOMAIN,
     mappingId,
     ignored,
-    missing,
+    issues: Object.fromEntries(
+      DIMENSIONS.map((dimension) => [
+        dimension,
+        issuesByDimension[dimension]
+          .map((detail) => issueHash(dimension, detail))
+          .sort(compareText),
+      ]),
+    ),
   });
   return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+function emptyIssues(): Record<SchemaAuditDimension, string[]> {
+  return Object.fromEntries(DIMENSIONS.map((dimension) => [dimension, []])) as unknown as Record<
+    SchemaAuditDimension,
+    string[]
+  >;
+}
+
+function schemaTypes(schema: JsonObject): Set<string> {
+  const result = new Set<string>();
+  const type = schema['type'];
+  if (typeof type === 'string') result.add(type);
+  else if (Array.isArray(type)) {
+    for (const value of type) if (typeof value === 'string') result.add(value);
+  }
+  if (schema['nullable'] === true || (schema['enum'] as unknown[] | undefined)?.includes(null)) {
+    result.add('null');
+  }
+  for (const keyword of ['anyOf', 'oneOf'] as const) {
+    const alternatives = schema[keyword];
+    if (Array.isArray(alternatives)) {
+      for (const alternative of alternatives) {
+        if (alternative && typeof alternative === 'object' && !Array.isArray(alternative)) {
+          for (const value of schemaTypes(alternative as JsonObject)) result.add(value);
+        }
+      }
+    }
+  }
+  if (result.size === 0) {
+    if (schema['properties']) result.add('object');
+    else if (schema['items']) result.add('array');
+  }
+  return result;
+}
+
+function normalizedPrimitiveTypes(schema: JsonObject): string[] {
+  return [...schemaTypes(schema)]
+    .filter((value) => !['null', 'object', 'array'].includes(value))
+    .map((value) => (value === 'integer' ? 'number' : value))
+    .sort(compareText);
+}
+
+function nesting(schema: JsonObject): 'object' | 'array' | 'scalar' {
+  const types = schemaTypes(schema);
+  if (types.has('object')) return 'object';
+  if (types.has('array')) return 'array';
+  return 'scalar';
+}
+
+function dereferenceSchema(
+  schema: unknown,
+  schemas: JsonObject,
+  seen = new Set<string>(),
+): JsonObject {
+  const object = asObject(schema, 'Schema node');
+  const reference = object['$ref'];
+  if (typeof reference === 'string') {
+    const prefix = '#/components/schemas/';
+    if (!reference.startsWith(prefix))
+      throw new Error('External schema references are unsupported');
+    const name = decodeURIComponent(reference.slice(prefix.length));
+    if (seen.has(name)) return object;
+    if (!Object.hasOwn(schemas, name)) throw new Error('Referenced OpenAPI schema not found');
+    return dereferenceSchema(schemas[name], schemas, new Set([...seen, name]));
+  }
+  const allOf = object['allOf'];
+  if (!Array.isArray(allOf)) return object;
+  const merged: JsonObject = { ...object };
+  delete merged['allOf'];
+  const properties: JsonObject = { ...(object['properties'] as JsonObject | undefined) };
+  const required = new Set(Array.isArray(object['required']) ? object['required'] : []);
+  for (const member of allOf) {
+    const expanded = dereferenceSchema(member, schemas, seen);
+    Object.assign(properties, expanded['properties'] as JsonObject | undefined);
+    for (const value of Array.isArray(expanded['required']) ? expanded['required'] : []) {
+      if (typeof value === 'string') required.add(value);
+    }
+    for (const [key, value] of Object.entries(expanded)) {
+      if (!['properties', 'required'].includes(key) && merged[key] === undefined)
+        merged[key] = value;
+    }
+  }
+  if (Object.keys(properties).length) merged['properties'] = properties;
+  if (required.size) merged['required'] = [...required];
+  return merged;
+}
+
+const CONSTRAINT_KEYS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'format',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+] as const;
+
+function canonicalValue(value: unknown): string {
+  return JSON.stringify(value, (_key, nested) =>
+    nested && typeof nested === 'object' && !Array.isArray(nested)
+      ? Object.fromEntries(
+          Object.entries(nested).sort(([left], [right]) => compareText(left, right)),
+        )
+      : nested,
+  );
+}
+
+function compareSchemaNodes(
+  toolSchema: unknown,
+  specificationSchema: unknown,
+  schemas: JsonObject,
+  ignored: Set<string>,
+  exceptionHashes: Set<string>,
+): {
+  checkedNodeCount: number;
+  issues: Record<SchemaAuditDimension, string[]>;
+} {
+  const issues = emptyIssues();
+  let checkedNodeCount = 0;
+  const addIssue = (dimension: SchemaAuditDimension, detail: string) => {
+    if (!exceptionHashes.has(issueHash(dimension, detail))) issues[dimension].push(detail);
+  };
+
+  const visit = (
+    toolValue: unknown,
+    specValue: unknown,
+    path: string,
+    requiredBySpec: boolean,
+    requiredByTool: boolean,
+  ) => {
+    const tool = asObject(toolValue, `Tool schema at ${path || '<root>'}`);
+    const specification = dereferenceSchema(specValue, schemas);
+    checkedNodeCount += 1;
+
+    const specNesting = nesting(specification);
+    const toolNesting = nesting(tool);
+    if (specNesting !== toolNesting) {
+      addIssue('nesting', `${path || '<root>'}:${specNesting}:${toolNesting}`);
+      return;
+    }
+    if (requiredBySpec !== requiredByTool) {
+      addIssue('requiredness', `${path || '<root>'}:${requiredBySpec}:${requiredByTool}`);
+    }
+    const specNullable = schemaTypes(specification).has('null');
+    const toolNullable = schemaTypes(tool).has('null');
+    if (specNullable !== toolNullable) {
+      addIssue('nullability', `${path || '<root>'}:${specNullable}:${toolNullable}`);
+    }
+    if (specNesting === 'scalar') {
+      const expectedTypes = normalizedPrimitiveTypes(specification);
+      const actualTypes = normalizedPrimitiveTypes(tool);
+      if (canonicalValue(expectedTypes) !== canonicalValue(actualTypes)) {
+        addIssue(
+          'type',
+          `${path || '<root>'}:${canonicalValue(expectedTypes)}:${canonicalValue(actualTypes)}`,
+        );
+      }
+      const expectedEnum = Array.isArray(specification['enum']) ? specification['enum'] : undefined;
+      const actualEnum = Array.isArray(tool['enum']) ? tool['enum'] : undefined;
+      if (expectedEnum || actualEnum) {
+        const expected = [...(expectedEnum ?? [])].sort();
+        const actual = [...(actualEnum ?? [])].sort();
+        if (canonicalValue(expected) !== canonicalValue(actual)) {
+          addIssue(
+            'enum',
+            `${path || '<root>'}:${canonicalValue(expected)}:${canonicalValue(actual)}`,
+          );
+        }
+      }
+    }
+    for (const key of CONSTRAINT_KEYS) {
+      if (specification[key] !== undefined || tool[key] !== undefined) {
+        if (canonicalValue(specification[key]) !== canonicalValue(tool[key])) {
+          addIssue(
+            'constraint',
+            `${path || '<root>'}:${key}:${canonicalValue(specification[key])}:${canonicalValue(tool[key])}`,
+          );
+        }
+      }
+    }
+
+    if (specNesting === 'array') {
+      if (specification['items'] && tool['items']) {
+        visit(tool['items'], specification['items'], `${path}[]`, false, false);
+      }
+      return;
+    }
+    if (specNesting !== 'object') return;
+    if (tool['additionalProperties'] !== false) {
+      addIssue('strictness', `${path || '<root>'}:additionalProperties`);
+    }
+    const specificationProperties = asObject(
+      specification['properties'] ?? {},
+      `OpenAPI schema properties at ${path || '<root>'}`,
+    );
+    const toolProperties = asObject(
+      tool['properties'] ?? {},
+      `Tool schema properties at ${path || '<root>'}`,
+    );
+    const requiredSpec = new Set(
+      (Array.isArray(specification['required']) ? specification['required'] : []).filter(
+        (value): value is string => typeof value === 'string',
+      ),
+    );
+    const requiredTool = new Set(
+      (Array.isArray(tool['required']) ? tool['required'] : []).filter(
+        (value): value is string => typeof value === 'string',
+      ),
+    );
+    for (const [property, childSpec] of Object.entries(specificationProperties).sort(
+      ([left], [right]) => compareText(left, right),
+    )) {
+      const childPath = path ? `${path}.${property}` : property;
+      if (ignored.has(property) || ignored.has(childPath)) continue;
+      if (!Object.hasOwn(toolProperties, property)) {
+        addIssue('field', childPath);
+        continue;
+      }
+      visit(
+        toolProperties[property],
+        childSpec,
+        childPath,
+        requiredSpec.has(property),
+        requiredTool.has(property),
+      );
+    }
+  };
+  visit(toolSchema, specificationSchema, '', false, false);
+  for (const dimension of DIMENSIONS) issues[dimension].sort(compareText);
+  return { checkedNodeCount, issues };
 }
 
 export function auditSchemaCoverage(
@@ -126,15 +431,31 @@ export function auditSchemaCoverage(
       `Tool schema for ${mapping.id}`,
     );
     const declared = sortedPropertyNames(toolSchema, `Tool schema for ${mapping.id}`);
+    const specificationSchema = schemas[mapping.specSchemaName];
     const specification = sortedPropertyNames(
-      schemas[mapping.specSchemaName],
+      dereferenceSchema(specificationSchema, schemas),
       `OpenAPI schema for ${mapping.id}`,
     );
     const ignored = [...new Set(mapping.ignoredProperties ?? [])].sort(compareText);
-    const declaredSet = new Set(declared);
-    const ignoredSet = new Set(ignored);
-    const missing = specification.filter(
-      (property) => !declaredSet.has(property) && !ignoredSet.has(property),
+    const exceptionHashes = new Set(
+      (mapping.compatibilityExceptions ?? []).map(({ issueHash: identity, rationale }) => {
+        if (!identity || !rationale.trim()) {
+          throw new Error(`Invalid compatibility exception for mapping ${mapping.id}`);
+        }
+        return identity;
+      }),
+    );
+    const comparison = compareSchemaNodes(
+      toolSchema,
+      specificationSchema,
+      schemas,
+      new Set(ignored),
+      exceptionHashes,
+    );
+    const missing = comparison.issues.field;
+    const compatibilityIssueCount = DIMENSIONS.reduce(
+      (count, dimension) => count + comparison.issues[dimension].length,
+      0,
     );
 
     return {
@@ -143,7 +464,12 @@ export function auditSchemaCoverage(
       specificationPropertyCount: specification.length,
       ignoredProperties: ignored,
       missingProperties: missing,
-      stateHash: stateHash(mapping.id, ignored, missing),
+      checkedNodeCount: comparison.checkedNodeCount,
+      compatibilityIssueCount,
+      resultClass: (compatibilityIssueCount === 0 ? 'compatible' : 'tracked-gap') as
+        'compatible' | 'tracked-gap',
+      issuesByDimension: comparison.issues,
+      stateHash: stateHash(mapping.id, ignored, comparison.issues),
     };
   });
 
@@ -152,7 +478,7 @@ export function auditSchemaCoverage(
 
 export function toAuditBaseline(results: readonly SchemaAuditResult[]): SchemaAuditBaseline {
   return {
-    formatVersion: 1,
+    formatVersion: 2,
     records: [...results]
       .sort((a, b) => compareText(a.id, b.id))
       .map((result) => ({
@@ -160,6 +486,11 @@ export function toAuditBaseline(results: readonly SchemaAuditResult[]): SchemaAu
         declaredPropertyCount: result.declaredPropertyCount,
         specificationPropertyCount: result.specificationPropertyCount,
         missingPropertyCount: result.missingProperties.length,
+        checkedNodeCount: result.checkedNodeCount,
+        issuesByDimension: Object.fromEntries(
+          DIMENSIONS.map((dimension) => [dimension, result.issuesByDimension[dimension].length]),
+        ) as Record<SchemaAuditDimension, number>,
+        resultClass: result.compatibilityIssueCount === 0 ? 'compatible' : 'tracked-gap',
         stateHash: result.stateHash,
       })),
   };
@@ -194,11 +525,17 @@ export function formatAuditSummary(
   comparison?: SchemaAuditComparison,
 ): string {
   const status = comparison ? (comparison.matches ? 'ok' : 'drift') : 'generated';
-  const lines = [`Schema audit: ${status}`];
-  for (const result of [...results].sort((a, b) => compareText(a.id, b.id))) {
-    lines.push(
-      `${result.id}: declared=${result.declaredPropertyCount} spec=${result.specificationPropertyCount} missing=${result.missingProperties.length} state=${result.stateHash}`,
-    );
+  const totals = {
+    compatible: results.filter(({ resultClass }) => resultClass === 'compatible').length,
+    trackedGap: results.filter(({ resultClass }) => resultClass === 'tracked-gap').length,
+    nodes: results.reduce((count, result) => count + result.checkedNodeCount, 0),
+    issues: results.reduce((count, result) => count + result.compatibilityIssueCount, 0),
+  };
+  const lines = [
+    `Schema audit: ${status} mappings=${results.length} compatible=${totals.compatible} tracked-gap=${totals.trackedGap} nodes=${totals.nodes} issues=${totals.issues} ${DIMENSIONS.map((dimension) => `${dimension}=${results.reduce((count, result) => count + result.issuesByDimension[dimension].length, 0)}`).join(' ')}`,
+  ];
+  if (comparison && !comparison.matches) {
+    lines.push(`Changed mappings: ${comparison.changedMappingIds.join(', ')}`);
   }
   return `${lines.join('\n')}\n`;
 }
@@ -209,8 +546,61 @@ export function formatAuditFields(results: readonly SchemaAuditResult[]): string
     lines.push(`${result.id}:`);
     // Property names originate in a fetched document. JSON quoting preserves
     // their exact value while preventing terminal control-sequence injection.
-    lines.push(...result.missingProperties.map((property) => `  - ${JSON.stringify(property)}`));
-    if (result.missingProperties.length === 0) lines.push('  (none)');
+    for (const dimension of DIMENSIONS) {
+      lines.push(`  ${dimension}:`);
+      const issues = result.issuesByDimension[dimension];
+      lines.push(...issues.map((issue) => `    - ${JSON.stringify(issue)}`));
+      if (issues.length === 0) lines.push('    (none)');
+    }
   }
   return `${lines.join('\n')}\n`;
+}
+
+export function auditMutationInventory(
+  tools: readonly DiscoveredToolSchema[],
+  mappings: readonly SchemaAuditMapping[],
+  exceptions: readonly MutationAuditException[],
+): MutationInventoryResult {
+  const mutationTools = tools.filter(({ inputSchema }) => {
+    const properties = inputSchema['properties'];
+    return (
+      properties !== null &&
+      typeof properties === 'object' &&
+      !Array.isArray(properties) &&
+      (Object.hasOwn(properties, 'confirm') || Object.hasOwn(properties, 'dryRun'))
+    );
+  });
+  const discoveredNames = new Set(mutationTools.map(({ name }) => name));
+  const mappedNames = new Set(mappings.map(({ toolName }) => toolName));
+  const exceptionIds = new Set<string>();
+  const exceptionNames = new Set<string>();
+  for (const exception of exceptions) {
+    if (
+      !exception.id ||
+      exceptionIds.has(exception.id) ||
+      exceptionNames.has(exception.toolName) ||
+      !exception.rationale.trim()
+    ) {
+      throw new Error('Invalid or duplicate mutation-audit exception');
+    }
+    if (exception.kind === 'passthrough' && !exception.preservationTest?.trim()) {
+      throw new Error(`Passthrough exception ${exception.id} requires a preservation test`);
+    }
+    exceptionIds.add(exception.id);
+    exceptionNames.add(exception.toolName);
+  }
+  const unmappedToolNames = [...discoveredNames]
+    .filter((name) => !mappedNames.has(name) && !exceptionNames.has(name))
+    .sort(compareText);
+  const staleExceptionIds = exceptions
+    .filter(({ toolName }) => !discoveredNames.has(toolName))
+    .map(({ id }) => id)
+    .sort(compareText);
+  return {
+    discoveredMutationCount: mutationTools.length,
+    mappedMutationCount: [...discoveredNames].filter((name) => mappedNames.has(name)).length,
+    exceptedMutationCount: [...discoveredNames].filter((name) => exceptionNames.has(name)).length,
+    unmappedToolNames,
+    staleExceptionIds,
+  };
 }

--- a/src/tools/absencetransactions.ts
+++ b/src/tools/absencetransactions.ts
@@ -17,7 +17,9 @@ export function registerAbsenceTransactionTools(
   const {
     listAbsenceTransactions,
     getAbsenceTransaction,
+    getAbsenceTransactionByDateCode,
     createAbsenceTransaction,
+    updateAbsenceTransaction,
     deleteAbsenceTransaction,
   } = operations;
   server.tool(
@@ -48,10 +50,17 @@ export function registerAbsenceTransactionTools(
     'Hämta en enskild frånvarotransaktion från Fortnox (kräver Lön-behörigheten).',
     {
       id: z.string().describe('id (UUID) för frånvarotransaktionen'),
+      date: z.string().optional().describe('Datum för sammansatt Fortnox-nyckel (YYYY-MM-DD)'),
+      code: z.string().optional().describe('Frånvarokod för sammansatt Fortnox-nyckel'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
     },
-    async ({ id, includeRaw }) => {
-      const data = await getAbsenceTransaction(id);
+    async ({ id, date, code, includeRaw }) => {
+      if ((date && !code) || (code && !date))
+        throw new Error('date and code must be supplied together');
+      const data =
+        date && code
+          ? await getAbsenceTransactionByDateCode(id, date, code)
+          : await getAbsenceTransaction(id);
       return detailResponse(data, absenceTransactionDetailColumns, data, includeRaw);
     },
   );
@@ -109,6 +118,32 @@ export function registerAbsenceTransactionTools(
 
       await deleteAbsenceTransaction(id);
       return textResponse(`Absence transaction ${id} deleted.`);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_absencetransaction',
+    'Uppdatera en frånvarotransaktion i Fortnox (kräver Lön-behörigheten).',
+    {
+      id: z.string().describe('id (UUID) för frånvarotransaktionen'),
+      EmployeeId: z.string().optional(),
+      CauseCode: z.string().optional(),
+      Date: z.string().optional(),
+      Hours: z.number().optional(),
+      Extent: z.number().optional(),
+      HolidayEntitling: z.boolean().optional(),
+      CostCenter: z.string().optional(),
+      Project: z.string().optional(),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ id, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun)
+        return dryRunResponse(`update absence transaction ${id}`, { AbsenceTransaction: fields });
+      if (!confirm) requireConfirmation(`update absence transaction ${id}`);
+      const data = await updateAbsenceTransaction(id, fields);
+      return detailResponse(data, absenceTransactionDetailColumns, data, includeRaw);
     },
   );
 }

--- a/src/tools/accruals.ts
+++ b/src/tools/accruals.ts
@@ -1,0 +1,222 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z, type ZodType } from 'zod';
+import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import {
+  detailResponse,
+  dryRunResponse,
+  listResponse,
+  requireConfirmation,
+  textResponse,
+} from '../tool-output.js';
+import { referenceDataColumns } from '../views.js';
+
+const Account = z.number().int().min(1000).max(9999);
+const Period = z.enum(['MONTHLY', 'BIMONTHLY', 'QUARTERLY', 'SEMIANNUALLY', 'ANNUALLY']);
+const AccrualRow = z.strictObject({
+  Account,
+  CostCenter: z.string().optional(),
+  Credit: z.number().optional(),
+  Debit: z.number().optional(),
+  Project: z.string().optional(),
+  TransactionInformation: z.string().max(100).optional(),
+});
+
+const commonScheduleFields = {
+  AccrualAccount: Account,
+  EndDate: z.iso.date(),
+  StartDate: z.iso.date(),
+  Total: z.number(),
+  VATIncluded: z.boolean().optional(),
+};
+
+interface AccrualToolDefinition {
+  id: string;
+  swedishName: string;
+  envelope: string;
+  listOperation: string;
+  getOperation: string;
+  createOperation: string;
+  updateOperation: string;
+  deleteOperation: string;
+  fields: Record<string, ZodType>;
+}
+
+export const ACCRUAL_TOOL_DEFINITIONS: readonly AccrualToolDefinition[] = [
+  {
+    id: 'invoice_accrual',
+    swedishName: 'kundfakturaperiodisering',
+    envelope: 'InvoiceAccrual',
+    listOperation: 'listInvoiceAccruals',
+    getOperation: 'getInvoiceAccrual',
+    createOperation: 'createInvoiceAccrual',
+    updateOperation: 'updateInvoiceAccrual',
+    deleteOperation: 'deleteInvoiceAccrual',
+    fields: {
+      ...commonScheduleFields,
+      Description: z.string(),
+      InvoiceNumber: z.number().int(),
+      Period: Period.optional(),
+      RevenueAccount: Account,
+      Times: z.number().int().optional(),
+      InvoiceAccrualRows: z.array(AccrualRow).min(2),
+    },
+  },
+  {
+    id: 'supplier_invoice_accrual',
+    swedishName: 'leverantörsfakturaperiodisering',
+    envelope: 'SupplierInvoiceAccrual',
+    listOperation: 'listSupplierInvoiceAccruals',
+    getOperation: 'getSupplierInvoiceAccrual',
+    createOperation: 'createSupplierInvoiceAccrual',
+    updateOperation: 'updateSupplierInvoiceAccrual',
+    deleteOperation: 'deleteSupplierInvoiceAccrual',
+    fields: {
+      ...commonScheduleFields,
+      Description: z.string().optional(),
+      SupplierInvoiceNumber: z.number().int(),
+      CostAccount: Account,
+      Period,
+      Times: z.number().int(),
+      SupplierInvoiceAccrualRows: z.array(AccrualRow).min(2),
+    },
+  },
+  {
+    id: 'contract_accrual',
+    swedishName: 'avtalsperiodisering',
+    envelope: 'ContractAccrual',
+    listOperation: 'listContractAccruals',
+    getOperation: 'getContractAccrual',
+    createOperation: 'createContractAccrual',
+    updateOperation: 'updateContractAccrual',
+    deleteOperation: 'deleteContractAccrual',
+    fields: {
+      AccrualAccount: Account,
+      AccrualRows: z.array(AccrualRow).min(2),
+      CostAccount: Account,
+      Description: z.string(),
+      DocumentNumber: z.number().int(),
+      Period: Period.optional(),
+      Times: z.number().int().optional(),
+      Total: z.number(),
+      VATIncluded: z.boolean().optional(),
+    },
+  },
+];
+
+type DynamicOperation = (...arguments_: unknown[]) => Promise<unknown>;
+
+export function registerAccrualTools(
+  server: McpServer,
+  operations: FortnoxOperations = defaultFortnoxOperations,
+): void {
+  const dynamic = operations as unknown as Record<string, DynamicOperation>;
+  for (const definition of ACCRUAL_TOOL_DEFINITIONS) {
+    server.tool(
+      `fortnox_list_${definition.id}s`,
+      `Lista ${definition.swedishName}ar i Fortnox`,
+      { includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox') },
+      async ({ includeRaw }) => {
+        const result = (await dynamic[definition.listOperation]?.()) as {
+          items: Record<string, unknown>[];
+          raw: Record<string, unknown>;
+        };
+        if (!result) throw new Error(`Missing operation ${definition.listOperation}`);
+        return listResponse(
+          result.items,
+          referenceDataColumns,
+          result.raw,
+          result.raw.MetaInformation as Record<string, unknown> | undefined,
+          includeRaw,
+        );
+      },
+    );
+
+    server.tool(
+      `fortnox_get_${definition.id}`,
+      `Hämta en ${definition.swedishName} från Fortnox`,
+      {
+        documentNumber: z.string().regex(/^\d+$/).describe('Dokumentnummer'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ documentNumber, includeRaw }) => {
+        const item = (await dynamic[definition.getOperation]?.(documentNumber)) as Record<
+          string,
+          unknown
+        >;
+        return detailResponse(item, referenceDataColumns, item, includeRaw);
+      },
+    );
+
+    server.tool(
+      `fortnox_create_${definition.id}`,
+      `Skapa en ${definition.swedishName} i Fortnox`,
+      {
+        ...definition.fields,
+        confirm: z.boolean().optional().describe('Bekräfta att periodiseringen ska skapas'),
+        dryRun: z.boolean().optional().describe('Visa exakt payload utan att skapa'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async (arguments_) => {
+        const fields = { ...(arguments_ as Record<string, unknown>) };
+        const { confirm, dryRun, includeRaw } = fields;
+        delete fields.confirm;
+        delete fields.dryRun;
+        delete fields.includeRaw;
+        const target = `create ${definition.id}`;
+        if (dryRun) return dryRunResponse(target, { [definition.envelope]: fields });
+        if (!confirm) requireConfirmation(target);
+        const item = (await dynamic[definition.createOperation]?.(fields)) as Record<
+          string,
+          unknown
+        >;
+        return detailResponse(item, referenceDataColumns, item, Boolean(includeRaw));
+      },
+    );
+
+    server.tool(
+      `fortnox_update_${definition.id}`,
+      `Uppdatera en ${definition.swedishName} i Fortnox`,
+      {
+        documentNumber: z.string().regex(/^\d+$/).describe('Dokumentnummer'),
+        ...definition.fields,
+        confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+        dryRun: z.boolean().optional().describe('Visa exakt payload utan att uppdatera'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async (arguments_) => {
+        const fields = { ...(arguments_ as Record<string, unknown>) };
+        const documentNumber = String(fields.documentNumber);
+        const { confirm, dryRun, includeRaw } = fields;
+        delete fields.documentNumber;
+        delete fields.confirm;
+        delete fields.dryRun;
+        delete fields.includeRaw;
+        const target = `update ${definition.id} ${documentNumber}`;
+        if (dryRun) return dryRunResponse(target, { [definition.envelope]: fields });
+        if (!confirm) requireConfirmation(target);
+        const item = (await dynamic[definition.updateOperation]?.(
+          documentNumber,
+          fields,
+        )) as Record<string, unknown>;
+        return detailResponse(item, referenceDataColumns, item, Boolean(includeRaw));
+      },
+    );
+
+    server.tool(
+      `fortnox_delete_${definition.id}`,
+      `Ta bort en ${definition.swedishName} i Fortnox`,
+      {
+        documentNumber: z.string().regex(/^\d+$/).describe('Dokumentnummer'),
+        confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+        dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+      },
+      async ({ documentNumber, confirm, dryRun }) => {
+        const target = `delete ${definition.id} ${documentNumber}`;
+        if (dryRun) return dryRunResponse(target);
+        if (!confirm) requireConfirmation(target);
+        await dynamic[definition.deleteOperation]?.(documentNumber);
+        return textResponse(`${definition.envelope} ${documentNumber} deleted.`);
+      },
+    );
+  }
+}

--- a/src/tools/accruals.ts
+++ b/src/tools/accruals.ts
@@ -11,7 +11,15 @@ import {
 import { referenceDataColumns } from '../views.js';
 
 const Account = z.number().int().min(1000).max(9999);
-const Period = z.enum(['MONTHLY', 'BIMONTHLY', 'QUARTERLY', 'SEMIANNUALLY', 'ANNUALLY']);
+const ContractPeriod = z.enum(['MONTHLY', 'BIMONTHLY', 'QUARTERLY', 'SEMIANNUALLY', 'ANNUALLY']);
+const InvoicePeriod = z.enum([
+  ...ContractPeriod.options,
+  '1_MONTHS',
+  '2_MONTHS',
+  '3_MONTHS',
+  '6_MONTHS',
+  '12_MONTHS',
+]);
 const AccrualRow = z.strictObject({
   Account,
   CostCenter: z.string().optional(),
@@ -55,7 +63,7 @@ export const ACCRUAL_TOOL_DEFINITIONS: readonly AccrualToolDefinition[] = [
       ...commonScheduleFields,
       Description: z.string(),
       InvoiceNumber: z.number().int(),
-      Period: Period.optional(),
+      Period: InvoicePeriod.optional(),
       RevenueAccount: Account,
       Times: z.number().int().optional(),
       InvoiceAccrualRows: z.array(AccrualRow).min(2),
@@ -75,7 +83,7 @@ export const ACCRUAL_TOOL_DEFINITIONS: readonly AccrualToolDefinition[] = [
       Description: z.string().optional(),
       SupplierInvoiceNumber: z.number().int(),
       CostAccount: Account,
-      Period,
+      Period: InvoicePeriod,
       Times: z.number().int(),
       SupplierInvoiceAccrualRows: z.array(AccrualRow).min(2),
     },
@@ -95,7 +103,7 @@ export const ACCRUAL_TOOL_DEFINITIONS: readonly AccrualToolDefinition[] = [
       CostAccount: Account,
       Description: z.string(),
       DocumentNumber: z.number().int(),
-      Period: Period.optional(),
+      Period: ContractPeriod.optional(),
       Times: z.number().int().optional(),
       Total: z.number(),
       VATIncluded: z.boolean().optional(),

--- a/src/tools/articles.ts
+++ b/src/tools/articles.ts
@@ -7,13 +7,14 @@ import {
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 export function registerArticleTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listArticles, getArticle, createArticle, updateArticle } = operations;
+  const { listArticles, getArticle, createArticle, updateArticle, deleteArticle } = operations;
   server.tool(
     'fortnox_list_articles',
     'Lista/sök artiklar i Fortnox. Returnerar: ArticleNumber, Description, SalesPrice, Unit, Active.',
@@ -109,6 +110,26 @@ export function registerArticleTools(
 
       const data = await updateArticle(articleNumber, fields);
       return detailResponse(data, articleDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_article',
+    'Ta bort en artikel i Fortnox',
+    {
+      articleNumber: z.string().describe('Artikelnummer att ta bort'),
+      confirm: z.boolean().optional().describe('Bekräfta att artikeln ska tas bort'),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe('Visa vad som skulle göras utan att ta bort artikeln'),
+    },
+    async ({ articleNumber, confirm, dryRun }) => {
+      if (dryRun) return dryRunResponse(`delete article ${articleNumber}`);
+      if (!confirm) requireConfirmation(`delete article ${articleNumber}`);
+
+      await deleteArticle(articleNumber);
+      return textResponse(`Article ${articleNumber} deleted.`);
     },
   );
 }

--- a/src/tools/attendancetransactions.ts
+++ b/src/tools/attendancetransactions.ts
@@ -17,7 +17,9 @@ export function registerAttendanceTransactionTools(
   const {
     listAttendanceTransactions,
     getAttendanceTransaction,
+    getAttendanceTransactionByDateCode,
     createAttendanceTransaction,
+    updateAttendanceTransaction,
     deleteAttendanceTransaction,
   } = operations;
   server.tool(
@@ -48,10 +50,17 @@ export function registerAttendanceTransactionTools(
     'Hämta en enskild närvarotransaktion från Fortnox (kräver Lön-behörigheten).',
     {
       id: z.string().describe('id (UUID) för närvarotransaktionen'),
+      date: z.string().optional().describe('Datum för sammansatt Fortnox-nyckel (YYYY-MM-DD)'),
+      code: z.string().optional().describe('Närvarokod för sammansatt Fortnox-nyckel'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
     },
-    async ({ id, includeRaw }) => {
-      const data = await getAttendanceTransaction(id);
+    async ({ id, date, code, includeRaw }) => {
+      if ((date && !code) || (code && !date))
+        throw new Error('date and code must be supplied together');
+      const data =
+        date && code
+          ? await getAttendanceTransactionByDateCode(id, date, code)
+          : await getAttendanceTransaction(id);
       return detailResponse(data, attendanceTransactionDetailColumns, data, includeRaw);
     },
   );
@@ -111,6 +120,32 @@ export function registerAttendanceTransactionTools(
 
       await deleteAttendanceTransaction(id);
       return textResponse(`Attendance transaction ${id} deleted.`);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_attendancetransaction',
+    'Uppdatera en närvarotransaktion i Fortnox (kräver Lön-behörigheten).',
+    {
+      id: z.string().describe('id (UUID) för närvarotransaktionen'),
+      EmployeeId: z.string().optional(),
+      CauseCode: z.string().optional(),
+      Date: z.string().optional(),
+      Hours: z.string().optional(),
+      CostCenter: z.string().optional(),
+      Project: z.string().optional(),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ id, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun)
+        return dryRunResponse(`update attendance transaction ${id}`, {
+          AttendanceTransaction: fields,
+        });
+      if (!confirm) requireConfirmation(`update attendance transaction ${id}`);
+      const data = await updateAttendanceTransaction(id, fields);
+      return detailResponse(data, attendanceTransactionDetailColumns, data, includeRaw);
     },
   );
 }

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -1,16 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import {
-  closeSync,
-  constants as fsConstants,
-  lstatSync,
-  mkdtempSync,
-  openSync,
-  writeSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
 import {
   accountListColumns,
   voucherAttachmentColumns,
@@ -25,57 +16,6 @@ import {
   requireConfirmation,
   textResponse,
 } from '../tool-output.js';
-
-/**
- * Write a downloaded file to `target`, refusing to write through a symlink.
- * Mirrors writePdf() in tools/invoices.ts, generalized to an arbitrary
- * buffer/content-type rather than an assumed PDF — voucher attachments can be
- * PDF, JPEG, PNG, etc.
- *
- * These paths come from tool arguments, i.e. they are model-generated and can
- * be influenced by whatever the model just read. O_EXCL already refuses to
- * follow a symlink; O_NOFOLLOW gives the overwrite path the same guarantee,
- * so "replace this file" can never silently truncate a symlink's target
- * instead. O_NOFOLLOW is POSIX-only, so Windows falls back to an explicit
- * lstat check.
- */
-function writeBinaryFile(target: string, data: Buffer, overwrite?: boolean): void {
-  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
-  const flags = overwrite
-    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
-    : O_WRONLY | O_CREAT | O_EXCL;
-
-  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
-    throw new Error(
-      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-    );
-  }
-
-  try {
-    const fd = openSync(target, flags, 0o600);
-    try {
-      let written = 0;
-      while (written < data.length) {
-        written += writeSync(fd, data, written, data.length - written);
-      }
-    } finally {
-      closeSync(fd);
-    }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'EEXIST') {
-      throw new Error(
-        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
-      );
-    }
-    if (code === 'ELOOP') {
-      throw new Error(
-        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-      );
-    }
-    throw err;
-  }
-}
 
 // The full writable VoucherRow field set (Fortnox `VoucherRowSinglePayloadItem`).
 // The MCP SDK strips any key the schema does not declare, so an undeclared field
@@ -156,6 +96,8 @@ export function registerBookkeepingTools(
     attachVoucherFiles,
     listVoucherAttachments,
     getVoucherFile,
+    getVoucherFileConnection,
+    deleteVoucherFileConnection,
     extensionForMime,
   } = operations;
   server.tool(
@@ -416,13 +358,44 @@ export function registerBookkeepingTools(
     async ({ fileId, outputPath, overwrite }) => {
       const file = await getVoucherFile(fileId);
       const ext = extensionForMime(file.contentType);
-      const target = outputPath
-        ? resolve(outputPath)
-        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `voucher-file-${fileId}${ext}`);
-      writeBinaryFile(target, file.buffer, overwrite);
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `voucher-file-${fileId}${ext}`),
+        file.buffer,
+        overwrite,
+      );
       return textResponse(
         `Sparade fil (${file.contentType}, ${file.buffer.length} bytes) till ${target}`,
       );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_voucher_file_connection',
+    'Hämta metadata för en filkoppling till en verifikation i Fortnox',
+    {
+      fileId: z.string().describe('Fil-ID'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ fileId, includeRaw }) => {
+      const connection = await getVoucherFileConnection(fileId);
+      return detailResponse(connection, voucherAttachmentColumns, connection, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_voucher_file_connection',
+    'Koppla loss en fil från en verifikation i Fortnox',
+    {
+      fileId: z.string().describe('Fil-ID'),
+      confirm: z.boolean().optional().describe('Bekräfta bortkopplingen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att koppla loss'),
+    },
+    async ({ fileId, confirm, dryRun }) => {
+      const target = `delete voucher file connection ${fileId}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await deleteVoucherFileConnection(fileId);
+      return textResponse(`Voucher file connection ${fileId} deleted.`);
     },
   );
 }

--- a/src/tools/bookkeeping.ts
+++ b/src/tools/bookkeeping.ts
@@ -113,12 +113,43 @@ const VoucherSeriesSchema = z
   .regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,9}$/, 'Voucher series must be alphanumeric')
   .optional();
 
+const AccountNumberSchema = z.number().int().min(1000).max(9999);
+const AccountSettingsSchema = z.enum(['ALLOWED', 'MANDATORY', 'NOTALLOWED']);
+const AccountWritableFields = {
+  Active: z.boolean().optional().describe('Om kontot är aktivt'),
+  BalanceBroughtForward: z.number().optional().describe('Ingående balans'),
+  CostCenter: z.string().optional().describe('Standardkostnadsställe'),
+  CostCenterSettings: AccountSettingsSchema.optional().describe('Kostnadsställesregel'),
+  Description: z.string().optional().describe('Kontobeskrivning'),
+  OpeningQuantities: z
+    .array(
+      z.strictObject({
+        Project: z.string().optional().describe('Projektnummer'),
+        Balance: z.number().int().optional().describe('Ingående antal'),
+      }),
+    )
+    .optional()
+    .describe('Ingående antal per projekt'),
+  Project: z.string().optional().describe('Standardprojekt'),
+  ProjectSettings: AccountSettingsSchema.optional().describe('Projektregel'),
+  SRU: z.number().int().optional().describe('SRU-kod'),
+  TransactionInformation: z.string().optional().describe('Standardtransaktionsinformation'),
+  TransactionInformationSettings: AccountSettingsSchema.optional().describe(
+    'Regel för transaktionsinformation',
+  ),
+  VATCode: z.string().optional().describe('Momskod'),
+};
+
 export function registerBookkeepingTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
   const {
     listAccounts,
+    getAccount,
+    createAccount,
+    updateAccount,
+    deleteAccount,
     listVouchers,
     getVoucher,
     createVoucher,
@@ -224,6 +255,72 @@ export function registerBookkeepingTools(
         data.MetaInformation,
         includeRaw,
       );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_account',
+    'Hämta ett konto från kontoplanen i Fortnox',
+    {
+      number: AccountNumberSchema.describe('Kontonummer'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ number, includeRaw }) => {
+      const data = await getAccount(number);
+      return detailResponse(data, accountListColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_account',
+    'Skapa ett konto i Fortnox',
+    {
+      ...AccountWritableFields,
+      Number: AccountNumberSchema.describe('Kontonummer'),
+      Description: z.string().describe('Kontobeskrivning'),
+      confirm: z.boolean().optional().describe('Bekräfta att kontot ska skapas'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att skapa kontot'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) return dryRunResponse(`create account ${fields.Number}`, { Account: fields });
+      if (!confirm) requireConfirmation(`create account ${fields.Number}`);
+      const data = await createAccount(fields);
+      return detailResponse(data, accountListColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_account',
+    'Uppdatera ett konto i Fortnox',
+    {
+      number: AccountNumberSchema.describe('Kontonummer att uppdatera'),
+      ...AccountWritableFields,
+      confirm: z.boolean().optional().describe('Bekräfta att kontot ska uppdateras'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera kontot'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ number, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) return dryRunResponse(`update account ${number}`, { Account: fields });
+      if (!confirm) requireConfirmation(`update account ${number}`);
+      const data = await updateAccount(number, fields);
+      return detailResponse(data, accountListColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_account',
+    'Ta bort ett konto i Fortnox',
+    {
+      number: AccountNumberSchema.describe('Kontonummer att ta bort'),
+      confirm: z.boolean().optional().describe('Bekräfta att kontot ska tas bort'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort kontot'),
+    },
+    async ({ number, confirm, dryRun }) => {
+      if (dryRun) return dryRunResponse(`delete account ${number}`);
+      if (!confirm) requireConfirmation(`delete account ${number}`);
+      await deleteAccount(number);
+      return textResponse(`Account ${number} deleted.`);
     },
   );
 

--- a/src/tools/contracts.ts
+++ b/src/tools/contracts.ts
@@ -19,7 +19,7 @@ const invoiceRowSchema = z
     VAT: z.number().optional().describe('Momssats (%)'),
     Discount: z.number().optional().describe('Rabatt'),
   })
-  .passthrough();
+  .strict();
 
 export function registerContractTools(
   server: McpServer,

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -7,6 +7,7 @@ import {
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 const CustomerNumberSchema = z
@@ -93,7 +94,7 @@ export function registerCustomerTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listCustomers, getCustomer, createCustomer, updateCustomer } = operations;
+  const { listCustomers, getCustomer, createCustomer, updateCustomer, deleteCustomer } = operations;
   server.tool(
     'fortnox_list_customers',
     'Lista/sök kunder i Fortnox. Returnerar: CustomerNumber, Name, OrganisationNumber, City, Email.',
@@ -171,6 +172,23 @@ export function registerCustomerTools(
 
       const data = await updateCustomer(customerNumber, fields);
       return detailResponse(data, customerDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_customer',
+    'Ta bort en kund i Fortnox',
+    {
+      customerNumber: CustomerNumberSchema.describe('Kundnummer att ta bort'),
+      confirm: z.boolean().optional().describe('Bekräfta att kunden ska tas bort'),
+      dryRun: z.boolean().optional().describe('Visa vad som skulle göras utan att ta bort kunden'),
+    },
+    async ({ customerNumber, confirm, dryRun }) => {
+      if (dryRun) return dryRunResponse(`delete customer ${customerNumber}`);
+      if (!confirm) requireConfirmation(`delete customer ${customerNumber}`);
+
+      await deleteCustomer(customerNumber);
+      return textResponse(`Customer ${customerNumber} deleted.`);
     },
   );
 }

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -13,6 +13,82 @@ const CustomerNumberSchema = z
   .string()
   .regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,49}$/, 'Customer number must be alphanumeric');
 
+// The full writable Customer field set (Fortnox `CustomerSinglePayloadItem`).
+// The MCP SDK silently strips any argument the schema does not declare, so a
+// field missing here never reaches Fortnox and never raises an error — it just
+// vanishes (#96, same class of bug as the Supplier field gap). The operations
+// layer forwards whatever it is given.
+//
+// Country / DeliveryCountry / VisitingCountry are deliberately NOT declared
+// here: Fortnox rejects them on write ("Fältet Country är endast läsbart") —
+// they're server-derived from the matching *CountryCode field, which is the
+// real writable source and is exposed below. operations/customers.ts strips
+// the *Country fields defensively too, so a `get` response fed straight back
+// into create/update still works, but the tool schema should not offer a
+// field that would then be silently dropped a second time.
+const customerWritableFields = {
+  Name: z.string().optional().describe('Kundnamn'),
+  Type: z.enum(['PRIVATE', 'COMPANY']).optional().describe('Kundtyp: privatperson eller företag'),
+  OrganisationNumber: z.string().optional().describe('Organisations- eller personnummer'),
+  Email: z.string().optional().describe('E-postadress'),
+  Phone1: z.string().optional().describe('Telefonnummer'),
+  Phone2: z.string().optional().describe('Alternativt telefonnummer'),
+  Fax: z.string().optional().describe('Faxnummer'),
+  WWW: z.string().optional().describe('Webbplats'),
+  Address1: z.string().optional().describe('Adressrad 1'),
+  Address2: z.string().optional().describe('Adressrad 2'),
+  ZipCode: z.string().optional().describe('Postnummer'),
+  City: z.string().optional().describe('Ort'),
+  CountryCode: z.string().optional().describe('Landskod (t.ex. "SE") — det skrivbara landfältet'),
+  DeliveryName: z.string().optional().describe('Leveransadress namn'),
+  DeliveryAddress1: z.string().optional().describe('Leveransadress rad 1'),
+  DeliveryAddress2: z.string().optional().describe('Leveransadress rad 2'),
+  DeliveryZipCode: z.string().optional().describe('Leveransadress postnummer'),
+  DeliveryCity: z.string().optional().describe('Leveransadress ort'),
+  DeliveryCountryCode: z.string().optional().describe('Leveransadress landskod'),
+  DeliveryFax: z.string().optional().describe('Leveransadress fax'),
+  DeliveryPhone1: z.string().optional().describe('Leveransadress telefon'),
+  DeliveryPhone2: z.string().optional().describe('Leveransadress alternativt telefon'),
+  VisitingAddress: z.string().optional().describe('Besöksadress'),
+  VisitingZipCode: z.string().optional().describe('Besöksadress postnummer'),
+  VisitingCity: z.string().optional().describe('Besöksadress ort'),
+  VisitingCountryCode: z.string().optional().describe('Besöksadress landskod'),
+  GLN: z.string().optional().describe('GLN-nummer (13 tecken)'),
+  GLNDelivery: z.string().optional().describe('GLN-nummer för leverans (13 tecken)'),
+  ExternalReference: z.string().optional().describe('Externt referens-id'),
+  OurReference: z.string().optional().describe('Vår referens'),
+  YourReference: z.string().optional().describe('Er referens'),
+  Comments: z.string().optional().describe('Kommentarer'),
+  Currency: z.string().optional().describe('Valuta (t.ex. "SEK")'),
+  CostCenter: z.string().optional().describe('Kostnadsställe'),
+  Project: z.string().optional().describe('Projektnummer'),
+  PriceList: z.string().optional().describe('Prislista'),
+  TermsOfDelivery: z.string().optional().describe('Leveransvillkor (kod)'),
+  TermsOfPayment: z.string().optional().describe('Betalningsvillkor (kod)'),
+  WayOfDelivery: z.string().optional().describe('Leveranssätt (kod)'),
+  VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
+  VATType: z
+    .enum(['SEVAT', 'SEREVERSEDVAT', 'EUREVERSEDVAT', 'EUVAT', 'EXPORT'])
+    .optional()
+    .describe('Momstyp'),
+  SalesAccount: z.string().optional().describe('Försäljningskonto (4 siffror)'),
+  InvoiceAdministrationFee: z.string().optional().describe('Faktureringsavgift'),
+  InvoiceDiscount: z.number().optional().describe('Fakturarabatt i procent'),
+  InvoiceFreight: z.string().optional().describe('Fraktavgift'),
+  InvoiceRemark: z.string().optional().describe('Fakturaanmärkning'),
+  ShowPriceVATIncluded: z.boolean().optional().describe('Visa priser inklusive moms'),
+  EmailInvoice: z.string().optional().describe('E-post för fakturor'),
+  EmailInvoiceCC: z.string().optional().describe('Kopia (CC) för fakturamejl'),
+  EmailInvoiceBCC: z.string().optional().describe('Hemlig kopia (BCC) för fakturamejl'),
+  EmailOffer: z.string().optional().describe('E-post för offerter'),
+  EmailOfferCC: z.string().optional().describe('Kopia (CC) för offertmejl'),
+  EmailOfferBCC: z.string().optional().describe('Hemlig kopia (BCC) för offertmejl'),
+  EmailOrder: z.string().optional().describe('E-post för ordrar'),
+  EmailOrderCC: z.string().optional().describe('Kopia (CC) för ordermejl'),
+  EmailOrderBCC: z.string().optional().describe('Hemlig kopia (BCC) för ordermejl'),
+  Active: z.boolean().optional().describe('Aktiv kund'),
+};
+
 export function registerCustomerTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
@@ -42,7 +118,7 @@ export function registerCustomerTools(
 
   server.tool(
     'fortnox_get_customer',
-    'Hämta en enskild kund från Fortnox. Returnerar: CustomerNumber, Name, OrganisationNumber, Email, Phone, Address1, ZipCode, City, Country, VATNumber.',
+    'Hämta en enskild kund från Fortnox. Returnerar: CustomerNumber, Name, Type, OrganisationNumber, Email, Phone1, Address1, ZipCode, City, Country, VATNumber.',
     {
       customerNumber: CustomerNumberSchema.describe('Kundnummer'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
@@ -57,15 +133,8 @@ export function registerCustomerTools(
     'fortnox_create_customer',
     'Skapa en ny kund i Fortnox',
     {
+      ...customerWritableFields,
       Name: z.string().describe('Kundnamn'),
-      OrganisationNumber: z.string().optional().describe('Organisationsnummer'),
-      Email: z.string().optional().describe('E-postadress'),
-      Phone: z.string().optional().describe('Telefonnummer'),
-      Address1: z.string().optional().describe('Adressrad 1'),
-      Address2: z.string().optional().describe('Adressrad 2'),
-      ZipCode: z.string().optional().describe('Postnummer'),
-      City: z.string().optional().describe('Ort'),
-      VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
       confirm: z.boolean().optional().describe('Bekräfta att kunden ska skapas'),
       dryRun: z.boolean().optional().describe('Visa vad som skulle skickas utan att skapa kunden'),
       includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
@@ -86,15 +155,7 @@ export function registerCustomerTools(
     'Uppdatera en befintlig kund i Fortnox',
     {
       customerNumber: CustomerNumberSchema.describe('Kundnummer att uppdatera'),
-      Name: z.string().optional().describe('Kundnamn'),
-      OrganisationNumber: z.string().optional().describe('Organisationsnummer'),
-      Email: z.string().optional().describe('E-postadress'),
-      Phone: z.string().optional().describe('Telefonnummer'),
-      Address1: z.string().optional().describe('Adressrad 1'),
-      Address2: z.string().optional().describe('Adressrad 2'),
-      ZipCode: z.string().optional().describe('Postnummer'),
-      City: z.string().optional().describe('Ort'),
-      VATNumber: z.string().optional().describe('Momsregistreringsnummer'),
+      ...customerWritableFields,
       confirm: z.boolean().optional().describe('Bekräfta att kunden ska uppdateras'),
       dryRun: z
         .boolean()

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -51,17 +51,22 @@ export function registerFileTools(
 
   server.tool(
     'fortnox_get_archive_entry',
-    'Hämta metadata för en arkivpost i Fortnox',
+    'Ladda ner en fil från Fortnox arkiv till en säker lokal sökväg',
     {
       id: z.string().describe('Arkivpostens ID'),
       path: z.string().optional().describe('Arkivsökväg'),
       fileId: z.string().optional().describe('Valfritt fil-ID'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      outputPath: z.string().optional().describe('Målsökväg; utelämna för privat tempkatalog'),
+      overwrite: z.boolean().optional().describe('Tillåt överskrivning av vanlig fil'),
     },
-    async ({ id, path, fileId, includeRaw }) => {
-      const raw = await getArchiveEntry(id, { path, fileId });
-      const folder = (raw.Folder ?? raw) as Record<string, unknown>;
-      return detailResponse(folder, referenceDataColumns, raw, includeRaw);
+    async ({ id, path, fileId, outputPath, overwrite }) => {
+      const file = await getArchiveEntry(id, { path, fileId });
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `archive-${id}`),
+        file.buffer,
+        overwrite,
+      );
+      return textResponse(`Archive file ${id} saved to ${target} (${file.buffer.length} bytes).`);
     },
   );
 

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,0 +1,198 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
+import {
+  detailResponse,
+  dryRunResponse,
+  listResponse,
+  requireConfirmation,
+  textResponse,
+} from '../tool-output.js';
+import { referenceDataColumns } from '../views.js';
+
+function folderItems(raw: Record<string, unknown>): Record<string, unknown>[] {
+  const folder = (raw.Folder ?? {}) as Record<string, unknown>;
+  return [
+    ...((folder.Folders ?? []) as Record<string, unknown>[]),
+    ...((folder.Files ?? []) as Record<string, unknown>[]),
+  ];
+}
+
+export function registerFileTools(
+  server: McpServer,
+  operations: FortnoxOperations = defaultFortnoxOperations,
+): void {
+  const {
+    listArchive,
+    getArchiveEntry,
+    uploadArchiveFile,
+    deleteArchivePath,
+    deleteArchiveEntry,
+    listInbox,
+    uploadInboxEntry,
+    getInboxFile,
+    deleteInboxEntry,
+  } = operations;
+
+  server.tool(
+    'fortnox_list_archive',
+    'Lista mappar och filer i Fortnox arkiv',
+    {
+      path: z.string().optional().describe('Arkivsökväg'),
+      fileId: z.string().optional().describe('Valfritt fil-ID'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ path, fileId, includeRaw }) => {
+      const raw = await listArchive({ path, fileId });
+      return listResponse(folderItems(raw), referenceDataColumns, raw, undefined, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_get_archive_entry',
+    'Hämta metadata för en arkivpost i Fortnox',
+    {
+      id: z.string().describe('Arkivpostens ID'),
+      path: z.string().optional().describe('Arkivsökväg'),
+      fileId: z.string().optional().describe('Valfritt fil-ID'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ id, path, fileId, includeRaw }) => {
+      const raw = await getArchiveEntry(id, { path, fileId });
+      const folder = (raw.Folder ?? raw) as Record<string, unknown>;
+      return detailResponse(folder, referenceDataColumns, raw, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_upload_archive_file',
+    'Ladda upp en lokal fil till Fortnox arkiv',
+    {
+      filePath: z.string().describe('Lokal filsökväg'),
+      folderId: z.string().optional().describe('Målmappens ID'),
+      path: z.string().optional().describe('Målsökväg i arkivet'),
+      confirm: z.boolean().optional().describe('Bekräfta uppladdningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att läsa eller ladda upp filen'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ filePath, folderId, path, confirm, dryRun, includeRaw }) => {
+      const target = `upload ${filePath} to archive`;
+      if (dryRun) return dryRunResponse(target, { folderId, path });
+      if (!confirm) requireConfirmation(target);
+      const raw = await uploadArchiveFile(filePath, { folderId, path });
+      return detailResponse(
+        (raw.File ?? raw) as Record<string, unknown>,
+        referenceDataColumns,
+        raw,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_archive_path',
+    'Ta bort en sökväg i Fortnox arkiv',
+    {
+      path: z.string().min(1).describe('Exakt arkivsökväg att ta bort'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ path, confirm, dryRun }) => {
+      const target = `delete archive path ${JSON.stringify(path)}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await deleteArchivePath(path);
+      return textResponse(`Archive path ${JSON.stringify(path)} deleted.`);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_archive_entry',
+    'Ta bort en post i Fortnox arkiv',
+    {
+      id: z.string().describe('Arkivpostens ID'),
+      path: z.string().optional().describe('Arkivsökväg'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ id, path, confirm, dryRun }) => {
+      const target = `delete archive entry ${id}`;
+      if (dryRun) return dryRunResponse(target, { path });
+      if (!confirm) requireConfirmation(target);
+      await deleteArchiveEntry(id, path);
+      return textResponse(`Archive entry ${id} deleted.`);
+    },
+  );
+
+  server.tool(
+    'fortnox_list_inbox',
+    'Lista mappar och filer i Fortnox inkorg',
+    { includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox') },
+    async ({ includeRaw }) => {
+      const raw = await listInbox();
+      return listResponse(folderItems(raw), referenceDataColumns, raw, undefined, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_upload_inbox_file',
+    'Ladda upp en lokal fil till Fortnox inkorg',
+    {
+      filePath: z.string().describe('Lokal filsökväg'),
+      folderId: z.string().optional().describe('Målmappens ID'),
+      path: z.string().optional().describe('Målsökväg i inkorgen'),
+      confirm: z.boolean().optional().describe('Bekräfta uppladdningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att läsa eller ladda upp filen'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ filePath, folderId, path, confirm, dryRun, includeRaw }) => {
+      const target = `upload ${filePath} to inbox`;
+      if (dryRun) return dryRunResponse(target, { folderId, path });
+      if (!confirm) requireConfirmation(target);
+      const raw = await uploadInboxEntry(filePath, { folderId, path });
+      return detailResponse(
+        (raw.File ?? raw) as Record<string, unknown>,
+        referenceDataColumns,
+        raw,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_inbox_file',
+    'Ladda ner en fil från Fortnox inkorg till en säker lokal sökväg',
+    {
+      id: z.string().describe('Fil-ID'),
+      outputPath: z.string().optional().describe('Målsökväg; utelämna för privat tempkatalog'),
+      overwrite: z.boolean().optional().describe('Tillåt överskrivning av vanlig fil'),
+    },
+    async ({ id, outputPath, overwrite }) => {
+      const file = await getInboxFile(id);
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `inbox-${id}`),
+        file.buffer,
+        overwrite,
+      );
+      return textResponse(`Inbox file ${id} saved to ${target} (${file.buffer.length} bytes).`);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_inbox_entry',
+    'Ta bort en fil eller post från Fortnox inkorg',
+    {
+      id: z.string().describe('Postens ID'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ id, confirm, dryRun }) => {
+      const target = `delete inbox entry ${id}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await deleteInboxEntry(id);
+      return textResponse(`Inbox entry ${id} deleted.`);
+    },
+  );
+}

--- a/src/tools/financial-years.ts
+++ b/src/tools/financial-years.ts
@@ -6,13 +6,19 @@ import {
   financialYearDetailColumns,
   lockedPeriodDetailColumns,
 } from '../views.js';
-import { detailResponse, listResponse, textResponse } from '../tool-output.js';
+import {
+  detailResponse,
+  dryRunResponse,
+  listResponse,
+  requireConfirmation,
+  textResponse,
+} from '../tool-output.js';
 
 export function registerFinancialYearTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listFinancialYears, getFinancialYear, getLockedPeriod } = operations;
+  const { listFinancialYears, getFinancialYear, createFinancialYear, getLockedPeriod } = operations;
   server.tool(
     'fortnox_list_financialyears',
     'Lista räkenskapsår i Fortnox. Returnerar: Id, FromDate, ToDate, AccountingMethod, AccountChartType. Kan filtreras till det räkenskapsår som innehåller ett visst datum.',
@@ -45,6 +51,26 @@ export function registerFinancialYearTools(
     async ({ id, includeRaw }) => {
       const data = await getFinancialYear(id);
       return detailResponse(data, financialYearDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_financialyear',
+    'Skapa ett räkenskapsår i Fortnox',
+    {
+      FromDate: z.string().describe('Startdatum (YYYY-MM-DD)'),
+      ToDate: z.string().describe('Slutdatum (YYYY-MM-DD)'),
+      AccountingMethod: z.enum(['ACCRUAL', 'CASH']).optional().describe('Bokföringsmetod'),
+      AccountChartType: z.string().optional().describe('Kontoplanstyp'),
+      confirm: z.boolean().optional().describe('Bekräfta att räkenskapsåret ska skapas'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att skapa'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) return dryRunResponse('create financial year', { FinancialYear: fields });
+      if (!confirm) requireConfirmation('create financial year');
+      const year = await createFinancialYear(fields);
+      return detailResponse(year, financialYearDetailColumns, year, includeRaw);
     },
   );
 

--- a/src/tools/invoice-payments.ts
+++ b/src/tools/invoice-payments.ts
@@ -16,8 +16,14 @@ export function registerInvoicePaymentTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listInvoicePayments, getInvoicePayment, createInvoicePayment, deleteInvoicePayment } =
-    operations;
+  const {
+    listInvoicePayments,
+    getInvoicePayment,
+    createInvoicePayment,
+    updateInvoicePayment,
+    deleteInvoicePayment,
+    bookkeepInvoicePayment,
+  } = operations;
   server.tool(
     'fortnox_list_invoice_payments',
     'Lista inbetalningar (kundfakturor) i Fortnox. Returnerar: Number, InvoiceNumber, PaymentDate, Amount.',
@@ -97,6 +103,48 @@ export function registerInvoicePaymentTools(
 
       await deleteInvoicePayment(paymentNumber);
       return confirmationResponse(`Inbetalning ${paymentNumber} borttagen.`, {});
+    },
+  );
+
+  server.tool(
+    'fortnox_update_invoice_payment',
+    'Uppdatera en inbetalning i Fortnox',
+    {
+      paymentNumber: PaymentNumberSchema.describe('Betalningsnummer'),
+      InvoiceNumber: z.number().optional().describe('Fakturanummer'),
+      Amount: z.number().optional().describe('Belopp'),
+      PaymentDate: z.string().optional().describe('Betalningsdatum (YYYY-MM-DD)'),
+      Source: z.string().optional().describe('Betalningskälla'),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ paymentNumber, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) {
+        return dryRunResponse(`update invoice payment ${paymentNumber}`, {
+          InvoicePayment: fields,
+        });
+      }
+      if (!confirm) requireConfirmation(`update invoice payment ${paymentNumber}`);
+      const payment = await updateInvoicePayment(paymentNumber, fields);
+      return detailResponse(payment, invoicePaymentDetailColumns, payment, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_bookkeep_invoice_payment',
+    'Bokför en inbetalning i Fortnox',
+    {
+      paymentNumber: PaymentNumberSchema.describe('Betalningsnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta bokföringen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att bokföra'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ paymentNumber, confirm, dryRun, includeRaw }) => {
+      if (dryRun) return dryRunResponse(`bookkeep invoice payment ${paymentNumber}`);
+      if (!confirm) requireConfirmation(`bookkeep invoice payment ${paymentNumber}`);
+      const payment = await bookkeepInvoicePayment(paymentNumber);
+      return detailResponse(payment, invoicePaymentDetailColumns, payment, includeRaw);
     },
   );
 }

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -1,16 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import {
-  closeSync,
-  constants as fsConstants,
-  lstatSync,
-  mkdtempSync,
-  openSync,
-  writeSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
 import {
   invoiceListColumns,
   invoiceDetailColumns,
@@ -86,59 +77,6 @@ const InvoiceRowSchema = z.strictObject({
 
 const DocumentNumberSchema = z.string().regex(/^\d+$/, 'Document number must be numeric');
 
-/**
- * Write a PDF to `target`, refusing to write through a symlink.
- *
- * These paths come from tool arguments, i.e. they are model-generated and can be
- * influenced by whatever the model just read. `O_EXCL` already refuses to follow
- * a symlink; `O_NOFOLLOW` gives the overwrite path the same guarantee, so
- * "replace this file" can never silently truncate a symlink's target instead.
- * O_NOFOLLOW is POSIX-only, so Windows falls back to an explicit lstat check.
- */
-function writePdf(target: string, pdf: Buffer, overwrite?: boolean): void {
-  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
-  const flags = overwrite
-    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
-    : O_WRONLY | O_CREAT | O_EXCL;
-
-  // Windows has no O_NOFOLLOW, so the flag above degrades to a no-op there.
-  // Check explicitly instead. This is a TOCTOU-racy fallback rather than an
-  // atomic guarantee, but it closes the ordinary case on the one platform the
-  // kernel flag cannot cover.
-  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
-    throw new Error(
-      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-    );
-  }
-
-  try {
-    const fd = openSync(target, flags, 0o600);
-    try {
-      // writeSync may return a short count; keep going until the whole buffer
-      // has landed. writeFileSync used to do this loop internally.
-      let written = 0;
-      while (written < pdf.length) {
-        written += writeSync(fd, pdf, written, pdf.length - written);
-      }
-    } finally {
-      closeSync(fd);
-    }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'EEXIST') {
-      throw new Error(
-        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
-      );
-    }
-    if (code === 'ELOOP') {
-      throw new Error(
-        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-      );
-    }
-    throw err;
-  }
-}
-
 export function registerInvoiceTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
@@ -153,8 +91,18 @@ export function registerInvoiceTools(
     markInvoicePrinted,
     bookkeepInvoice,
     creditInvoice,
+    cancelInvoice,
+    externalPrintInvoice,
+    eprintInvoice,
+    getInvoiceReminderPdf,
     attachInvoiceFiles,
     listInvoiceAttachments,
+    createDocumentAttachment,
+    listDocumentAttachments,
+    getAttachmentCounts,
+    validateAttachmentsOnSend,
+    updateDocumentAttachment,
+    detachDocumentAttachment,
   } = operations;
   server.tool(
     'fortnox_list_invoices',
@@ -348,12 +296,12 @@ export function registerInvoiceTools(
       // Arguments here are agent-generated, so a stray path must not silently
       // truncate an existing file. Without an explicit path we use a fresh
       // private directory rather than a predictable, clobber-prone temp name.
-      const target = outputPath
-        ? resolve(outputPath)
-        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `invoice-${documentNumber}.pdf`);
-
       const pdf = await getInvoicePdf(documentNumber);
-      writePdf(target, pdf, overwrite);
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `invoice-${documentNumber}.pdf`),
+        pdf,
+        overwrite,
+      );
 
       // Only now that the PDF is safely on disk do we change anything in Fortnox.
       // If that fails, the download still succeeded — say so, or the caller has
@@ -379,7 +327,7 @@ export function registerInvoiceTools(
       let refreshNote = '';
       if (printed?.pdf) {
         try {
-          writePdf(target, printed.pdf, true);
+          writeBinaryFile(target, printed.pdf, true);
           bytes = printed.pdf.length;
         } catch (err) {
           refreshNote = ` Den sparade filen är /preview-versionen; kunde inte skriva om den med den utskrivna versionen: ${
@@ -465,6 +413,87 @@ export function registerInvoiceTools(
     },
   );
 
+  const invoiceActions = [
+    {
+      name: 'fortnox_cancel_invoice',
+      description: 'Makulera en faktura i Fortnox',
+      verb: 'cancel',
+      message: 'makulerad',
+      execute: cancelInvoice,
+    },
+    {
+      name: 'fortnox_eprint_invoice',
+      description: 'Skicka en faktura via Fortnox e-print',
+      verb: 'e-print',
+      message: 'skickad via e-print',
+      execute: eprintInvoice,
+    },
+    {
+      name: 'fortnox_external_print_invoice',
+      description: 'Markera en faktura som externt utskriven i Fortnox',
+      verb: 'external print',
+      message: 'markerad som externt utskriven',
+      execute: externalPrintInvoice,
+    },
+  ] as const;
+  for (const action of invoiceActions) {
+    server.tool(
+      action.name,
+      action.description,
+      {
+        documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
+        confirm: z.boolean().optional().describe('Bekräfta åtgärden'),
+        dryRun: z.boolean().optional().describe('Visa åtgärden utan att utföra den'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+        const target = `${action.verb} invoice ${documentNumber}`;
+        if (dryRun) return dryRunResponse(target);
+        if (!confirm) requireConfirmation(target);
+        const invoice = await action.execute(documentNumber);
+        return confirmationResponse(
+          `Faktura ${documentNumber} ${action.message}.`,
+          invoice,
+          invoiceConfirmColumns,
+          includeRaw,
+        );
+      },
+    );
+  }
+
+  server.tool(
+    'fortnox_invoice_reminder_pdf',
+    'Skapa en påminnelseutskrift för en faktura och spara PDF:en på disk',
+    {
+      documentNumber: DocumentNumberSchema.describe('Fakturanummer'),
+      outputPath: z.string().optional().describe('Målsökväg; utelämna för privat tempkatalog'),
+      overwrite: z.boolean().optional().describe('Tillåt överskrivning av vanlig fil'),
+      confirm: z.boolean().optional().describe('Bekräfta påminnelseutskriften'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att skriva ut'),
+    },
+    async ({ documentNumber, outputPath, overwrite, confirm, dryRun }) => {
+      const action = `print reminder for invoice ${documentNumber}`;
+      if (dryRun) return dryRunResponse(action);
+      if (!confirm) requireConfirmation(action);
+      const pdf = await getInvoiceReminderPdf(documentNumber);
+      if (!pdf) {
+        return confirmationResponse(
+          `Påminnelseutskrift utförd för faktura ${documentNumber}; Fortnox returnerade ingen PDF.`,
+          {},
+        );
+      }
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `invoice-reminder-${documentNumber}.pdf`),
+        pdf,
+        overwrite,
+      );
+      return confirmationResponse(
+        `Påminnelse för faktura ${documentNumber} sparad som PDF: ${target}.`,
+        { DocumentNumber: documentNumber, Path: target, Bytes: pdf.length },
+      );
+    },
+  );
+
   server.tool(
     'fortnox_attach_invoice_files',
     'Ladda upp kvitto/underlagsfiler och koppla dem till en kundfaktura i Fortnox. Kräver "archive"-behörigheten (noxctl init --with-archive).',
@@ -522,6 +551,134 @@ export function registerInvoiceTools(
         undefined,
         includeRaw,
       );
+    },
+  );
+
+  const AttachmentEntityType = z.enum(['F', 'OF', 'O', 'C']);
+  const AttachmentFields = {
+    entityId: z.number().int().optional(),
+    entityType: AttachmentEntityType.optional(),
+    fileId: z.string().optional(),
+    id: z.string().uuid().optional(),
+    includeOnSend: z.boolean().optional(),
+  };
+
+  server.tool(
+    'fortnox_create_document_attachment',
+    'Koppla en befintlig arkivfil till en faktura, offert, order eller ett avtal i Fortnox',
+    {
+      documentNumber: DocumentNumberSchema.describe('Dokumentnummer'),
+      entityType: AttachmentEntityType.describe('F=faktura, OF=offert, O=order, C=avtal'),
+      fileId: z.string().min(1).describe('Arkivfilens ID'),
+      includeOnSend: z.boolean().optional().describe('Bifoga filen när dokumentet skickas'),
+      confirm: z.boolean().optional().describe('Bekräfta kopplingen'),
+      dryRun: z.boolean().optional().describe('Visa kopplingen utan att utföra den'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, entityType, fileId, includeOnSend, confirm, dryRun, includeRaw }) => {
+      const target = `attach archive file ${fileId} to ${entityType} document ${documentNumber}`;
+      const body = { documentNumber, entityType, fileId, includeOnSend: includeOnSend ?? true };
+      if (dryRun) return dryRunResponse(target, body);
+      if (!confirm) requireConfirmation(target);
+      const attachment = await createDocumentAttachment(
+        documentNumber,
+        entityType,
+        fileId,
+        includeOnSend ?? true,
+      );
+      return confirmationResponse(
+        'Bilagan kopplades till dokumentet.',
+        attachment,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_list_document_attachments',
+    'Lista bilagor för en offert, order eller ett avtal i Fortnox',
+    {
+      documentNumber: DocumentNumberSchema.describe('Dokumentnummer'),
+      entityType: z.enum(['OF', 'O', 'C']).describe('OF=offert, O=order, C=avtal'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ documentNumber, entityType, includeRaw }) => {
+      const attachments = await listDocumentAttachments(documentNumber, entityType);
+      return listResponse(
+        attachments,
+        invoiceAttachmentListColumns,
+        attachments,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_attachment_counts',
+    'Hämta antal bilagor för dokument i Fortnox',
+    {
+      entityIds: z.array(z.number().int()).min(1).describe('Dokument-ID:n'),
+      entityType: AttachmentEntityType.describe('Dokumenttyp'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ entityIds, entityType, includeRaw }) => {
+      const counts = await getAttachmentCounts(entityIds, entityType);
+      return detailResponse(counts, invoiceAttachmentListColumns, counts, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_validate_attachments_on_send',
+    'Validera att valda bilagor kan inkluderas när ett dokument skickas från Fortnox',
+    {
+      attachments: z.array(z.strictObject(AttachmentFields)).min(1),
+      confirm: z.boolean().optional().describe('Bekräfta valideringsanropet'),
+      dryRun: z.boolean().optional().describe('Visa exakt payload utan att anropa Fortnox'),
+    },
+    async ({ attachments, confirm, dryRun }) => {
+      const target = 'validate attachments included on send';
+      if (dryRun) return dryRunResponse(target, attachments);
+      if (!confirm) requireConfirmation(target);
+      await validateAttachmentsOnSend(attachments);
+      return textResponse('Fortnox accepted the attachment send validation.');
+    },
+  );
+
+  server.tool(
+    'fortnox_update_document_attachment',
+    'Uppdatera metadata för en dokumentbilaga i Fortnox',
+    {
+      attachmentId: z.string().uuid().describe('Bilagans ID'),
+      ...AttachmentFields,
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa exakt payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ attachmentId, confirm, dryRun, includeRaw, ...fields }) => {
+      const target = `update attachment ${attachmentId}`;
+      if (dryRun) return dryRunResponse(target, fields);
+      if (!confirm) requireConfirmation(target);
+      const attachment = await updateDocumentAttachment(attachmentId, fields);
+      return detailResponse(attachment, invoiceAttachmentListColumns, attachment, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_detach_document_attachment',
+    'Koppla loss en dokumentbilaga i Fortnox utan att hämta fjärr-URL:er',
+    {
+      attachmentId: z.string().uuid().describe('Bilagans ID'),
+      confirm: z.boolean().optional().describe('Bekräfta bortkopplingen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att koppla loss'),
+    },
+    async ({ attachmentId, confirm, dryRun }) => {
+      const target = `detach attachment ${attachmentId}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await detachDocumentAttachment(attachmentId);
+      return textResponse(`Attachment ${attachmentId} detached.`);
     },
   );
 }

--- a/src/tools/offers.ts
+++ b/src/tools/offers.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
 import { offerListColumns, offerDetailColumns, offerConfirmColumns } from '../views.js';
 import {
   confirmationResponse,
@@ -73,6 +74,10 @@ export function registerOfferTools(
     updateOffer,
     createInvoiceFromOffer,
     createOrderFromOffer,
+    cancelOffer,
+    emailOffer,
+    externalPrintOffer,
+    getOfferPdf,
   } = operations;
   server.tool(
     'fortnox_list_offers',
@@ -224,6 +229,92 @@ export function registerOfferTools(
         order,
         offerConfirmColumns,
       );
+    },
+  );
+
+  const offerActions = [
+    {
+      name: 'fortnox_cancel_offer',
+      description: 'Makulera en offert i Fortnox',
+      verb: 'cancel',
+      message: 'makulerad',
+      execute: cancelOffer,
+    },
+    {
+      name: 'fortnox_email_offer',
+      description: 'Skicka en offert via e-post från Fortnox',
+      verb: 'email',
+      message: 'skickad via e-post',
+      execute: emailOffer,
+    },
+    {
+      name: 'fortnox_external_print_offer',
+      description: 'Markera en offert som externt utskriven i Fortnox',
+      verb: 'external print',
+      message: 'markerad som externt utskriven',
+      execute: externalPrintOffer,
+    },
+  ] as const;
+  for (const action of offerActions) {
+    server.tool(
+      action.name,
+      action.description,
+      {
+        documentNumber: DocumentNumberSchema.describe('Offertnummer'),
+        confirm: z.boolean().optional().describe('Bekräfta åtgärden'),
+        dryRun: z.boolean().optional().describe('Visa åtgärden utan att utföra den'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+        const target = `${action.verb} offer ${documentNumber}`;
+        if (dryRun) return dryRunResponse(target);
+        if (!confirm) requireConfirmation(target);
+        const offer = await action.execute(documentNumber);
+        return confirmationResponse(
+          `Offert ${documentNumber} ${action.message}.`,
+          offer,
+          offerConfirmColumns,
+          includeRaw,
+        );
+      },
+    );
+  }
+
+  server.tool(
+    'fortnox_offer_pdf',
+    'Hämta en offert som PDF och spara den säkert på disk',
+    {
+      documentNumber: DocumentNumberSchema.describe('Offertnummer'),
+      mode: z
+        .enum(['preview', 'print'])
+        .optional()
+        .describe('preview är läsning; print ändrar status'),
+      outputPath: z.string().optional().describe('Målsökväg; utelämna för privat tempkatalog'),
+      overwrite: z.boolean().optional().describe('Tillåt överskrivning av vanlig fil'),
+      confirm: z.boolean().optional().describe('Bekräfta print-åtgärden'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att hämta PDF'),
+    },
+    async ({ documentNumber, mode = 'preview', outputPath, overwrite, confirm, dryRun }) => {
+      const action = `${mode} offer ${documentNumber} as PDF`;
+      if (dryRun) return dryRunResponse(action);
+      if (mode === 'print' && !confirm) requireConfirmation(action);
+      const pdf = await getOfferPdf(documentNumber, mode);
+      if (!pdf)
+        return confirmationResponse(
+          `Offert ${documentNumber} utskriven; Fortnox returnerade ingen PDF.`,
+          {},
+        );
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `offer-${documentNumber}.pdf`),
+        pdf,
+        overwrite,
+      );
+      return confirmationResponse(`Offert ${documentNumber} sparad som PDF: ${target}.`, {
+        DocumentNumber: documentNumber,
+        Path: target,
+        Bytes: pdf.length,
+        Mode: mode,
+      });
     },
   );
 }

--- a/src/tools/orders.ts
+++ b/src/tools/orders.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
 import { orderListColumns, orderDetailColumns, orderConfirmColumns } from '../views.js';
 import {
   confirmationResponse,
@@ -75,7 +76,17 @@ export function registerOrderTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listOrders, getOrder, createOrder, updateOrder, createInvoiceFromOrder } = operations;
+  const {
+    listOrders,
+    getOrder,
+    createOrder,
+    updateOrder,
+    createInvoiceFromOrder,
+    cancelOrder,
+    emailOrder,
+    externalPrintOrder,
+    getOrderPdf,
+  } = operations;
   server.tool(
     'fortnox_list_orders',
     'Lista/filtrera ordrar i Fortnox. Returnerar: DocumentNumber, CustomerName, OrderDate, DeliveryDate, Total.',
@@ -200,6 +211,92 @@ export function registerOrderTools(
         invoice,
         orderConfirmColumns,
       );
+    },
+  );
+
+  const orderActions = [
+    {
+      name: 'fortnox_cancel_order',
+      description: 'Makulera en order i Fortnox',
+      verb: 'cancel',
+      message: 'makulerad',
+      execute: cancelOrder,
+    },
+    {
+      name: 'fortnox_email_order',
+      description: 'Skicka en order via e-post från Fortnox',
+      verb: 'email',
+      message: 'skickad via e-post',
+      execute: emailOrder,
+    },
+    {
+      name: 'fortnox_external_print_order',
+      description: 'Markera en order som externt utskriven i Fortnox',
+      verb: 'external print',
+      message: 'markerad som externt utskriven',
+      execute: externalPrintOrder,
+    },
+  ] as const;
+  for (const action of orderActions) {
+    server.tool(
+      action.name,
+      action.description,
+      {
+        documentNumber: DocumentNumberSchema.describe('Ordernummer'),
+        confirm: z.boolean().optional().describe('Bekräfta åtgärden'),
+        dryRun: z.boolean().optional().describe('Visa åtgärden utan att utföra den'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ documentNumber, confirm, dryRun, includeRaw }) => {
+        const target = `${action.verb} order ${documentNumber}`;
+        if (dryRun) return dryRunResponse(target);
+        if (!confirm) requireConfirmation(target);
+        const order = await action.execute(documentNumber);
+        return confirmationResponse(
+          `Order ${documentNumber} ${action.message}.`,
+          order,
+          orderConfirmColumns,
+          includeRaw,
+        );
+      },
+    );
+  }
+
+  server.tool(
+    'fortnox_order_pdf',
+    'Hämta en order som PDF och spara den säkert på disk',
+    {
+      documentNumber: DocumentNumberSchema.describe('Ordernummer'),
+      mode: z
+        .enum(['preview', 'print'])
+        .optional()
+        .describe('preview är läsning; print ändrar status'),
+      outputPath: z.string().optional().describe('Målsökväg; utelämna för privat tempkatalog'),
+      overwrite: z.boolean().optional().describe('Tillåt överskrivning av vanlig fil'),
+      confirm: z.boolean().optional().describe('Bekräfta print-åtgärden'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att hämta PDF'),
+    },
+    async ({ documentNumber, mode = 'preview', outputPath, overwrite, confirm, dryRun }) => {
+      const action = `${mode} order ${documentNumber} as PDF`;
+      if (dryRun) return dryRunResponse(action);
+      if (mode === 'print' && !confirm) requireConfirmation(action);
+      const pdf = await getOrderPdf(documentNumber, mode);
+      if (!pdf)
+        return confirmationResponse(
+          `Order ${documentNumber} utskriven; Fortnox returnerade ingen PDF.`,
+          {},
+        );
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `order-${documentNumber}.pdf`),
+        pdf,
+        overwrite,
+      );
+      return confirmationResponse(`Order ${documentNumber} sparad som PDF: ${target}.`, {
+        DocumentNumber: documentNumber,
+        Path: target,
+        Bytes: pdf.length,
+        Mode: mode,
+      });
     },
   );
 }

--- a/src/tools/pricelists.ts
+++ b/src/tools/pricelists.ts
@@ -12,6 +12,7 @@ import {
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 export function registerPriceListTools(
@@ -25,7 +26,9 @@ export function registerPriceListTools(
     updatePriceList,
     listPrices,
     getPrice,
+    createPrice,
     updatePrice,
+    deletePrice,
   } = operations;
   server.tool(
     'fortnox_list_pricelists',
@@ -119,7 +122,7 @@ export function registerPriceListTools(
     'fortnox_list_prices',
     'Lista priser i en prislista i Fortnox. Returnerar: ArticleNumber, Price, FromQuantity, Percent.',
     {
-      priceListCode: z.string().describe('Prislistekod'),
+      priceListCode: z.string().optional().describe('Prislistekod; utelämna för alla priser'),
       articleNumber: z.string().optional().describe('Filtrera på artikelnummer'),
       page: z.number().optional().describe('Sidnummer (default 1)'),
       limit: z.number().optional().describe('Antal per sida (default 100, max 500)'),
@@ -148,6 +151,27 @@ export function registerPriceListTools(
     },
     async ({ priceListCode, articleNumber, fromQuantity, includeRaw }) => {
       const data = await getPrice(priceListCode, articleNumber, fromQuantity);
+      return detailResponse(data, priceDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_price',
+    'Skapa ett pris i Fortnox',
+    {
+      PriceList: z.string().describe('Prislistekod'),
+      ArticleNumber: z.string().describe('Artikelnummer'),
+      FromQuantity: z.number().optional().describe('Från antal'),
+      Price: z.number().optional().describe('Pris'),
+      Percent: z.number().optional().describe('Rabatt i procent'),
+      confirm: z.boolean().optional().describe('Bekräfta att priset ska skapas'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att skapa priset'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) return dryRunResponse('create price', { Price: fields });
+      if (!confirm) requireConfirmation('create price');
+      const data = await createPrice(fields);
       return detailResponse(data, priceDetailColumns, data, includeRaw);
     },
   );
@@ -184,6 +208,25 @@ export function registerPriceListTools(
 
       const data = await updatePrice(priceListCode, articleNumber, fields, fromQuantity);
       return detailResponse(data, priceDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_price',
+    'Ta bort ett kvantitetspris från Fortnox',
+    {
+      priceListCode: z.string().describe('Prislistekod'),
+      articleNumber: z.string().describe('Artikelnummer'),
+      fromQuantity: z.number().describe('Från antal'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ priceListCode, articleNumber, fromQuantity, confirm, dryRun }) => {
+      const target = `delete price ${priceListCode}/${articleNumber}/${fromQuantity}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await deletePrice(priceListCode, articleNumber, fromQuantity);
+      return textResponse(`Price ${priceListCode}/${articleNumber}/${fromQuantity} deleted.`);
     },
   );
 }

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -7,13 +7,14 @@ import {
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
 
 export function registerProjectTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listProjects, getProject, createProject, updateProject } = operations;
+  const { listProjects, getProject, createProject, updateProject, deleteProject } = operations;
   server.tool(
     'fortnox_list_projects',
     'Lista projekt i Fortnox. Returnerar: ProjectNumber, Description, Status, StartDate, EndDate.',
@@ -114,6 +115,22 @@ export function registerProjectTools(
 
       const data = await updateProject(projectNumber, fields);
       return detailResponse(data, projectDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_project',
+    'Ta bort ett projekt i Fortnox',
+    {
+      projectNumber: z.string().describe('Projektnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ projectNumber, confirm, dryRun }) => {
+      if (dryRun) return dryRunResponse(`delete project ${projectNumber}`);
+      if (!confirm) requireConfirmation(`delete project ${projectNumber}`);
+      await deleteProject(projectNumber);
+      return textResponse(`Project ${projectNumber} deleted.`);
     },
   );
 }

--- a/src/tools/recurrings.ts
+++ b/src/tools/recurrings.ts
@@ -24,7 +24,7 @@ const patchOperation = z
     path: z.string().startsWith('/').describe('JSON Pointer-sökväg'),
     value: z.unknown().optional().describe('Nytt värde (ej för remove)'),
   })
-  .passthrough();
+  .strict();
 
 function withMetadata(result: {
   recurring: Record<string, unknown>;

--- a/src/tools/reference-data.ts
+++ b/src/tools/reference-data.ts
@@ -1,0 +1,162 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z, type ZodType } from 'zod';
+import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { detailResponse, listResponse } from '../tool-output.js';
+import { referenceDataColumns } from '../views.js';
+
+interface ReferenceToolDefinition {
+  id: string;
+  swedishName: string;
+  listOperation: string;
+  getOperation?: string;
+  getId?: string;
+  identifier?: { field: string; description: string };
+}
+
+export const REFERENCE_TOOL_DEFINITIONS: readonly ReferenceToolDefinition[] = [
+  {
+    id: 'currencies',
+    getId: 'currency',
+    swedishName: 'valutor',
+    listOperation: 'listCurrencies',
+    getOperation: 'getCurrency',
+    identifier: { field: 'code', description: 'Valutakod' },
+  },
+  {
+    id: 'units',
+    getId: 'unit',
+    swedishName: 'enheter',
+    listOperation: 'listUnits',
+    getOperation: 'getUnit',
+    identifier: { field: 'code', description: 'Enhetskod' },
+  },
+  {
+    id: 'modes_of_payments',
+    getId: 'mode_of_payment',
+    swedishName: 'betalsätt',
+    listOperation: 'listModesOfPayments',
+    getOperation: 'getModeOfPayment',
+    identifier: { field: 'code', description: 'Kod för betalsätt' },
+  },
+  {
+    id: 'terms_of_deliveries',
+    getId: 'term_of_delivery',
+    swedishName: 'leveransvillkor',
+    listOperation: 'listTermsOfDeliveries',
+    getOperation: 'getTermOfDelivery',
+    identifier: { field: 'code', description: 'Kod för leveransvillkor' },
+  },
+  {
+    id: 'terms_of_payments',
+    getId: 'term_of_payment',
+    swedishName: 'betalningsvillkor',
+    listOperation: 'listTermsOfPayments',
+    getOperation: 'getTermOfPayment',
+    identifier: { field: 'code', description: 'Kod för betalningsvillkor' },
+  },
+  {
+    id: 'ways_of_delivery',
+    getId: 'way_of_delivery',
+    swedishName: 'leveranssätt',
+    listOperation: 'listWaysOfDelivery',
+    getOperation: 'getWayOfDelivery',
+    identifier: { field: 'code', description: 'Kod för leveranssätt' },
+  },
+  {
+    id: 'voucher_series',
+    getId: 'voucher_series',
+    swedishName: 'verifikationsserier',
+    listOperation: 'listVoucherSeries',
+    getOperation: 'getVoucherSeries',
+    identifier: { field: 'code', description: 'Kod för verifikationsserie' },
+  },
+  {
+    id: 'predefined_voucher_series',
+    getId: 'predefined_voucher_series',
+    swedishName: 'fördefinierade verifikationsserier',
+    listOperation: 'listPredefinedVoucherSeries',
+    getOperation: 'getPredefinedVoucherSeries',
+    identifier: { field: 'name', description: 'Namn på fördefinierad serie' },
+  },
+  { id: 'account_charts', swedishName: 'kontoplanstyper', listOperation: 'listAccountCharts' },
+  {
+    id: 'predefined_accounts',
+    getId: 'predefined_account',
+    swedishName: 'fördefinierade konton',
+    listOperation: 'listPredefinedAccounts',
+    getOperation: 'getPredefinedAccount',
+    identifier: { field: 'name', description: 'Namn på fördefinierat konto' },
+  },
+  {
+    id: 'customer_references',
+    getId: 'customer_reference',
+    swedishName: 'kundreferenser',
+    listOperation: 'listCustomerReferences',
+    getOperation: 'getCustomerReference',
+    identifier: { field: 'rowId', description: 'Kundreferensens rad-ID' },
+  },
+];
+
+type DynamicOperation = (argument?: unknown) => Promise<unknown>;
+
+export function registerReferenceDataTools(
+  server: McpServer,
+  operations: FortnoxOperations = defaultFortnoxOperations,
+): void {
+  const dynamicOperations = operations as unknown as Record<string, DynamicOperation>;
+  for (const definition of REFERENCE_TOOL_DEFINITIONS) {
+    server.tool(
+      `fortnox_list_${definition.id}`,
+      `Lista ${definition.swedishName} i Fortnox`,
+      {
+        page: z.number().int().positive().optional().describe('Sidnummer'),
+        limit: z.number().int().positive().max(500).optional().describe('Antal per sida'),
+        all: z.boolean().optional().describe('Hämta alla sidor'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ page, limit, all, includeRaw }) => {
+        const result = (await dynamicOperations[definition.listOperation]?.({
+          page,
+          limit,
+          all,
+        })) as { items: Record<string, unknown>[]; raw: Record<string, unknown> };
+        if (!result) throw new Error(`Missing operation ${definition.listOperation}`);
+        return listResponse(
+          result.items,
+          referenceDataColumns,
+          result.raw,
+          result.raw.MetaInformation as Record<string, unknown> | undefined,
+          includeRaw,
+        );
+      },
+    );
+
+    if (!definition.getOperation || !definition.identifier) continue;
+    const identifierSchema: Record<string, ZodType> = {
+      [definition.identifier.field]: z.string().describe(definition.identifier.description),
+    };
+    server.tool(
+      `fortnox_get_${definition.getId}`,
+      `Hämta en post ur ${definition.swedishName} i Fortnox`,
+      {
+        ...identifierSchema,
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async (arguments_) => {
+        const dynamicArguments = arguments_ as Record<string, unknown>;
+        const identifier = String(dynamicArguments[definition.identifier!.field]);
+        const result = (await dynamicOperations[definition.getOperation!]?.(identifier)) as {
+          item: Record<string, unknown>;
+          raw: Record<string, unknown>;
+        };
+        if (!result) throw new Error(`Missing operation ${definition.getOperation}`);
+        return detailResponse(
+          result.item,
+          referenceDataColumns,
+          result.raw,
+          Boolean(dynamicArguments.includeRaw),
+        );
+      },
+    );
+  }
+}

--- a/src/tools/salarytransactions.ts
+++ b/src/tools/salarytransactions.ts
@@ -18,6 +18,7 @@ export function registerSalaryTransactionTools(
     listSalaryTransactions,
     getSalaryTransaction,
     createSalaryTransaction,
+    updateSalaryTransaction,
     deleteSalaryTransaction,
   } = operations;
   server.tool(
@@ -111,6 +112,37 @@ export function registerSalaryTransactionTools(
 
       await deleteSalaryTransaction(salaryRow);
       return textResponse(`Salary transaction ${salaryRow} deleted.`);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_salarytransaction',
+    'Uppdatera en lönetransaktion i Fortnox (kräver Lön-behörigheten).',
+    {
+      salaryRow: z.string().describe('SalaryRow (radens ID)'),
+      EmployeeId: z.string().optional(),
+      SalaryCode: z.string().optional(),
+      Date: z.string().optional(),
+      Amount: z.string().optional(),
+      CostCenter: z.string().optional(),
+      Project: z.string().optional(),
+      Expense: z.string().optional(),
+      Number: z.string().optional(),
+      TextRow: z.string().optional(),
+      Total: z.string().optional(),
+      VAT: z.string().optional(),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ salaryRow, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun)
+        return dryRunResponse(`update salary transaction ${salaryRow}`, {
+          SalaryTransaction: fields,
+        });
+      if (!confirm) requireConfirmation(`update salary transaction ${salaryRow}`);
+      const data = await updateSalaryTransaction(salaryRow, fields);
+      return detailResponse(data, salaryTransactionDetailColumns, data, includeRaw);
     },
   );
 }

--- a/src/tools/supplier-invoice-payments.ts
+++ b/src/tools/supplier-invoice-payments.ts
@@ -23,7 +23,9 @@ export function registerSupplierInvoicePaymentTools(
     listSupplierInvoicePayments,
     getSupplierInvoicePayment,
     createSupplierInvoicePayment,
+    updateSupplierInvoicePayment,
     deleteSupplierInvoicePayment,
+    bookkeepSupplierInvoicePayment,
   } = operations;
   server.tool(
     'fortnox_list_supplier_invoice_payments',
@@ -105,6 +107,48 @@ export function registerSupplierInvoicePaymentTools(
 
       await deleteSupplierInvoicePayment(paymentNumber);
       return confirmationResponse(`Leverantörsbetalning ${paymentNumber} borttagen.`, {});
+    },
+  );
+
+  server.tool(
+    'fortnox_update_supplier_invoice_payment',
+    'Uppdatera en leverantörsbetalning i Fortnox',
+    {
+      paymentNumber: PaymentNumberSchema.describe('Betalningsnummer'),
+      InvoiceNumber: z.string().optional().describe('Leverantörsfakturanummer'),
+      Amount: z.number().optional().describe('Belopp'),
+      PaymentDate: z.string().optional().describe('Betalningsdatum (YYYY-MM-DD)'),
+      Source: z.string().optional().describe('Betalningskälla'),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ paymentNumber, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) {
+        return dryRunResponse(`update supplier invoice payment ${paymentNumber}`, {
+          SupplierInvoicePayment: fields,
+        });
+      }
+      if (!confirm) requireConfirmation(`update supplier invoice payment ${paymentNumber}`);
+      const payment = await updateSupplierInvoicePayment(paymentNumber, fields);
+      return detailResponse(payment, supplierInvoicePaymentDetailColumns, payment, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_bookkeep_supplier_invoice_payment',
+    'Bokför en leverantörsbetalning i Fortnox',
+    {
+      paymentNumber: PaymentNumberSchema.describe('Betalningsnummer'),
+      confirm: z.boolean().optional().describe('Bekräfta bokföringen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att bokföra'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ paymentNumber, confirm, dryRun, includeRaw }) => {
+      if (dryRun) return dryRunResponse(`bookkeep supplier invoice payment ${paymentNumber}`);
+      if (!confirm) requireConfirmation(`bookkeep supplier invoice payment ${paymentNumber}`);
+      const payment = await bookkeepSupplierInvoicePayment(paymentNumber);
+      return detailResponse(payment, supplierInvoicePaymentDetailColumns, payment, includeRaw);
     },
   );
 }

--- a/src/tools/supplier-invoices.ts
+++ b/src/tools/supplier-invoices.ts
@@ -1,16 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import {
-  closeSync,
-  constants as fsConstants,
-  lstatSync,
-  mkdtempSync,
-  openSync,
-  writeSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { privateOutputPath, writeBinaryFile } from '../safe-file-output.js';
 import {
   supplierInvoiceListColumns,
   supplierInvoiceDetailColumns,
@@ -24,50 +15,6 @@ import {
   requireConfirmation,
   textResponse,
 } from '../tool-output.js';
-
-/**
- * Write a downloaded file to `target`, refusing to write through a symlink.
- * Mirrors writeBinaryFile() in tools/bookkeeping.ts — see that copy for the
- * rationale (paths here are model-generated tool arguments, so this closes
- * off a symlink-overwrite path).
- */
-function writeBinaryFile(target: string, data: Buffer, overwrite?: boolean): void {
-  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
-  const flags = overwrite
-    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
-    : O_WRONLY | O_CREAT | O_EXCL;
-
-  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
-    throw new Error(
-      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-    );
-  }
-
-  try {
-    const fd = openSync(target, flags, 0o600);
-    try {
-      let written = 0;
-      while (written < data.length) {
-        written += writeSync(fd, data, written, data.length - written);
-      }
-    } finally {
-      closeSync(fd);
-    }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'EEXIST') {
-      throw new Error(
-        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
-      );
-    }
-    if (code === 'ELOOP') {
-      throw new Error(
-        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
-      );
-    }
-    throw err;
-  }
-}
 
 const SupplierInvoiceRowSchema = z.strictObject({
   Account: z.number().int().min(1000).max(9999).describe('Kontonummer (1000–9999)'),
@@ -124,9 +71,17 @@ export function registerSupplierInvoiceTools(
     listSupplierInvoices,
     getSupplierInvoice,
     createSupplierInvoice,
+    updateSupplierInvoice,
     bookkeepSupplierInvoice,
+    approvalBookkeepSupplierInvoice,
+    approvalPaymentSupplierInvoice,
+    cancelSupplierInvoice,
+    creditSupplierInvoice,
     listSupplierInvoiceAttachments,
     getSupplierInvoiceFile,
+    getSupplierInvoiceFileConnection,
+    createSupplierInvoiceFileConnection,
+    deleteSupplierInvoiceFileConnection,
     extensionForMime,
   } = operations;
   server.tool(
@@ -236,6 +191,89 @@ export function registerSupplierInvoiceTools(
   );
 
   server.tool(
+    'fortnox_update_supplier_invoice',
+    'Uppdatera en leverantörsfaktura i Fortnox',
+    {
+      givenNumber: z.string().describe('Leverantörsfakturanummer att uppdatera'),
+      SupplierNumber: z.string().optional().describe('Leverantörsnummer'),
+      InvoiceNumber: z.string().optional().describe('Leverantörens fakturanummer'),
+      InvoiceDate: z.string().optional().describe('Fakturadatum (YYYY-MM-DD)'),
+      DueDate: z.string().optional().describe('Förfallodatum (YYYY-MM-DD)'),
+      Total: z.number().optional().describe('Totalbelopp inkl. moms'),
+      OCR: z.string().optional().describe('OCR-nummer'),
+      Currency: z.string().optional().describe('Valutakod'),
+      Comments: z.string().optional().describe('Kommentarer'),
+      SupplierInvoiceRows: z
+        .array(SupplierInvoiceRowSchema.partial())
+        .optional()
+        .describe('Fakturarader (ersätter befintliga rader)'),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ givenNumber, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) {
+        return dryRunResponse(`update supplier invoice ${givenNumber}`, {
+          SupplierInvoice: fields,
+        });
+      }
+      if (!confirm) requireConfirmation(`update supplier invoice ${givenNumber}`);
+      const invoice = await updateSupplierInvoice(givenNumber, fields);
+      return detailResponse(invoice, supplierInvoiceDetailColumns, invoice, includeRaw);
+    },
+  );
+
+  const supplierInvoiceActions = [
+    {
+      name: 'fortnox_approval_bookkeep_supplier_invoice',
+      description: 'Attestera och bokför en leverantörsfaktura i Fortnox',
+      verb: 'approval bookkeep',
+      message: 'attesterad och bokförd',
+      execute: approvalBookkeepSupplierInvoice,
+    },
+    {
+      name: 'fortnox_approval_payment_supplier_invoice',
+      description: 'Betalningsattestera en leverantörsfaktura i Fortnox',
+      verb: 'approval payment',
+      message: 'betalningsattesterad',
+      execute: approvalPaymentSupplierInvoice,
+    },
+    {
+      name: 'fortnox_cancel_supplier_invoice',
+      description: 'Makulera en leverantörsfaktura i Fortnox',
+      verb: 'cancel',
+      message: 'makulerad',
+      execute: cancelSupplierInvoice,
+    },
+    {
+      name: 'fortnox_credit_supplier_invoice',
+      description: 'Kreditera en leverantörsfaktura i Fortnox',
+      verb: 'credit',
+      message: 'krediterad',
+      execute: creditSupplierInvoice,
+    },
+  ] as const;
+  for (const action of supplierInvoiceActions) {
+    server.tool(
+      action.name,
+      action.description,
+      {
+        givenNumber: z.string().describe('Leverantörsfakturanummer'),
+        confirm: z.boolean().optional().describe('Bekräfta åtgärden'),
+        dryRun: z.boolean().optional().describe('Visa åtgärden utan att utföra den'),
+        includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      },
+      async ({ givenNumber, confirm, dryRun, includeRaw }) => {
+        const target = `${action.verb} supplier invoice ${givenNumber}`;
+        if (dryRun) return dryRunResponse(target);
+        if (!confirm) requireConfirmation(target);
+        const invoice = await action.execute(givenNumber);
+        return detailResponse(invoice, supplierInvoiceConfirmColumns, invoice, includeRaw);
+      },
+    );
+  }
+
+  server.tool(
     'fortnox_list_supplier_invoice_attachments',
     'Lista filer (t.ex. den inskannade/mottagna fakturan) som är kopplade till en leverantörsfaktura i Fortnox. Fungerar även för obokförda och ej godkända fakturor (unbooked/authorizepending) — till skillnad från verifikationsbilagor, som bara finns tillgängliga efter bokföring. Returnerar: File (filnamn), File ID. Använd fileId med fortnox_get_supplier_invoice_file för att hämta själva filen.',
     {
@@ -273,13 +311,64 @@ export function registerSupplierInvoiceTools(
     async ({ fileId, outputPath, overwrite }) => {
       const file = await getSupplierInvoiceFile(fileId);
       const ext = extensionForMime(file.contentType);
-      const target = outputPath
-        ? resolve(outputPath)
-        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `supplier-invoice-file-${fileId}${ext}`);
-      writeBinaryFile(target, file.buffer, overwrite);
+      const target = writeBinaryFile(
+        outputPath ?? privateOutputPath('noxctl-', `supplier-invoice-file-${fileId}${ext}`),
+        file.buffer,
+        overwrite,
+      );
       return textResponse(
         `Sparade fil (${file.contentType}, ${file.buffer.length} bytes) till ${target}`,
       );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_supplier_invoice_file_connection',
+    'Hämta metadata för en filkoppling till en leverantörsfaktura i Fortnox',
+    {
+      fileId: z.string().describe('Fil-ID'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ fileId, includeRaw }) => {
+      const connection = await getSupplierInvoiceFileConnection(fileId);
+      return detailResponse(connection, supplierInvoiceAttachmentColumns, connection, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_create_supplier_invoice_file_connection',
+    'Koppla en befintlig inkorgsfil till en leverantörsfaktura i Fortnox',
+    {
+      givenNumber: z.string().describe('Leverantörsfakturanummer'),
+      fileId: z.string().describe('Fil-ID från Fortnox inkorg'),
+      confirm: z.boolean().optional().describe('Bekräfta kopplingen'),
+      dryRun: z.boolean().optional().describe('Visa exakt payload utan att koppla'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ givenNumber, fileId, confirm, dryRun, includeRaw }) => {
+      const payload = { SupplierInvoiceNumber: givenNumber, FileId: fileId };
+      const target = `connect file ${fileId} to supplier invoice ${givenNumber}`;
+      if (dryRun) return dryRunResponse(target, { SupplierInvoiceFileConnection: payload });
+      if (!confirm) requireConfirmation(target);
+      const connection = await createSupplierInvoiceFileConnection(givenNumber, fileId);
+      return detailResponse(connection, supplierInvoiceAttachmentColumns, connection, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_supplier_invoice_file_connection',
+    'Koppla loss en fil från en leverantörsfaktura i Fortnox',
+    {
+      fileId: z.string().describe('Fil-ID'),
+      confirm: z.boolean().optional().describe('Bekräfta bortkopplingen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att koppla loss'),
+    },
+    async ({ fileId, confirm, dryRun }) => {
+      const target = `delete supplier invoice file connection ${fileId}`;
+      if (dryRun) return dryRunResponse(target);
+      if (!confirm) requireConfirmation(target);
+      await deleteSupplierInvoiceFileConnection(fileId);
+      return textResponse(`Supplier invoice file connection ${fileId} deleted.`);
     },
   );
 }

--- a/src/tools/supplier-invoices.ts
+++ b/src/tools/supplier-invoices.ts
@@ -1,17 +1,73 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
 import {
   supplierInvoiceListColumns,
   supplierInvoiceDetailColumns,
   supplierInvoiceConfirmColumns,
+  supplierInvoiceAttachmentColumns,
 } from '../views.js';
 import {
   detailResponse,
   dryRunResponse,
   listResponse,
   requireConfirmation,
+  textResponse,
 } from '../tool-output.js';
+
+/**
+ * Write a downloaded file to `target`, refusing to write through a symlink.
+ * Mirrors writeBinaryFile() in tools/bookkeeping.ts — see that copy for the
+ * rationale (paths here are model-generated tool arguments, so this closes
+ * off a symlink-overwrite path).
+ */
+function writeBinaryFile(target: string, data: Buffer, overwrite?: boolean): void {
+  const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;
+  const flags = overwrite
+    ? O_WRONLY | O_CREAT | O_TRUNC | (O_NOFOLLOW ?? 0)
+    : O_WRONLY | O_CREAT | O_EXCL;
+
+  if (overwrite && !O_NOFOLLOW && lstatSync(target, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    throw new Error(
+      `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+    );
+  }
+
+  try {
+    const fd = openSync(target, flags, 0o600);
+    try {
+      let written = 0;
+      while (written < data.length) {
+        written += writeSync(fd, data, written, data.length - written);
+      }
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      throw new Error(
+        `${target} already exists. Pass a different outputPath, or overwrite: true to replace it.`,
+      );
+    }
+    if (code === 'ELOOP') {
+      throw new Error(
+        `${target} is a symbolic link. Refusing to write through it — pass the real path instead.`,
+      );
+    }
+    throw err;
+  }
+}
 
 const SupplierInvoiceRowSchema = z.strictObject({
   Account: z.number().int().min(1000).max(9999).describe('Kontonummer (1000–9999)'),
@@ -69,6 +125,9 @@ export function registerSupplierInvoiceTools(
     getSupplierInvoice,
     createSupplierInvoice,
     bookkeepSupplierInvoice,
+    listSupplierInvoiceAttachments,
+    getSupplierInvoiceFile,
+    extensionForMime,
   } = operations;
   server.tool(
     'fortnox_list_supplier_invoices',
@@ -173,6 +232,54 @@ export function registerSupplierInvoiceTools(
 
       const data = await bookkeepSupplierInvoice(givenNumber);
       return detailResponse(data, supplierInvoiceConfirmColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_list_supplier_invoice_attachments',
+    'Lista filer (t.ex. den inskannade/mottagna fakturan) som är kopplade till en leverantörsfaktura i Fortnox. Fungerar även för obokförda och ej godkända fakturor (unbooked/authorizepending) — till skillnad från verifikationsbilagor, som bara finns tillgängliga efter bokföring. Returnerar: File (filnamn), File ID. Använd fileId med fortnox_get_supplier_invoice_file för att hämta själva filen.',
+    {
+      givenNumber: z.string().describe('Leverantörsfakturanummer (GivenNumber)'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ givenNumber, includeRaw }) => {
+      const attachments = await listSupplierInvoiceAttachments(givenNumber);
+      return listResponse(
+        attachments as unknown as Record<string, unknown>[],
+        supplierInvoiceAttachmentColumns,
+        attachments,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+
+  server.tool(
+    'fortnox_get_supplier_invoice_file',
+    'Ladda ner en fil som är kopplad till en leverantörsfaktura och spara den på disk. Returnerar sökvägen till filen (inte filinnehållet). Hämta fileId via fortnox_list_supplier_invoice_attachments.',
+    {
+      fileId: z.string().describe('Fil-ID, från fortnox_list_supplier_invoice_attachments'),
+      outputPath: z
+        .string()
+        .optional()
+        .describe(
+          'Sökväg att spara filen till. Skriver inte över en befintlig fil om inte overwrite är satt. Utelämnas: en ny privat temp-katalog används.',
+        ),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe('Tillåt att en befintlig fil på outputPath skrivs över'),
+    },
+    async ({ fileId, outputPath, overwrite }) => {
+      const file = await getSupplierInvoiceFile(fileId);
+      const ext = extensionForMime(file.contentType);
+      const target = outputPath
+        ? resolve(outputPath)
+        : join(mkdtempSync(join(tmpdir(), 'noxctl-')), `supplier-invoice-file-${fileId}${ext}`);
+      writeBinaryFile(target, file.buffer, overwrite);
+      return textResponse(
+        `Sparade fil (${file.contentType}, ${file.buffer.length} bytes) till ${target}`,
+      );
     },
   );
 }

--- a/src/tools/taxreductions.ts
+++ b/src/tools/taxreductions.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
 import { taxReductionListColumns, taxReductionDetailColumns } from '../views.js';
 import {
+  confirmationResponse,
   detailResponse,
   dryRunResponse,
   listResponse,
@@ -13,7 +14,13 @@ export function registerTaxReductionTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
 ): void {
-  const { listTaxReductions, getTaxReduction, createTaxReduction } = operations;
+  const {
+    listTaxReductions,
+    getTaxReduction,
+    createTaxReduction,
+    updateTaxReduction,
+    deleteTaxReduction,
+  } = operations;
   server.tool(
     'fortnox_list_taxreductions',
     'Lista skattereduktioner (ROT/RUT) i Fortnox. Returnerar: Id, CustomerName, TypeOfReduction, ReferenceNumber, AskedAmount, ApprovedAmount.',
@@ -85,6 +92,45 @@ export function registerTaxReductionTools(
 
       const data = await createTaxReduction(params);
       return detailResponse(data, taxReductionDetailColumns, data, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_update_taxreduction',
+    'Uppdatera en skattereduktion (ROT/RUT) i Fortnox',
+    {
+      id: z.number().int().positive().describe('Skattereduktions-ID'),
+      ReferenceNumber: z.string().optional().describe('Referensnummer'),
+      ReferenceDocumentType: z.enum(['INVOICE', 'OFFER', 'ORDER']).optional(),
+      TypeOfReduction: z.enum(['rot', 'rut']).optional(),
+      CustomerName: z.string().optional(),
+      AskedAmount: z.number().optional(),
+      PropertyDesignation: z.string().optional(),
+      confirm: z.boolean().optional().describe('Bekräfta uppdateringen'),
+      dryRun: z.boolean().optional().describe('Visa payload utan att uppdatera'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ id, confirm, dryRun, includeRaw, ...fields }) => {
+      if (dryRun) return dryRunResponse(`update tax reduction ${id}`, { TaxReduction: fields });
+      if (!confirm) requireConfirmation(`update tax reduction ${id}`);
+      const reduction = await updateTaxReduction(id, fields);
+      return detailResponse(reduction, taxReductionDetailColumns, reduction, includeRaw);
+    },
+  );
+
+  server.tool(
+    'fortnox_delete_taxreduction',
+    'Ta bort en skattereduktion (ROT/RUT) i Fortnox',
+    {
+      id: z.number().int().positive().describe('Skattereduktions-ID'),
+      confirm: z.boolean().optional().describe('Bekräfta borttagningen'),
+      dryRun: z.boolean().optional().describe('Visa åtgärden utan att ta bort'),
+    },
+    async ({ id, confirm, dryRun }) => {
+      if (dryRun) return dryRunResponse(`delete tax reduction ${id}`);
+      if (!confirm) requireConfirmation(`delete tax reduction ${id}`);
+      await deleteTaxReduction(id);
+      return confirmationResponse(`Skattereduktion ${id} borttagen.`, {});
     },
   );
 }

--- a/src/views.ts
+++ b/src/views.ts
@@ -2,6 +2,12 @@ import type { Column } from './formatter.js';
 
 const currency = (v: unknown) => (typeof v === 'number' ? v.toFixed(2) : String(v ?? ''));
 
+export const referenceDataColumns: Column[] = [
+  { key: 'Code', header: 'Code', width: 16 },
+  { key: 'Name', header: 'Name', width: 24 },
+  { key: 'Description', header: 'Description', width: 36 },
+];
+
 // --- Invoice views (target ≤80 cols) ---
 
 // 7 + 2 + 20 + 2 + 10 + 2 + 10 + 2 + 10 + 2 + 10 = 77

--- a/src/views.ts
+++ b/src/views.ts
@@ -180,6 +180,11 @@ export const supplierInvoiceConfirmColumns: Column[] = [
   { key: 'Booked', header: 'Booked', width: 5 },
 ];
 
+export const supplierInvoiceAttachmentColumns: Column[] = [
+  { key: 'fileName', header: 'File', width: 40 },
+  { key: 'fileId', header: 'File ID', width: 36 },
+];
+
 // --- Invoice payment views (target ≤80 cols) ---
 
 // 8 + 2 + 10 + 2 + 10 + 2 + 12 + 2 + 10 + 2 + 10 = 70

--- a/src/views.ts
+++ b/src/views.ts
@@ -52,9 +52,12 @@ export const customerListColumns: Column[] = [
 export const customerDetailColumns: Column[] = [
   { key: 'CustomerNumber', header: 'Customer #', width: 20 },
   { key: 'Name', header: 'Name', width: 40 },
+  { key: 'Type', header: 'Type', width: 8 },
   { key: 'OrganisationNumber', header: 'Org Nr', width: 20 },
   { key: 'Email', header: 'Email', width: 40 },
-  { key: 'Phone', header: 'Phone', width: 20 },
+  // The real Fortnox field is Phone1 (there is no bare "Phone") — see the write
+  // schema fix in tools/customers.ts for the same mismatch on the write side.
+  { key: 'Phone1', header: 'Phone', width: 20 },
   { key: 'Address1', header: 'Address', width: 40 },
   { key: 'ZipCode', header: 'Zip Code', width: 10 },
   { key: 'City', header: 'City', width: 20 },

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -14,6 +14,12 @@ const partial = (overrides: Partial<ApiCoverageMapping> = {}): ApiCoverageMappin
   publicOperationCount: 2,
   implementedOperationIdentities: ['operation-a'],
   missingOperationIdentities: ['operation-b'],
+  excludedOperationIdentities: [],
+  evidence: {
+    operationExports: ['listExample'],
+    mcpTools: ['fortnox_list_examples'],
+    cliCommands: [['examples', 'list']],
+  },
   ...overrides,
 });
 
@@ -54,6 +60,7 @@ describe('API coverage manifest core', () => {
     [partial({ classification: 'complete' }), 'Complete mapping'],
     [partial({ classification: 'excluded' }), 'requires a rationale'],
     [partial({ classification: 'blocked' }), 'requires a rationale'],
+    [partial({ evidence: undefined }), 'requires export, MCP, and CLI evidence'],
     [
       partial({
         classification: 'partial',
@@ -78,14 +85,18 @@ describe('API coverage manifest core', () => {
         id: 'excluded',
         classification: 'excluded',
         implementedOperationIdentities: [],
-        missingOperationIdentities: ['operation-a', 'operation-b'],
+        missingOperationIdentities: [],
+        excludedOperationIdentities: ['operation-a', 'operation-b'],
+        evidence: undefined,
         rationale: 'Outside the public core product.',
       }),
       partial({
         id: 'blocked',
         classification: 'blocked',
         implementedOperationIdentities: [],
-        missingOperationIdentities: ['operation-a', 'operation-b'],
+        missingOperationIdentities: [],
+        excludedOperationIdentities: ['operation-a', 'operation-b'],
+        evidence: undefined,
         rationale: 'The upstream API does not expose this capability.',
       }),
     ]);

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateApiCoverage,
+  compareApiCoverageBaselines,
+  formatApiCoverageDetails,
+  formatApiCoverageSummary,
+  toApiCoverageBaseline,
+  type ApiCoverageMapping,
+} from '../src/api-coverage.js';
+
+const partial = (overrides: Partial<ApiCoverageMapping> = {}): ApiCoverageMapping => ({
+  id: 'example-family',
+  classification: 'partial',
+  publicOperationCount: 2,
+  implementedOperationIdentities: ['operation-a'],
+  missingOperationIdentities: ['operation-b'],
+  ...overrides,
+});
+
+describe('API coverage manifest core', () => {
+  it('produces deterministic privacy-safe baselines and summaries', () => {
+    const first = calculateApiCoverage([partial()]);
+    const second = calculateApiCoverage([partial()]);
+    const baseline = toApiCoverageBaseline(first);
+
+    expect(second).toEqual(first);
+    expect(JSON.stringify(baseline)).not.toContain('operation-a');
+    expect(JSON.stringify(baseline)).not.toContain('operation-b');
+    expect(formatApiCoverageSummary(first)).not.toContain('operation-b');
+    expect(formatApiCoverageDetails(first)).toContain('"operation-b"');
+  });
+
+  it('sorts records and detects baseline drift', () => {
+    const results = calculateApiCoverage([
+      partial({ id: 'z-family' }),
+      partial({ id: 'a-family' }),
+    ]);
+    const baseline = toApiCoverageBaseline(results);
+    const changed = structuredClone(baseline);
+    changed.records[0]!.missingCount = 0;
+
+    expect(baseline.records.map(({ id }) => id)).toEqual(['a-family', 'z-family']);
+    expect(compareApiCoverageBaselines(baseline, baseline)).toEqual({
+      matches: true,
+      changedMappingIds: [],
+    });
+    expect(compareApiCoverageBaselines(baseline, changed).changedMappingIds).toEqual(['a-family']);
+  });
+
+  it.each([
+    [partial({ publicOperationCount: 3 }), 'accounts for 2 of 3'],
+    [partial({ implementedOperationIdentities: ['operation-a', 'operation-a'] }), 'Duplicate'],
+    [partial({ missingOperationIdentities: ['operation-a'] }), 'both implemented and missing'],
+    [partial({ classification: 'complete' }), 'Complete mapping'],
+    [partial({ classification: 'excluded' }), 'requires a rationale'],
+    [partial({ classification: 'blocked' }), 'requires a rationale'],
+    [
+      partial({
+        classification: 'partial',
+        missingOperationIdentities: [],
+        publicOperationCount: 1,
+      }),
+      'must have a missing',
+    ],
+  ])('fails closed for an invalid mapping', (mapping, error) => {
+    expect(() => calculateApiCoverage([mapping as ApiCoverageMapping])).toThrow(error as string);
+  });
+
+  it('supports complete, excluded, and blocked classifications with explicit accounting', () => {
+    const results = calculateApiCoverage([
+      partial({
+        id: 'complete',
+        classification: 'complete',
+        publicOperationCount: 1,
+        missingOperationIdentities: [],
+      }),
+      partial({
+        id: 'excluded',
+        classification: 'excluded',
+        implementedOperationIdentities: [],
+        missingOperationIdentities: ['operation-a', 'operation-b'],
+        rationale: 'Outside the public core product.',
+      }),
+      partial({
+        id: 'blocked',
+        classification: 'blocked',
+        implementedOperationIdentities: [],
+        missingOperationIdentities: ['operation-a', 'operation-b'],
+        rationale: 'The upstream API does not expose this capability.',
+      }),
+    ]);
+
+    expect(results.map(({ classification }) => classification)).toEqual([
+      'blocked',
+      'complete',
+      'excluded',
+    ]);
+  });
+
+  it('quotes control characters in explicit local details', () => {
+    const details = formatApiCoverageDetails(
+      calculateApiCoverage([
+        partial({ missingOperationIdentities: ['danger\n\u001b[31m'], publicOperationCount: 2 }),
+      ]),
+    );
+    expect(details).not.toContain('\u001b');
+    expect(details).toContain('danger\\n\\u001b[31m');
+  });
+});

--- a/tests/operations/accounts.test.ts
+++ b/tests/operations/accounts.test.ts
@@ -80,4 +80,47 @@ describe('accounts operations', () => {
       expect(calledUrl).toContain('financialyear=2');
     });
   });
+
+  it('gets one account by number', async () => {
+    mockFetch({ Account: { Number: 1930, Description: 'Företagskonto' } });
+    const { getAccount } = await import('../../src/operations/accounts.js');
+
+    const account = await getAccount(1930);
+
+    expect(account.Number).toBe(1930);
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain('accounts/1930');
+  });
+
+  it('creates an account with the Fortnox envelope', async () => {
+    mockFetch({ Account: { Number: 2999, Description: 'Avräkning' } });
+    const { createAccount } = await import('../../src/operations/accounts.js');
+
+    await createAccount({ Number: 2999, Description: 'Avräkning' });
+
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1].method).toBe('POST');
+    expect(JSON.parse(call[1].body).Account).toEqual({ Number: 2999, Description: 'Avräkning' });
+  });
+
+  it('updates an account without duplicating its path identifier in the body', async () => {
+    mockFetch({ Account: { Number: 2999, Description: 'Ny beskrivning' } });
+    const { updateAccount } = await import('../../src/operations/accounts.js');
+
+    await updateAccount(2999, { Number: 2999, Description: 'Ny beskrivning' });
+
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1].method).toBe('PUT');
+    expect(JSON.parse(call[1].body).Account.Number).toBeUndefined();
+  });
+
+  it('deletes an account', async () => {
+    mockFetch({});
+    const { deleteAccount } = await import('../../src/operations/accounts.js');
+
+    await deleteAccount(2999);
+
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain('accounts/2999');
+    expect(call[1].method).toBe('DELETE');
+  });
 });

--- a/tests/operations/accruals.test.ts
+++ b/tests/operations/accruals.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
+import { createAccrualOperations } from '../../src/operations/accruals.js';
+
+describe('accrual operations', () => {
+  it('covers list/get/create/update/delete for all three native families', async () => {
+    const request = vi.fn();
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+    const definitions = [
+      ['Invoice', 'invoiceaccruals', 'InvoiceAccruals', 'InvoiceAccrual'],
+      [
+        'SupplierInvoice',
+        'supplierinvoiceaccruals',
+        'SupplierInvoiceAccruals',
+        'SupplierInvoiceAccrual',
+      ],
+      ['Contract', 'contractaccruals', 'ContractAccruals', 'ContractAccrual'],
+    ] as const;
+    const dynamic = operations as unknown as Record<
+      string,
+      (...arguments_: unknown[]) => Promise<unknown>
+    >;
+
+    for (const [prefix, endpoint, listKey, singleKey] of definitions) {
+      request.mockResolvedValueOnce({ [listKey]: [{ DocumentNumber: 7 }] });
+      const listed = (await dynamic[`list${prefix}Accruals`]?.()) as {
+        items: Record<string, unknown>[];
+      };
+      expect(listed.items).toHaveLength(1);
+      expect(request).toHaveBeenLastCalledWith(endpoint);
+
+      request.mockResolvedValueOnce({ [singleKey]: { DocumentNumber: 7 } });
+      await dynamic[`get${prefix}Accrual`]?.('7');
+      expect(request).toHaveBeenLastCalledWith(`${endpoint}/7`);
+
+      request.mockResolvedValueOnce({ [singleKey]: { DocumentNumber: 7 } });
+      await dynamic[`create${prefix}Accrual`]?.({ Total: 100 });
+      expect(request).toHaveBeenLastCalledWith(endpoint, {
+        method: 'POST',
+        body: { [singleKey]: { Total: 100 } },
+      });
+
+      request.mockResolvedValueOnce({ [singleKey]: { DocumentNumber: 7 } });
+      await dynamic[`update${prefix}Accrual`]?.('7', { Total: 200 });
+      expect(request).toHaveBeenLastCalledWith(`${endpoint}/7`, {
+        method: 'PUT',
+        body: { [singleKey]: { Total: 200 } },
+      });
+
+      request.mockResolvedValueOnce({});
+      await dynamic[`delete${prefix}Accrual`]?.('7');
+      expect(request).toHaveBeenLastCalledWith(`${endpoint}/7`, { method: 'DELETE' });
+    }
+  });
+
+  it('rejects unsafe document-number path segments', async () => {
+    const request = vi.fn();
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+    await expect(operations.getInvoiceAccrual('../companyinformation')).rejects.toThrow(
+      'Invalid document number',
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/tests/operations/articles.test.ts
+++ b/tests/operations/articles.test.ts
@@ -113,4 +113,17 @@ describe('article operations', () => {
       expect(body.Article.ArticleNumber).toBeUndefined();
     });
   });
+
+  describe('deleteArticle', () => {
+    it('uses DELETE and encodes the article number', async () => {
+      mockFetch({});
+      const { deleteArticle } = await import('../../src/operations/articles.js');
+
+      await deleteArticle('A/B');
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('articles/A%2FB');
+      expect(fetchCall[1].method).toBe('DELETE');
+    });
+  });
 });

--- a/tests/operations/attachment-parity.test.ts
+++ b/tests/operations/attachment-parity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
+import { createInvoiceOperations } from '../../src/operations/invoices.js';
+import { createSupplierInvoiceOperations } from '../../src/operations/supplier-invoices.js';
+import { createVoucherOperations } from '../../src/operations/vouchers.js';
+
+describe('attachment connection operation parity', () => {
+  it('gets and deletes voucher file connections', async () => {
+    const request = vi.fn().mockResolvedValue({ VoucherFileConnection: { FileId: 'f1' } });
+    const operations = createVoucherOperations({ request } as unknown as FortnoxTransport);
+    await operations.getVoucherFileConnection('a/b');
+    await operations.deleteVoucherFileConnection('a/b');
+    expect(request.mock.calls).toEqual([
+      ['voucherfileconnections/a%2Fb'],
+      ['voucherfileconnections/a%2Fb', { method: 'DELETE' }],
+    ]);
+  });
+
+  it('covers supplier invoice file-connection lifecycle', async () => {
+    const request = vi.fn().mockResolvedValue({
+      SupplierInvoiceFileConnection: { FileId: 'f1', SupplierInvoiceNumber: '7' },
+    });
+    const operations = createSupplierInvoiceOperations({ request } as unknown as FortnoxTransport);
+    await operations.getSupplierInvoiceFileConnection('a/b');
+    await operations.createSupplierInvoiceFileConnection('7', 'f1');
+    await operations.deleteSupplierInvoiceFileConnection('a/b');
+    expect(request.mock.calls).toEqual([
+      ['supplierinvoicefileconnections/a%2Fb'],
+      [
+        'supplierinvoicefileconnections',
+        {
+          method: 'POST',
+          body: {
+            SupplierInvoiceFileConnection: { SupplierInvoiceNumber: '7', FileId: 'f1' },
+          },
+        },
+      ],
+      ['supplierinvoicefileconnections/a%2Fb', { method: 'DELETE' }],
+    ]);
+  });
+
+  it('covers document attachment create/list/count/validate/update/detach', async () => {
+    const request = vi.fn().mockResolvedValue([{ id: 'a1' }]);
+    const operations = createInvoiceOperations({ request } as unknown as FortnoxTransport);
+    await operations.createDocumentAttachment('7', 'O', 'f1', true);
+    await operations.listDocumentAttachments('7', 'O');
+    await operations.getAttachmentCounts([7, 8], 'O');
+    await operations.validateAttachmentsOnSend([{ id: 'a1', includeOnSend: true }]);
+    await operations.updateDocumentAttachment('a/b', { includeOnSend: false });
+    await operations.detachDocumentAttachment('a/b');
+    expect(request.mock.calls).toEqual([
+      [
+        '/api/fileattachments/attachments-v1',
+        {
+          method: 'POST',
+          body: [{ entityId: 7, entityType: 'O', fileId: 'f1', includeOnSend: true }],
+        },
+      ],
+      ['/api/fileattachments/attachments-v1', { params: { entityid: '7', entitytype: 'O' } }],
+      [
+        '/api/fileattachments/attachments-v1/numberofattachments',
+        { params: { entityids: '7,8', entitytype: 'O' } },
+      ],
+      [
+        '/api/fileattachments/attachments-v1/validateincludedonsend',
+        { method: 'POST', body: [{ id: 'a1', includeOnSend: true }] },
+      ],
+      [
+        '/api/fileattachments/attachments-v1/a%2Fb',
+        { method: 'PUT', body: { includeOnSend: false } },
+      ],
+      ['/api/fileattachments/attachments-v1/a%2Fb', { method: 'DELETE' }],
+    ]);
+  });
+});

--- a/tests/operations/attachment-parity.test.ts
+++ b/tests/operations/attachment-parity.test.ts
@@ -72,4 +72,17 @@ describe('attachment connection operation parity', () => {
       ['/api/fileattachments/attachments-v1/a%2Fb', { method: 'DELETE' }],
     ]);
   });
+
+  it('rejects invalid attachment document numbers before sending a request', async () => {
+    const request = vi.fn();
+    const operations = createInvoiceOperations({ request } as unknown as FortnoxTransport);
+
+    await expect(
+      operations.createDocumentAttachment('not-a-number', 'F', 'f1', true),
+    ).rejects.toThrow('Invalid document number');
+    await expect(
+      operations.createDocumentAttachment('9007199254740993', 'F', 'f1', true),
+    ).rejects.toThrow('Invalid document number');
+    expect(request).not.toHaveBeenCalled();
+  });
 });

--- a/tests/operations/customers.test.ts
+++ b/tests/operations/customers.test.ts
@@ -149,4 +149,27 @@ describe('customer operations', () => {
       expect(body.Customer.CountryCode).toBe('SE');
     });
   });
+
+  describe('deleteCustomer', () => {
+    it('uses DELETE on the validated customer path', async () => {
+      mockFetch({});
+      const { deleteCustomer } = await import('../../src/operations/customers.js');
+
+      await deleteCustomer('A-42');
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('customers/A-42');
+      expect(fetchCall[1].method).toBe('DELETE');
+    });
+
+    it('rejects path traversal before sending a request', async () => {
+      mockFetch({});
+      const { deleteCustomer } = await import('../../src/operations/customers.js');
+
+      await expect(deleteCustomer('../companyinformation')).rejects.toThrow(
+        'Invalid customer number',
+      );
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
 });

--- a/tests/operations/files.test.ts
+++ b/tests/operations/files.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
+import { createFileOperations } from '../../src/operations/files.js';
+import { privateOutputPath, writeBinaryFile } from '../../src/safe-file-output.js';
+
+describe('archive and inbox operations', () => {
+  it('covers native archive and inbox reads/deletes', async () => {
+    const request = vi.fn().mockResolvedValue({ Folder: { Files: [] } });
+    const requestFile = vi.fn().mockResolvedValue({
+      buffer: Buffer.from('file'),
+      contentType: 'application/pdf',
+    });
+    const operations = createFileOperations({
+      request,
+      requestFile,
+    } as unknown as FortnoxTransport);
+
+    await operations.listArchive({ path: 'docs', fileId: 'f1' });
+    await operations.getArchiveEntry('a/b', { path: 'docs' });
+    await operations.deleteArchivePath('docs/old');
+    await operations.deleteArchiveEntry('a/b', 'docs');
+    await operations.listInbox();
+    const file = await operations.getInboxFile('a/b');
+    await operations.deleteInboxEntry('a/b');
+
+    expect(request.mock.calls).toEqual([
+      ['archive', { params: { path: 'docs', fileid: 'f1' } }],
+      ['archive/a%2Fb', { params: { path: 'docs', fileid: undefined } }],
+      ['archive', { method: 'DELETE', params: { path: 'docs/old' } }],
+      ['archive/a%2Fb', { method: 'DELETE', params: { path: 'docs' } }],
+      ['inbox'],
+      ['inbox/a%2Fb', { method: 'DELETE' }],
+    ]);
+    expect(requestFile).toHaveBeenCalledWith('inbox/a%2Fb');
+    expect(file.buffer.toString()).toBe('file');
+  });
+
+  it('uploads exact local bytes through multipart requests', async () => {
+    const request = vi.fn().mockResolvedValue({ File: { Id: 'f1' } });
+    const operations = createFileOperations({ request } as unknown as FortnoxTransport);
+    const path = privateOutputPath('noxctl-test-', 'receipt.pdf');
+    writeBinaryFile(path, Buffer.from('%PDF-test'));
+
+    await operations.uploadArchiveFile(path, { folderId: 'archive-folder' });
+    await operations.uploadInboxEntry(path, { folderId: 'inbox-folder' });
+
+    const archiveOptions = request.mock.calls[0][1];
+    const inboxOptions = request.mock.calls[1][1];
+    expect(archiveOptions.method).toBe('POST');
+    expect(archiveOptions.rawBody).toBeInstanceOf(FormData);
+    expect(archiveOptions.params.folderid).toBe('archive-folder');
+    expect(inboxOptions.rawBody).toBeInstanceOf(FormData);
+    expect(inboxOptions.params.folderId).toBe('inbox-folder');
+  });
+});

--- a/tests/operations/files.test.ts
+++ b/tests/operations/files.test.ts
@@ -16,7 +16,10 @@ describe('archive and inbox operations', () => {
     } as unknown as FortnoxTransport);
 
     await operations.listArchive({ path: 'docs', fileId: 'f1' });
-    await operations.getArchiveEntry('a/b', { path: 'docs' });
+    const archiveFile = await operations.getArchiveEntry('a/b', {
+      path: 'docs',
+      fileId: 'nested-file',
+    });
     await operations.deleteArchivePath('docs/old');
     await operations.deleteArchiveEntry('a/b', 'docs');
     await operations.listInbox();
@@ -25,13 +28,16 @@ describe('archive and inbox operations', () => {
 
     expect(request.mock.calls).toEqual([
       ['archive', { params: { path: 'docs', fileid: 'f1' } }],
-      ['archive/a%2Fb', { params: { path: 'docs', fileid: undefined } }],
       ['archive', { method: 'DELETE', params: { path: 'docs/old' } }],
       ['archive/a%2Fb', { method: 'DELETE', params: { path: 'docs' } }],
       ['inbox'],
       ['inbox/a%2Fb', { method: 'DELETE' }],
     ]);
-    expect(requestFile).toHaveBeenCalledWith('inbox/a%2Fb');
+    expect(requestFile.mock.calls).toEqual([
+      ['archive/a%2Fb', { params: { path: 'docs', fileid: 'nested-file' } }],
+      ['inbox/a%2Fb'],
+    ]);
+    expect(archiveFile.buffer.toString()).toBe('file');
     expect(file.buffer.toString()).toBe('file');
   });
 

--- a/tests/operations/operation-parity.test.ts
+++ b/tests/operations/operation-parity.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+function mockJson(response: unknown) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    text: () => Promise.resolve(JSON.stringify(response)),
+    json: () => Promise.resolve(response),
+  });
+}
+
+function calls(): [string, RequestInit][] {
+  return (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string, RequestInit][];
+}
+
+describe('existing-family operation parity', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('updates and resolves composite absence transactions', async () => {
+    mockJson({ AbsenceTransaction: { id: 'row-1' } });
+    const { updateAbsenceTransaction, getAbsenceTransactionByDateCode } =
+      await import('../../src/operations/absencetransactions.js');
+    await updateAbsenceTransaction('row-1', { Hours: 4 });
+    await getAbsenceTransactionByDateCode('employee/1', '2026-09-01', 'VAB');
+
+    expect(calls()[0][1].method).toBe('PUT');
+    expect(JSON.parse(String(calls()[0][1].body)).AbsenceTransaction).toEqual({ Hours: 4 });
+    expect(calls()[1][0]).toContain('employee%2F1/2026-09-01/VAB');
+  });
+
+  it('updates and resolves composite attendance transactions', async () => {
+    mockJson({ AttendanceTransaction: { id: 'row-1' } });
+    const { updateAttendanceTransaction, getAttendanceTransactionByDateCode } =
+      await import('../../src/operations/attendancetransactions.js');
+    await updateAttendanceTransaction('row-1', { Hours: 8 });
+    await getAttendanceTransactionByDateCode('employee/1', '2026-09-01', 'ARB');
+
+    expect(calls()[0][1].method).toBe('PUT');
+    expect(calls()[1][0]).toContain('employee%2F1/2026-09-01/ARB');
+  });
+
+  it('updates salary transactions', async () => {
+    mockJson({ SalaryTransaction: { SalaryRow: '4' } });
+    const { updateSalaryTransaction } = await import('../../src/operations/salarytransactions.js');
+    await updateSalaryTransaction('4', { Amount: 100 });
+    expect(calls()[0][1].method).toBe('PUT');
+    expect(JSON.parse(String(calls()[0][1].body)).SalaryTransaction.Amount).toBe(100);
+  });
+
+  it('updates and bookkeeps customer invoice payments', async () => {
+    mockJson({ InvoicePayment: { Number: 4 } });
+    const { updateInvoicePayment, bookkeepInvoicePayment } =
+      await import('../../src/operations/invoice-payments.js');
+    await updateInvoicePayment('4', { Amount: 100 });
+    await bookkeepInvoicePayment('4');
+    expect(calls().map(([url]) => url)).toEqual([
+      expect.stringContaining('invoicepayments/4'),
+      expect.stringContaining('invoicepayments/4/bookkeep'),
+    ]);
+    expect(calls().every(([, init]) => init.method === 'PUT')).toBe(true);
+  });
+
+  it('updates and bookkeeps supplier invoice payments', async () => {
+    mockJson({ SupplierInvoicePayment: { Number: 4 } });
+    const { updateSupplierInvoicePayment, bookkeepSupplierInvoicePayment } =
+      await import('../../src/operations/supplier-invoice-payments.js');
+    await updateSupplierInvoicePayment('4', { Amount: 100 });
+    await bookkeepSupplierInvoicePayment('4');
+    expect(calls()[1][0]).toContain('supplierinvoicepayments/4/bookkeep');
+    expect(calls().every(([, init]) => init.method === 'PUT')).toBe(true);
+  });
+
+  it('updates and deletes tax reductions', async () => {
+    mockJson({ TaxReduction: { Id: 7 } });
+    const { updateTaxReduction, deleteTaxReduction } =
+      await import('../../src/operations/taxreductions.js');
+    await updateTaxReduction(7, { Status: 'PAID' });
+    await deleteTaxReduction(7);
+    expect(calls().map(([, init]) => init.method)).toEqual(['PUT', 'DELETE']);
+  });
+
+  it('deletes projects', async () => {
+    mockJson({});
+    const { deleteProject } = await import('../../src/operations/projects.js');
+    await deleteProject('P/1');
+    expect(calls()[0][0]).toContain('projects/P%2F1');
+    expect(calls()[0][1].method).toBe('DELETE');
+  });
+
+  it('creates a financial year with its native envelope', async () => {
+    mockJson({ FinancialYear: { Id: 7 } });
+    const { createFinancialYear } = await import('../../src/operations/financial-years.js');
+    await createFinancialYear({ FromDate: '2026-01-01', ToDate: '2026-12-31' });
+    expect(calls()[0][1].method).toBe('POST');
+    expect(JSON.parse(String(calls()[0][1].body)).FinancialYear.ToDate).toBe('2026-12-31');
+  });
+
+  it('covers supplier-invoice update and native approval/status actions', async () => {
+    mockJson({ SupplierInvoice: { GivenNumber: '8' } });
+    const operations = await import('../../src/operations/supplier-invoices.js');
+    await operations.updateSupplierInvoice('8', { Comments: 'reviewed' });
+    await operations.approvalBookkeepSupplierInvoice('8');
+    await operations.approvalPaymentSupplierInvoice('8');
+    await operations.cancelSupplierInvoice('8');
+    await operations.creditSupplierInvoice('8');
+    expect(calls().map(([url]) => url)).toEqual([
+      expect.stringContaining('supplierinvoices/8'),
+      expect.stringContaining('/approvalbookkeep'),
+      expect.stringContaining('/approvalpayment'),
+      expect.stringContaining('/cancel'),
+      expect.stringContaining('/credit'),
+    ]);
+  });
+
+  it('covers remaining invoice delivery and status actions', async () => {
+    mockJson({ Invoice: { DocumentNumber: '8' } });
+    const { cancelInvoice, externalPrintInvoice, eprintInvoice } =
+      await import('../../src/operations/invoices.js');
+    await cancelInvoice('8');
+    await externalPrintInvoice('8');
+    await eprintInvoice('8');
+    expect(calls().map(([url]) => url)).toEqual([
+      expect.stringContaining('/cancel'),
+      expect.stringContaining('/externalprint'),
+      expect.stringContaining('/eprint'),
+    ]);
+  });
+
+  it('covers remaining offer and order status/delivery actions', async () => {
+    mockJson({ Offer: { DocumentNumber: '8' }, Order: { DocumentNumber: '9' } });
+    const offers = await import('../../src/operations/offers.js');
+    await offers.cancelOffer('8');
+    await offers.externalPrintOffer('8');
+    await offers.emailOffer('8');
+    const orders = await import('../../src/operations/orders.js');
+    await orders.cancelOrder('9');
+    await orders.externalPrintOrder('9');
+    await orders.emailOrder('9');
+    expect(calls().map(([url]) => url)).toEqual([
+      expect.stringContaining('offers/8/cancel'),
+      expect.stringContaining('offers/8/externalprint'),
+      expect.stringContaining('offers/8/email'),
+      expect.stringContaining('orders/9/cancel'),
+      expect.stringContaining('orders/9/externalprint'),
+      expect.stringContaining('orders/9/email'),
+    ]);
+  });
+
+  it('lists, creates, updates, gets and deletes quantity-aware prices', async () => {
+    mockJson({ Prices: [], Price: { Price: 12 } });
+    const prices = await import('../../src/operations/pricelists.js');
+    await prices.listPrices({});
+    await prices.createPrice({ PriceList: 'A', ArticleNumber: '1', Price: 12 });
+    await prices.getPrice('A', '1', 5);
+    await prices.getPrice('A', '1');
+    await prices.updatePrice('A', '1', { Price: 14 }, 5);
+    await prices.updatePrice('A', '1', { Price: 15 });
+    await prices.deletePrice('A', '1', 5);
+    expect(calls().map(([, init]) => init.method)).toEqual([
+      'GET',
+      'POST',
+      'GET',
+      'GET',
+      'PUT',
+      'PUT',
+      'DELETE',
+    ]);
+    expect(calls()[0][0]).toMatch(/\/prices\?/);
+    expect(calls()[3][0]).toMatch(/\/A\/1$/);
+    expect(calls()[6][0]).toContain('/A/1/5');
+  });
+});

--- a/tests/operations/pricelists.test.ts
+++ b/tests/operations/pricelists.test.ts
@@ -146,7 +146,7 @@ describe('price operations', () => {
       await updatePrice('A', 'ART1', { Price: 200 });
 
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(fetchCall[0]).toContain('prices/A/ART1/0');
+      expect(fetchCall[0]).toMatch(/prices\/A\/ART1$/);
       expect(fetchCall[1].method).toBe('PUT');
       const body = JSON.parse(fetchCall[1].body);
       expect(body.Price.Price).toBe(200);

--- a/tests/operations/reference-data.test.ts
+++ b/tests/operations/reference-data.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
+import { createReferenceDataOperations } from '../../src/operations/reference-data.js';
+
+describe('reference data operations', () => {
+  it('uses every reviewed native list and get endpoint and preserves envelopes', async () => {
+    const request = vi.fn();
+    const transport = { request } as unknown as FortnoxTransport;
+    const operations = createReferenceDataOperations(transport);
+    const definitions = [
+      ['listCurrencies', 'getCurrency', 'currencies', 'Currencies', 'Currency'],
+      ['listUnits', 'getUnit', 'units', 'Units', 'Unit'],
+      [
+        'listModesOfPayments',
+        'getModeOfPayment',
+        'modesofpayments',
+        'ModesOfPayments',
+        'ModeOfPayment',
+      ],
+      [
+        'listTermsOfDeliveries',
+        'getTermOfDelivery',
+        'termsofdeliveries',
+        'TermsOfDeliveries',
+        'TermsOfDelivery',
+      ],
+      [
+        'listTermsOfPayments',
+        'getTermOfPayment',
+        'termsofpayments',
+        'TermsOfPayments',
+        'TermsOfPayment',
+      ],
+      [
+        'listWaysOfDelivery',
+        'getWayOfDelivery',
+        'wayofdeliveries',
+        'WayOfDeliveries',
+        'WayOfDelivery',
+      ],
+      [
+        'listVoucherSeries',
+        'getVoucherSeries',
+        'voucherseries',
+        'VoucherSeriesCollection',
+        'VoucherSeries',
+      ],
+      [
+        'listPredefinedVoucherSeries',
+        'getPredefinedVoucherSeries',
+        'predefinedvoucherseries',
+        'PreDefinedVoucherSeriesCollection',
+        'PreDefinedVoucherSeries',
+      ],
+      [
+        'listPredefinedAccounts',
+        'getPredefinedAccount',
+        'predefinedaccounts',
+        'PreDefinedAccounts',
+        'PreDefinedAccount',
+      ],
+      [
+        'listCustomerReferences',
+        'getCustomerReference',
+        'customerreferences',
+        'CustomerReference',
+        'CustomerReference',
+      ],
+    ] as const;
+    const dynamic = operations as unknown as Record<string, (arg?: unknown) => Promise<unknown>>;
+
+    for (const [listName, getName, endpoint, listKey, singleKey] of definitions) {
+      request.mockResolvedValueOnce({ [listKey]: [{ Code: 'A' }] });
+      const listed = (await dynamic[listName]?.({ page: 2, limit: 20 })) as {
+        items: Record<string, unknown>[];
+      };
+      expect(listed.items).toEqual([{ Code: 'A' }]);
+      expect(request).toHaveBeenLastCalledWith(endpoint, {
+        params: { page: 2, limit: 20 },
+      });
+
+      request.mockResolvedValueOnce({ [singleKey]: { Code: 'A' } });
+      const received = (await dynamic[getName]?.('A/B')) as { item: Record<string, unknown> };
+      expect(received.item).toEqual({ Code: 'A' });
+      expect(request).toHaveBeenLastCalledWith(`${endpoint}/A%2FB`);
+    }
+
+    request.mockResolvedValueOnce({ AccountCharts: [{ Name: 'BAS' }] });
+    const charts = await operations.listAccountCharts();
+    expect(charts.items).toEqual([{ Name: 'BAS' }]);
+    expect(request).toHaveBeenLastCalledWith('accountcharts', {
+      params: { page: 1, limit: 100 },
+    });
+  });
+});

--- a/tests/operations/supplier-invoices.test.ts
+++ b/tests/operations/supplier-invoices.test.ts
@@ -13,6 +13,16 @@ function mockFetch(response: unknown) {
   });
 }
 
+function mockBinary(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+  });
+}
+
 describe('supplier invoice operations', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -100,6 +110,63 @@ describe('supplier invoice operations', () => {
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(fetchCall[0]).toContain('supplierinvoices/1/bookkeep');
       expect(fetchCall[1].method).toBe('PUT');
+    });
+  });
+
+  describe('listSupplierInvoiceAttachments', () => {
+    it('GETs supplierinvoicefileconnections filtered by supplierinvoicenumber and maps the response', async () => {
+      const { listSupplierInvoiceAttachments } =
+        await import('../../src/operations/supplier-invoices.js');
+      mockFetch({
+        SupplierInvoiceFileConnections: [
+          { FileId: 'f1', Name: 'invoice-scan.pdf', SupplierInvoiceNumber: '1' },
+        ],
+      });
+
+      const result = await listSupplierInvoiceAttachments('1');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('supplierinvoicefileconnections');
+      expect(url).toContain('supplierinvoicenumber=1');
+      expect(result).toEqual([
+        { fileName: 'invoice-scan.pdf', fileId: 'f1', supplierInvoiceNumber: '1' },
+      ]);
+    });
+
+    it('returns an empty array when the invoice has no attachments', async () => {
+      const { listSupplierInvoiceAttachments } =
+        await import('../../src/operations/supplier-invoices.js');
+      mockFetch({ SupplierInvoiceFileConnections: [] });
+
+      const result = await listSupplierInvoiceAttachments('2');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSupplierInvoiceFile', () => {
+    it('GETs inbox/{fileId} and returns the raw bytes with content-type', async () => {
+      const { getSupplierInvoiceFile } = await import('../../src/operations/supplier-invoices.js');
+      const bytes = Buffer.from('fake-pdf-bytes');
+      mockBinary(bytes, 'application/pdf');
+
+      const result = await getSupplierInvoiceFile('f1');
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+      expect(url).toContain('inbox/f1');
+      expect(result.fileId).toBe('f1');
+      expect(result.contentType).toBe('application/pdf');
+      expect(result.buffer.equals(bytes)).toBe(true);
+    });
+
+    it('throws when Fortnox answers 2xx with a JSON error envelope instead of file bytes', async () => {
+      const { getSupplierInvoiceFile } = await import('../../src/operations/supplier-invoices.js');
+      const bytes = Buffer.from(
+        JSON.stringify({ ErrorInformation: { message: 'not found', code: 123 } }),
+      );
+      mockBinary(bytes, 'application/json');
+
+      await expect(getSupplierInvoiceFile('missing')).rejects.toThrow(/not found/);
     });
   });
 });

--- a/tests/safe-file-output.test.ts
+++ b/tests/safe-file-output.test.ts
@@ -1,0 +1,30 @@
+import { lstatSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { privateOutputPath, writeBinaryFile } from '../src/safe-file-output.js';
+
+describe('safe binary file output', () => {
+  it('creates private temporary destinations and exact bytes', () => {
+    const path = privateOutputPath('noxctl-test-', 'file.bin');
+    expect(writeBinaryFile(path, Buffer.from([0, 1, 2]))).toBe(path);
+    expect(readFileSync(path)).toEqual(Buffer.from([0, 1, 2]));
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it('refuses overwrite unless explicitly allowed', () => {
+    const path = privateOutputPath('noxctl-test-', 'existing.bin');
+    writeFileSync(path, 'old');
+    expect(() => writeBinaryFile(path, Buffer.from('new'))).toThrow('already exists');
+    writeBinaryFile(path, Buffer.from('new'), true);
+    expect(readFileSync(path, 'utf8')).toBe('new');
+  });
+
+  it('never follows a destination symlink', () => {
+    const real = privateOutputPath('noxctl-test-', 'real.bin');
+    const link = join(real, '..', 'link.bin');
+    writeFileSync(real, 'old');
+    symlinkSync(real, link);
+    expect(() => writeBinaryFile(link, Buffer.from('new'), true)).toThrow('symbolic link');
+    expect(readFileSync(real, 'utf8')).toBe('old');
+  });
+});

--- a/tests/safe-file-output.test.ts
+++ b/tests/safe-file-output.test.ts
@@ -1,5 +1,5 @@
 import { lstatSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { privateOutputPath, writeBinaryFile } from '../src/safe-file-output.js';
 
@@ -9,6 +9,12 @@ describe('safe binary file output', () => {
     expect(writeBinaryFile(path, Buffer.from([0, 1, 2]))).toBe(path);
     expect(readFileSync(path)).toEqual(Buffer.from([0, 1, 2]));
     expect(lstatSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it('keeps untrusted default file names inside the private temporary directory', () => {
+    const path = privateOutputPath('noxctl-test-', 'archive-x/../../../../outside.bin');
+    expect(basename(path)).toBe('outside.bin');
+    expect(basename(dirname(path))).toMatch(/^noxctl-test-/);
   });
 
   it('refuses overwrite unless explicitly allowed', () => {

--- a/tests/safe-file-output.test.ts
+++ b/tests/safe-file-output.test.ts
@@ -8,7 +8,9 @@ describe('safe binary file output', () => {
     const path = privateOutputPath('noxctl-test-', 'file.bin');
     expect(writeBinaryFile(path, Buffer.from([0, 1, 2]))).toBe(path);
     expect(readFileSync(path)).toEqual(Buffer.from([0, 1, 2]));
-    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    // POSIX mode bits are not meaningful on Windows; the user's temporary
+    // directory ACL is the relevant boundary there.
+    if (process.platform !== 'win32') expect(lstatSync(path).mode & 0o777).toBe(0o600);
   });
 
   it('keeps untrusted default file names inside the private temporary directory', () => {

--- a/tests/schema-audit.test.ts
+++ b/tests/schema-audit.test.ts
@@ -4,13 +4,14 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from '../src/index.js';
 import {
   auditSchemaCoverage,
+  auditMutationInventory,
   compareAuditBaselines,
   formatAuditFields,
   formatAuditSummary,
   toAuditBaseline,
   type SchemaAuditMapping,
 } from '../src/schema-audit.js';
-import { SCHEMA_AUDIT_MAPPINGS } from '../src/schema-audit-mappings.js';
+import { SCHEMA_AUDIT_EXCEPTIONS, SCHEMA_AUDIT_MAPPINGS } from '../src/schema-audit-mappings.js';
 
 const mapping: SchemaAuditMapping = {
   id: 'example-row',
@@ -27,6 +28,7 @@ function syntheticInputs() {
         name: 'fortnox_create_example',
         inputSchema: {
           type: 'object',
+          additionalProperties: false,
           properties: {
             Rows: {
               type: 'array',
@@ -146,7 +148,7 @@ describe('OpenAPI tool-schema audit', () => {
     const other = { ...mapping, id: 'aaa-example-row' };
     const baseline = toAuditBaseline(auditSchemaCoverage(spec, tools, [mapping, other]));
 
-    expect(baseline.formatVersion).toBe(1);
+    expect(baseline.formatVersion).toBe(2);
     expect(baseline.records.map((record) => record.id)).toEqual(['aaa-example-row', 'example-row']);
     expect(`${JSON.stringify(baseline, null, 2)}\n`).toBe(
       `${JSON.stringify(toAuditBaseline(auditSchemaCoverage(spec, tools, [other, mapping])), null, 2)}\n`,
@@ -178,10 +180,105 @@ describe('OpenAPI tool-schema audit', () => {
         SCHEMA_AUDIT_MAPPINGS,
       );
 
-      expect(results).toHaveLength(6);
-      expect(results.every((result) => result.declaredPropertyCount > 0)).toBe(true);
+      expect(results).toHaveLength(SCHEMA_AUDIT_MAPPINGS.length);
+      expect(results.every((result) => result.checkedNodeCount > 0)).toBe(true);
+      expect(
+        auditMutationInventory(tools, SCHEMA_AUDIT_MAPPINGS, SCHEMA_AUDIT_EXCEPTIONS),
+      ).toMatchObject({ unmappedToolNames: [], staleExceptionIds: [] });
     } finally {
       await Promise.allSettled([client.close(), server.close()]);
     }
+  });
+
+  it('reports every compatibility dimension independently', () => {
+    const tool = {
+      name: 'fortnox_create_example',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          Kind: { type: 'string', enum: ['wrong'], maxLength: 9 },
+          Nested: { type: 'string' },
+          Maybe: { type: 'string' },
+          Open: { type: 'object', properties: { Value: { type: 'string' } } },
+        },
+        required: ['Maybe'],
+      },
+    };
+    const spec = {
+      components: {
+        schemas: {
+          Example: {
+            type: 'object',
+            properties: {
+              Missing: { type: 'string' },
+              Kind: { type: 'number', enum: [1, 2], maxLength: 8 },
+              Nested: { type: 'array', items: { type: 'string' } },
+              Maybe: { type: ['string', 'null'] },
+              Open: {
+                type: 'object',
+                properties: { Value: { type: 'string' } },
+                additionalProperties: false,
+              },
+            },
+            required: ['Kind'],
+          },
+        },
+      },
+    };
+    const [result] = auditSchemaCoverage(
+      spec,
+      [tool],
+      [{ ...mapping, toolSchemaPointer: '', specSchemaName: 'Example', ignoredProperties: [] }],
+    );
+
+    expect(result.issuesByDimension.field).toHaveLength(1);
+    expect(result.issuesByDimension.nesting).toHaveLength(1);
+    expect(result.issuesByDimension.requiredness).toHaveLength(2);
+    expect(result.issuesByDimension.type).toHaveLength(1);
+    expect(result.issuesByDimension.enum).toHaveLength(1);
+    expect(result.issuesByDimension.nullability).toHaveLength(1);
+    expect(result.issuesByDimension.constraint).toHaveLength(1);
+    expect(result.issuesByDimension.strictness).toHaveLength(2);
+  });
+
+  it('inventories discovered mutations and requires tested passthrough exceptions', () => {
+    const tools = [
+      { name: 'fortnox_create_example', inputSchema: { properties: { confirm: {} } } },
+      { name: 'fortnox_delete_example', inputSchema: { properties: { dryRun: {} } } },
+      { name: 'fortnox_list_examples', inputSchema: { properties: {} } },
+    ];
+    expect(
+      auditMutationInventory(
+        tools,
+        [mapping],
+        [
+          {
+            id: 'delete-example',
+            toolName: 'fortnox_delete_example',
+            kind: 'no-structured-body',
+            rationale: 'Identifier-only delete.',
+          },
+        ],
+      ),
+    ).toMatchObject({
+      discoveredMutationCount: 2,
+      mappedMutationCount: 1,
+      exceptedMutationCount: 1,
+      unmappedToolNames: [],
+    });
+    expect(() =>
+      auditMutationInventory(
+        tools,
+        [],
+        [
+          {
+            id: 'open',
+            toolName: 'fortnox_create_example',
+            kind: 'passthrough',
+            rationale: 'Provider payload.',
+          },
+        ],
+      ),
+    ).toThrow(/preservation test/i);
   });
 });

--- a/tests/strict-mcp-inputs.test.ts
+++ b/tests/strict-mcp-inputs.test.ts
@@ -106,7 +106,7 @@ describe('strict MCP tool inputs', () => {
     }
   });
 
-  it('preserves additional fields in the intentional contract-row passthrough', async () => {
+  it('rejects additional fields in structured contract rows', async () => {
     const { client } = await setupClientServer();
 
     const result = await client.callTool({
@@ -125,7 +125,6 @@ describe('strict MCP tool inputs', () => {
       },
     });
 
-    expect(result.isError).not.toBe(true);
-    expect(textOf(result)).toContain('"FutureFortnoxField": "bevaras"');
+    expect(result.isError).toBe(true);
   });
 });

--- a/tests/tools/accruals.test.ts
+++ b/tests/tools/accruals.test.ts
@@ -111,4 +111,20 @@ describe('accrual tools', () => {
     expect(result.isError).toBe(true);
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it('accepts the extended native period values for invoice accrual families', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setup();
+    for (const [name, payload] of [
+      ['fortnox_create_invoice_accrual', payloads.invoice_accrual],
+      ['fortnox_create_supplier_invoice_accrual', payloads.supplier_invoice_accrual],
+    ] as const) {
+      const result = await client.callTool({
+        name,
+        arguments: { ...payload, Period: '12_MONTHS', dryRun: true },
+      });
+      expect(result.isError, name).toBeFalsy();
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/tests/tools/accruals.test.ts
+++ b/tests/tools/accruals.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../src/index.js';
+import { ACCRUAL_TOOL_DEFINITIONS } from '../../src/tools/accruals.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+async function setup() {
+  const server = createServer();
+  const client = new Client({ name: 'accrual-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { server, client };
+}
+
+const payloads = {
+  invoice_accrual: {
+    AccrualAccount: 1790,
+    Description: 'Annual service',
+    EndDate: '2026-12-31',
+    InvoiceAccrualRows: [
+      { Account: 3001, Credit: 100 },
+      { Account: 1790, Debit: 100 },
+    ],
+    InvoiceNumber: 7,
+    RevenueAccount: 3001,
+    StartDate: '2026-01-01',
+    Total: 1200,
+  },
+  supplier_invoice_accrual: {
+    AccrualAccount: 1790,
+    CostAccount: 6540,
+    EndDate: '2026-12-31',
+    Period: 'MONTHLY',
+    StartDate: '2026-01-01',
+    SupplierInvoiceAccrualRows: [
+      { Account: 6540, Debit: 100 },
+      { Account: 1790, Credit: 100 },
+    ],
+    SupplierInvoiceNumber: 7,
+    Times: 12,
+    Total: 1200,
+  },
+  contract_accrual: {
+    AccrualAccount: 1790,
+    AccrualRows: [
+      { Account: 3001, Credit: 100 },
+      { Account: 1790, Debit: 100 },
+    ],
+    CostAccount: 3001,
+    Description: 'Contract',
+    DocumentNumber: 7,
+    Total: 1200,
+  },
+} as const;
+
+describe('accrual tools', () => {
+  it('discovers the full lifecycle for every accrual family', async () => {
+    const { client } = await setup();
+    const names = (await client.listTools()).tools.map(({ name }) => name);
+    for (const definition of ACCRUAL_TOOL_DEFINITIONS) {
+      for (const verb of ['list', 'get', 'create', 'update', 'delete']) {
+        const plural = verb === 'list' ? 's' : '';
+        expect(names).toContain(`fortnox_${verb}_${definition.id}${plural}`);
+      }
+    }
+  });
+
+  it('previews exact create/update/delete payloads without network access', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setup();
+    for (const definition of ACCRUAL_TOOL_DEFINITIONS) {
+      const payload = payloads[definition.id as keyof typeof payloads];
+      for (const request of [
+        { name: `fortnox_create_${definition.id}`, arguments: { ...payload, dryRun: true } },
+        {
+          name: `fortnox_update_${definition.id}`,
+          arguments: { documentNumber: '7', ...payload, dryRun: true },
+        },
+        {
+          name: `fortnox_delete_${definition.id}`,
+          arguments: { documentNumber: '7', dryRun: true },
+        },
+      ]) {
+        const result = await client.callTool(request);
+        expect(result.isError, request.name).toBeFalsy();
+        expect((result.content as { text: string }[])[0]?.text).toContain('Dry run');
+      }
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown nested row properties before a request', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setup();
+    const result = await client.callTool({
+      name: 'fortnox_create_invoice_accrual',
+      arguments: {
+        ...payloads.invoice_accrual,
+        InvoiceAccrualRows: [
+          { Account: 3001, Unknown: true },
+          { Account: 1790, Debit: 100 },
+        ],
+        confirm: true,
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/articles.test.ts
+++ b/tests/tools/articles.test.ts
@@ -206,4 +206,38 @@ describe('article tools', () => {
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     });
   });
+
+  describe('fortnox_delete_article', () => {
+    it('requires confirmation and supports dry run', async () => {
+      mockFetch({});
+      const { client } = await setupClientServer();
+
+      const unconfirmed = await client.callTool({
+        name: 'fortnox_delete_article',
+        arguments: { articleNumber: 'A-1' },
+      });
+      const dryRun = await client.callTool({
+        name: 'fortnox_delete_article',
+        arguments: { articleNumber: 'A-1', dryRun: true },
+      });
+
+      expect(unconfirmed.isError).toBe(true);
+      expect((dryRun.content as { type: string; text: string }[])[0].text).toContain('Dry run');
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('deletes only after explicit confirmation', async () => {
+      mockFetch({});
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_delete_article',
+        arguments: { articleNumber: 'A-1', confirm: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[1].method).toBe('DELETE');
+    });
+  });
 });

--- a/tests/tools/bookkeeping.test.ts
+++ b/tests/tools/bookkeeping.test.ts
@@ -416,6 +416,81 @@ describe('bookkeeping tools', () => {
       expect(parsed.Accounts).toHaveLength(2);
     });
 
+    it('gets a single account', async () => {
+      mockFetch({ Account: { Number: 1930, Description: 'Företagskonto' } });
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_get_account',
+        arguments: { number: 1930 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect((result.content as { type: string; text: string }[])[0].text).toContain(
+        'Företagskonto',
+      );
+    });
+
+    it('creates, updates, and deletes only with confirmation', async () => {
+      mockFetch({ Account: { Number: 2999, Description: 'Avräkning' } });
+      const { client } = await setupClientServer();
+
+      for (const request of [
+        { name: 'fortnox_create_account', arguments: { Number: 2999, Description: 'Avräkning' } },
+        { name: 'fortnox_update_account', arguments: { number: 2999, Description: 'Avräkning' } },
+        { name: 'fortnox_delete_account', arguments: { number: 2999 } },
+      ]) {
+        const result = await client.callTool(request);
+        expect(result.isError).toBe(true);
+      }
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('supports dry-run previews for every account mutation', async () => {
+      mockFetch({});
+      const { client } = await setupClientServer();
+
+      for (const request of [
+        {
+          name: 'fortnox_create_account',
+          arguments: { Number: 2999, Description: 'Avräkning', dryRun: true },
+        },
+        {
+          name: 'fortnox_update_account',
+          arguments: { number: 2999, Description: 'Avräkning', dryRun: true },
+        },
+        { name: 'fortnox_delete_account', arguments: { number: 2999, dryRun: true } },
+      ]) {
+        const result = await client.callTool(request);
+        expect((result.content as { type: string; text: string }[])[0].text).toContain('Dry run');
+      }
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('forwards the complete structured account payload', async () => {
+      mockFetch({ Account: { Number: 2999, Description: 'Avräkning' } });
+      const { client } = await setupClientServer();
+      const payload = {
+        Number: 2999,
+        Description: 'Avräkning',
+        Active: true,
+        CostCenterSettings: 'ALLOWED',
+        ProjectSettings: 'MANDATORY',
+        TransactionInformationSettings: 'NOTALLOWED',
+        VATCode: 'MP1',
+        OpeningQuantities: [{ Project: 'P1', Balance: 5 }],
+        confirm: true,
+      };
+
+      await client.callTool({ name: 'fortnox_create_account', arguments: payload });
+
+      const sent = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+      ).Account;
+      expect(sent.OpeningQuantities).toEqual([{ Project: 'P1', Balance: 5 }]);
+      expect(sent.ProjectSettings).toBe('MANDATORY');
+    });
+
     it('requires confirmation before creating a voucher', async () => {
       mockFetch({ Voucher: { VoucherNumber: 1, VoucherSeries: 'A' } });
 

--- a/tests/tools/customers.test.ts
+++ b/tests/tools/customers.test.ts
@@ -198,6 +198,40 @@ describe('customer tools', () => {
     });
   });
 
+  describe('fortnox_delete_customer', () => {
+    it('requires confirmation and supports dry run', async () => {
+      mockFetch({});
+      const { client } = await setupClientServer();
+
+      const unconfirmed = await client.callTool({
+        name: 'fortnox_delete_customer',
+        arguments: { customerNumber: '42' },
+      });
+      const dryRun = await client.callTool({
+        name: 'fortnox_delete_customer',
+        arguments: { customerNumber: '42', dryRun: true },
+      });
+
+      expect(unconfirmed.isError).toBe(true);
+      expect((dryRun.content as { type: string; text: string }[])[0].text).toContain('Dry run');
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('deletes only after explicit confirmation', async () => {
+      mockFetch({});
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_delete_customer',
+        arguments: { customerNumber: '42', confirm: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[1].method).toBe('DELETE');
+    });
+  });
+
   // Same class of bug as #96 (Supplier field gap): the MCP SDK silently strips
   // any argument the Zod schema does not declare, so an undeclared field
   // reaches neither Fortnox nor an error message — it just vanishes. Type and

--- a/tests/tools/customers.test.ts
+++ b/tests/tools/customers.test.ts
@@ -138,7 +138,7 @@ describe('customer tools', () => {
           Name: 'Full Example AB',
           OrganisationNumber: '556677-8899',
           Email: 'info@full-example.example',
-          Phone: '08-123456',
+          Phone1: '08-123456',
           Address1: 'Exempelgatan 1',
           ZipCode: '11122',
           City: 'Uppsala',
@@ -150,6 +150,7 @@ describe('customer tools', () => {
       const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
       expect(body.Customer.OrganisationNumber).toBe('556677-8899');
       expect(body.Customer.City).toBe('Uppsala');
+      expect(body.Customer.Phone1).toBe('08-123456');
     });
   });
 
@@ -194,6 +195,130 @@ describe('customer tools', () => {
 
       expect(result.isError).toBe(true);
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  // Same class of bug as #96 (Supplier field gap): the MCP SDK silently strips
+  // any argument the Zod schema does not declare, so an undeclared field
+  // reaches neither Fortnox nor an error message — it just vanishes. Type and
+  // Phone1/Phone2 were missing entirely, and Phone was declared under a name
+  // Fortnox's Customer resource doesn't have (only Phone1/Phone2 exist).
+  describe('customer write schemas cover the real Customer resource', () => {
+    const extendedFields = {
+      Type: 'PRIVATE',
+      Phone1: '08-123456',
+      Phone2: '070-1234567',
+      Fax: '08-654321',
+      WWW: 'https://example.test',
+      Address2: 'Plan 4',
+      CountryCode: 'SE',
+      DeliveryName: 'Lagret',
+      DeliveryAddress1: 'Lagergatan 1',
+      DeliveryZipCode: '11133',
+      DeliveryCity: 'Uppsala',
+      DeliveryCountryCode: 'SE',
+      VisitingAddress: 'Besöksgatan 2',
+      VisitingZipCode: '11144',
+      VisitingCity: 'Uppsala',
+      VisitingCountryCode: 'SE',
+      GLN: '1234567890123',
+      ExternalReference: 'ext-42',
+      OurReference: 'Anna Andersson',
+      YourReference: 'Erik Eriksson',
+      Comments: 'VIP customer',
+      Currency: 'SEK',
+      CostCenter: 'CC1',
+      Project: '12',
+      PriceList: 'A',
+      TermsOfDelivery: 'EXW',
+      TermsOfPayment: '30',
+      VATNumber: 'SE556677889901',
+      VATType: 'SEVAT',
+      SalesAccount: '3001',
+      InvoiceRemark: 'Handle with care',
+      ShowPriceVATIncluded: false,
+      EmailInvoice: 'invoices@example.test',
+      Active: true,
+    };
+
+    // The claim is full coverage of the Customer resource, so assert the
+    // schema's property list itself — sending a subset of values cannot
+    // detect a field quietly dropped from the schema.
+    const writableCustomerFields = Object.keys(extendedFields);
+
+    it('declares every writable Customer field on create', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_create_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      for (const field of writableCustomerFields) {
+        expect(declared).toContain(field);
+      }
+    });
+
+    it('declares every writable Customer field on update', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_update_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      for (const field of writableCustomerFields) {
+        expect(declared).toContain(field);
+      }
+    });
+
+    // Regression guard: Country/DeliveryCountry/VisitingCountry are genuinely
+    // read-only on this resource (Fortnox rejects them with "Fältet Country är
+    // endast läsbart") — they must stay off the writable schema, not just be
+    // silently stripped a second time at the operations layer.
+    it('does not declare the read-only *Country fields', async () => {
+      const { client } = await setupClientServer();
+      const { tools } = await client.listTools();
+      const schema = tools.find((t) => t.name === 'fortnox_update_customer')!.inputSchema;
+      const declared = Object.keys(schema.properties as Record<string, unknown>);
+      expect(declared).not.toContain('Country');
+      expect(declared).not.toContain('DeliveryCountry');
+      expect(declared).not.toContain('VisitingCountry');
+    });
+
+    it('forwards extended fields on create', async () => {
+      mockFetch({ Customer: { CustomerNumber: '3' } });
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_create_customer',
+        arguments: { Name: 'New Customer', confirm: true, ...extendedFields },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const sent = JSON.parse(fetchCall[1].body as string).Customer;
+      for (const [key, value] of Object.entries(extendedFields)) {
+        expect(sent[key]).toEqual(value);
+      }
+    });
+
+    it('forwards extended fields on update', async () => {
+      mockFetch({ Customer: { CustomerNumber: '3' } });
+      const { client } = await setupClientServer();
+      await client.callTool({
+        name: 'fortnox_update_customer',
+        arguments: { customerNumber: '3', confirm: true, ...extendedFields },
+      });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const sent = JSON.parse(fetchCall[1].body as string).Customer;
+      for (const [key, value] of Object.entries(extendedFields)) {
+        expect(sent[key]).toEqual(value);
+      }
+      expect(sent.customerNumber).toBeUndefined();
+    });
+
+    it('rejects an invalid Type value', async () => {
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_customer',
+        arguments: { Name: 'Bad Type', Type: 'INDIVIDUAL', confirm: true },
+      });
+
+      expect(result.isError).toBe(true);
     });
   });
 });

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { readFileSync } from 'node:fs';
 import { createServer } from '../../src/index.js';
+import { privateOutputPath } from '../../src/safe-file-output.js';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
@@ -83,5 +85,27 @@ describe('archive, inbox, and attachment tools', () => {
       expect((result.content as { text: string }[])[0]?.text, name).toContain('Dry run');
     }
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('downloads archive responses as binary data to an exclusive destination', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(Buffer.from('archive-bytes'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      }),
+    );
+    const { client } = await setup();
+    const outputPath = privateOutputPath('noxctl-test-', 'archive.bin');
+    const result = await client.callTool({
+      name: 'fortnox_get_archive_entry',
+      arguments: { id: 'a/b', path: 'docs', fileId: 'nested', outputPath },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(readFileSync(outputPath).toString()).toBe('archive-bytes');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/3/archive/a%2Fb?path=docs&fileid=nested'),
+      expect.objectContaining({ method: 'GET' }),
+    );
   });
 });

--- a/tests/tools/files.test.ts
+++ b/tests/tools/files.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../src/index.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+async function setup() {
+  const server = createServer();
+  const client = new Client({ name: 'file-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { server, client };
+}
+
+const mutations = [
+  ['fortnox_upload_archive_file', { filePath: '/not/read.pdf', dryRun: true }],
+  ['fortnox_delete_archive_path', { path: 'old', dryRun: true }],
+  ['fortnox_delete_archive_entry', { id: 'a1', dryRun: true }],
+  ['fortnox_upload_inbox_file', { filePath: '/not/read.pdf', dryRun: true }],
+  ['fortnox_delete_inbox_entry', { id: 'a1', dryRun: true }],
+  ['fortnox_delete_voucher_file_connection', { fileId: 'f1', dryRun: true }],
+  [
+    'fortnox_create_supplier_invoice_file_connection',
+    { givenNumber: '7', fileId: 'f1', dryRun: true },
+  ],
+  ['fortnox_delete_supplier_invoice_file_connection', { fileId: 'f1', dryRun: true }],
+  [
+    'fortnox_create_document_attachment',
+    {
+      documentNumber: '7',
+      entityType: 'O',
+      fileId: 'f1',
+      includeOnSend: true,
+      dryRun: true,
+    },
+  ],
+  [
+    'fortnox_validate_attachments_on_send',
+    { attachments: [{ entityId: 7, entityType: 'F', fileId: 'f1' }], dryRun: true },
+  ],
+  [
+    'fortnox_update_document_attachment',
+    {
+      attachmentId: '11111111-1111-4111-8111-111111111111',
+      includeOnSend: false,
+      dryRun: true,
+    },
+  ],
+  [
+    'fortnox_detach_document_attachment',
+    { attachmentId: '11111111-1111-4111-8111-111111111111', dryRun: true },
+  ],
+] as const;
+
+describe('archive, inbox, and attachment tools', () => {
+  it('discovers the selected complete file surface', async () => {
+    const { client } = await setup();
+    const names = (await client.listTools()).tools.map(({ name }) => name);
+    for (const name of [
+      'fortnox_list_archive',
+      'fortnox_get_archive_entry',
+      'fortnox_list_inbox',
+      'fortnox_get_inbox_file',
+      'fortnox_get_voucher_file_connection',
+      'fortnox_get_supplier_invoice_file_connection',
+      'fortnox_list_document_attachments',
+      'fortnox_get_attachment_counts',
+      ...mutations.map(([name]) => name),
+    ])
+      expect(names).toContain(name);
+  });
+
+  it('previews every file mutation without reading paths or calling Fortnox', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setup();
+    for (const [name, arguments_] of mutations) {
+      const result = await client.callTool({ name, arguments: arguments_ });
+      expect(result.isError, name).toBeFalsy();
+      expect((result.content as { text: string }[])[0]?.text, name).toContain('Dry run');
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/operation-parity.test.ts
+++ b/tests/tools/operation-parity.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../src/index.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'parity-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+const dryRuns = [
+  ['fortnox_update_absencetransaction', { id: '1', Hours: 4, dryRun: true }],
+  ['fortnox_update_attendancetransaction', { id: '1', Hours: '8', dryRun: true }],
+  ['fortnox_update_salarytransaction', { salaryRow: '1', Amount: '10', dryRun: true }],
+  ['fortnox_update_invoice_payment', { paymentNumber: '1', Amount: 10, dryRun: true }],
+  ['fortnox_bookkeep_invoice_payment', { paymentNumber: '1', dryRun: true }],
+  ['fortnox_update_supplier_invoice_payment', { paymentNumber: '1', Amount: 10, dryRun: true }],
+  ['fortnox_bookkeep_supplier_invoice_payment', { paymentNumber: '1', dryRun: true }],
+  ['fortnox_update_taxreduction', { id: 1, AskedAmount: 10, dryRun: true }],
+  ['fortnox_delete_taxreduction', { id: 1, dryRun: true }],
+  ['fortnox_delete_project', { projectNumber: '1', dryRun: true }],
+  ['fortnox_create_financialyear', { FromDate: '2026-01-01', ToDate: '2026-12-31', dryRun: true }],
+  ['fortnox_update_supplier_invoice', { givenNumber: '1', Comments: 'ok', dryRun: true }],
+  ['fortnox_approval_bookkeep_supplier_invoice', { givenNumber: '1', dryRun: true }],
+  ['fortnox_approval_payment_supplier_invoice', { givenNumber: '1', dryRun: true }],
+  ['fortnox_cancel_supplier_invoice', { givenNumber: '1', dryRun: true }],
+  ['fortnox_credit_supplier_invoice', { givenNumber: '1', dryRun: true }],
+  ['fortnox_cancel_invoice', { documentNumber: '1', dryRun: true }],
+  ['fortnox_eprint_invoice', { documentNumber: '1', dryRun: true }],
+  ['fortnox_external_print_invoice', { documentNumber: '1', dryRun: true }],
+  ['fortnox_invoice_reminder_pdf', { documentNumber: '1', dryRun: true }],
+  ['fortnox_cancel_offer', { documentNumber: '1', dryRun: true }],
+  ['fortnox_email_offer', { documentNumber: '1', dryRun: true }],
+  ['fortnox_external_print_offer', { documentNumber: '1', dryRun: true }],
+  ['fortnox_offer_pdf', { documentNumber: '1', dryRun: true }],
+  ['fortnox_cancel_order', { documentNumber: '1', dryRun: true }],
+  ['fortnox_email_order', { documentNumber: '1', dryRun: true }],
+  ['fortnox_external_print_order', { documentNumber: '1', dryRun: true }],
+  ['fortnox_order_pdf', { documentNumber: '1', dryRun: true }],
+  ['fortnox_create_price', { PriceList: 'A', ArticleNumber: '1', Price: 10, dryRun: true }],
+  [
+    'fortnox_delete_price',
+    { priceListCode: 'A', articleNumber: '1', fromQuantity: 0, dryRun: true },
+  ],
+] as const;
+
+describe('MCP operation parity', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('discovers every newly completed existing-family operation', async () => {
+    const { client } = await setupClientServer();
+    const names = (await client.listTools()).tools.map(({ name }) => name);
+    for (const [name] of dryRuns) expect(names).toContain(name);
+  });
+
+  it('requires no network access for exact dry-run previews', async () => {
+    global.fetch = vi.fn();
+    const { client } = await setupClientServer();
+    for (const [name, args] of dryRuns) {
+      const result = await client.callTool({ name, arguments: args });
+      expect(result.isError, name).toBeFalsy();
+      expect((result.content as { type: string; text: string }[])[0]?.text, name).toContain(
+        'Dry run',
+      );
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/pricelists.test.ts
+++ b/tests/tools/pricelists.test.ts
@@ -172,7 +172,7 @@ describe('price tools', () => {
       });
 
       const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(fetchCall[0]).toContain('prices/A/ART1/0');
+      expect(fetchCall[0]).toMatch(/prices\/A\/ART1$/);
       expect(fetchCall[1].method).toBe('PUT');
     });
 

--- a/tests/tools/recurrings.test.ts
+++ b/tests/tools/recurrings.test.ts
@@ -55,4 +55,61 @@ describe('recurring tools', () => {
 
     expect(result.isError).toBe(true);
   });
+
+  it('preserves provider-defined create payloads end to end', async () => {
+    mockFetch({ id: 'id-1', status: 'ACTIVE' });
+    const input = {
+      customer: { customer_number: '17', provider_extension: { mode: 'exact' } },
+      rows: [{ article_number: 'A1', custom_value: 0 }],
+    };
+    const result = await (
+      await client()
+    ).callTool({
+      name: 'fortnox_create_recurring',
+      arguments: { input, confirm: true },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      body?: string;
+    };
+    expect(JSON.parse(init.body ?? 'null')).toEqual(input);
+  });
+
+  it('preserves provider-defined replacement payloads end to end', async () => {
+    mockFetch({ id: '550e8400-e29b-41d4-a716-446655440000', status: 'ACTIVE' });
+    const input = { status: 'ACTIVE', provider_extension: { retain: false } };
+    const result = await (
+      await client()
+    ).callTool({
+      name: 'fortnox_replace_recurring',
+      arguments: {
+        recurringId: '550e8400-e29b-41d4-a716-446655440000',
+        etag: '"v1"',
+        input,
+        confirm: true,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      body?: string;
+    };
+    expect(JSON.parse(init.body ?? 'null')).toEqual(input);
+  });
+
+  it('rejects unknown fields in structured JSON Patch operations', async () => {
+    const result = await (
+      await client()
+    ).callTool({
+      name: 'fortnox_patch_recurring',
+      arguments: {
+        recurringId: '550e8400-e29b-41d4-a716-446655440000',
+        etag: '"v1"',
+        operations: [{ op: 'replace', path: '/status', value: 'ACTIVE', unexpected: true }],
+        dryRun: true,
+      },
+    });
+    expect(result.isError).toBe(true);
+  });
 });

--- a/tests/tools/reference-data.test.ts
+++ b/tests/tools/reference-data.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../src/index.js';
+import { REFERENCE_TOOL_DEFINITIONS } from '../../src/tools/reference-data.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+  getResolvedProfile: vi.fn().mockReturnValue('default'),
+}));
+
+async function setup() {
+  const server = createServer();
+  const client = new Client({ name: 'reference-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { server, client };
+}
+
+describe('reference data tools', () => {
+  it('discovers explicit list/get tools for every selected resource', async () => {
+    const { client } = await setup();
+    const names = (await client.listTools()).tools.map(({ name }) => name);
+    for (const definition of REFERENCE_TOOL_DEFINITIONS) {
+      expect(names).toContain(`fortnox_list_${definition.id}`);
+      if (definition.getId) expect(names).toContain(`fortnox_get_${definition.getId}`);
+    }
+  });
+
+  it('returns stable list and detail output', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(JSON.stringify({ Currencies: [{ Code: 'SEK', Description: 'Krona' }] })),
+    });
+    const { client } = await setup();
+    const listed = await client.callTool({ name: 'fortnox_list_currencies', arguments: {} });
+    expect((listed.content as { text: string }[])[0]?.text).toContain('SEK');
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(JSON.stringify({ Currency: { Code: 'SEK', Description: 'Krona' } })),
+    });
+    const detail = await client.callTool({
+      name: 'fortnox_get_currency',
+      arguments: { code: 'SEK' },
+    });
+    expect((detail.content as { text: string }[])[0]?.text).toContain('Krona');
+  });
+});

--- a/tests/tools/supplier-invoices.test.ts
+++ b/tests/tools/supplier-invoices.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { createServer } from '../../src/index.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -13,6 +15,16 @@ function mockFetch(response: unknown, ok = true, status = 200) {
     status,
     text: () => Promise.resolve(JSON.stringify(response)),
     json: () => Promise.resolve(response),
+  });
+}
+
+function mockBinaryFetch(bytes: Buffer, contentType: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': contentType }),
+    arrayBuffer: () =>
+      Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
   });
 }
 
@@ -245,6 +257,97 @@ describe('supplier invoice tools', () => {
 
       expect(result.isError).toBe(true);
       expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('fortnox_list_supplier_invoice_attachments', () => {
+    it('lists attached files for a supplier invoice, even an unbooked one', async () => {
+      mockFetch({
+        SupplierInvoiceFileConnections: [
+          { FileId: 'f1', Name: 'invoice-scan.pdf', SupplierInvoiceNumber: '1' },
+        ],
+      });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_supplier_invoice_attachments',
+        arguments: { givenNumber: '1' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('invoice-scan.pdf');
+      expect(text).toContain('f1');
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('supplierinvoicenumber=1');
+    });
+
+    it('is read-only — no confirmation required', async () => {
+      mockFetch({ SupplierInvoiceFileConnections: [] });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_list_supplier_invoice_attachments',
+        arguments: { givenNumber: '1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('fortnox_get_supplier_invoice_file', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('downloads the file and saves it to a temp path, returning that path', async () => {
+      const bytes = Buffer.from('%PDF-1.4 fake supplier invoice scan');
+      mockBinaryFetch(bytes, 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      const match = text.match(/till (.+supplier-invoice-file-f1\.pdf)/);
+      expect(match).not.toBeNull();
+      const savedPath = match![1]!;
+      expect(readFileSync(savedPath).equals(bytes)).toBe(true);
+      rmSync(savedPath, { force: true });
+    });
+
+    it('writes to an explicit outputPath when given', async () => {
+      const bytes = Buffer.from('image-bytes');
+      mockBinaryFetch(bytes, 'image/jpeg');
+      const target = `${tmpdir()}/noxctl-test-supplier-invoice-file.jpg`;
+      rmSync(target, { force: true });
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f2', outputPath: target },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(readFileSync(target).equals(bytes)).toBe(true);
+      rmSync(target, { force: true });
+    });
+
+    it('refuses to overwrite an existing file without overwrite: true', async () => {
+      const target = `${tmpdir()}/noxctl-test-supplier-invoice-file-exists.pdf`;
+      writeFileSync(target, 'already here');
+      mockBinaryFetch(Buffer.from('new-bytes'), 'application/pdf');
+
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_get_supplier_invoice_file',
+        arguments: { fileId: 'f3', outputPath: target },
+      });
+
+      expect(result.isError).toBe(true);
+      rmSync(target, { force: true });
     });
   });
 });


### PR DESCRIPTION
## Summary

Complete the deliberately scoped open-source Fortnox core API surface for v1.0.

- classify every current public API family and operation in a privacy-safe manifest
- audit every discovered structured MCP mutation or document its explicit exception
- close operation gaps in existing supported families
- add core reference/setup reads and native invoice, supplier-invoice, and contract accrual lifecycles
- complete the selected archive, inbox, file-connection, and document-attachment surface
- preserve CLI/MCP parity, strict inputs, confirmation, dry-run, retry, and binary-output safeguards

This is intentionally not a claim that every Fortnox product domain is supported. The reviewed core contract implements 212 operations and explicitly excludes 193 operations across out-of-scope domains, with no unexplained operation gaps.

## Coverage and privacy

- 87 API families classified as `complete`, `partial`, `excluded`, or `blocked`
- 405 public operations accounted for
- 47 selected families complete, 40 families explicitly excluded
- 61 structured mutation mappings plus 51 reviewed action/binary/passthrough exceptions
- normal CI output and committed state contain curated IDs, counts, classifications, rationales, and domain-separated opaque hashes only
- exact OpenAPI paths, operation IDs, schemas, and field diagnostics remain local and opt-in

The schema audit currently reports known tracked contract differences rather than pretending that every Fortnox request schema is identical to noxctl's reviewed safe input contract. This change makes those differences deterministic and regression-visible.

## Safety

- all newly exposed mutations retain confirmation and dry-run behavior
- consequential GET-style actions are marked as mutations and are not automatically retried
- downloads use exclusive mode-0600 writes, private temporary defaults, explicit overwrite controls, and symlink refusal
- archive/inbox downloads validate Fortnox error envelopes before saving arbitrary binary bytes
- URL-connection surfaces remain excluded to avoid creating an arbitrary remote-fetch boundary

## Review findings addressed

The final conductor review corrected archive binary responses and prevented untrusted default names from escaping their private temporary directory.

An independent M5 review used `qwen3-coder-next-80b` for the main passes and `qwen3-30b-instruct` for the final bounded checks. It was partially useful: most suggestions were rejected against the client architecture or current OpenAPI, while two grounded defects were fixed and regression-tested. Invoice and supplier-invoice accruals now accept Fortnox's extended `1_MONTHS` through `12_MONTHS` period values without widening the separate contract-accrual enum, and the exported attachment operation rejects non-numeric or unsafe document identifiers before making a request.

## Verification

- `npm run check:release`
- 92 Vitest files / 1,052 tests
- TypeScript build, ESLint, and Prettier
- online and offline API implementation coverage audit
- recursive mutation-schema audit
- zero production dependency vulnerabilities
- packed embedded-consumer check
- npm package dry run

No live Fortnox mutations were performed.

Closes #150
Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
