### PR TITLE
fix: close customer schema and attachment download gaps

### DIFF
--- a/api-spec/tool-schema-coverage.json
+++ b/api-spec/tool-schema-coverage.json
@@ -269,41 +269,41 @@
     },
     {
       "id": "customer",
-      "declaredPropertyCount": 60,
+      "declaredPropertyCount": 63,
       "specificationPropertyCount": 63,
-      "missingPropertyCount": 6,
-      "checkedNodeCount": 58,
+      "missingPropertyCount": 3,
+      "checkedNodeCount": 68,
       "issuesByDimension": {
-        "field": 6,
+        "field": 3,
         "nesting": 0,
         "requiredness": 0,
         "type": 0,
         "enum": 0,
         "nullability": 0,
-        "constraint": 52,
+        "constraint": 54,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "4129eb4086e36fef65d42af2c4d90c775bd80c0b075b4f934fd9115a8140f544"
+      "stateHash": "caee6e1297ba1645bb8d885e10de6a3ece638473da476bfa9a31ee6916ca4cac"
     },
     {
       "id": "customer-update",
-      "declaredPropertyCount": 61,
+      "declaredPropertyCount": 64,
       "specificationPropertyCount": 63,
-      "missingPropertyCount": 6,
-      "checkedNodeCount": 58,
+      "missingPropertyCount": 3,
+      "checkedNodeCount": 68,
       "issuesByDimension": {
-        "field": 6,
+        "field": 3,
         "nesting": 0,
         "requiredness": 1,
         "type": 0,
         "enum": 0,
         "nullability": 0,
-        "constraint": 52,
+        "constraint": 54,
         "strictness": 0
       },
       "resultClass": "tracked-gap",
-      "stateHash": "0f29f53c8198e03fe7c8dfc3978e7d93d418e10a5a602827c0faab788a0ef661"
+      "stateHash": "9e749b9f1d8e5f9565615319b1f94f8b875308ba1017835878ecd4e246f3bcab"
     },
     {
       "id": "document-attachment-create",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2450,6 +2450,7 @@ supplierInvoices
     '-f, --file <path>',
     'Write the file here (- for stdout; default: supplier-invoice-file-<fileId><ext>)',
   )
+  .option('--overwrite', 'Allow replacing an existing regular file')
   .addHelpText(
     'after',
     `
@@ -2458,9 +2459,10 @@ Examples:
   noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63
   noxctl supplier-invoices file c7e578d8-59a7-4e00-b29b-b99e4d9ede63 --file invoice-scan.pdf`,
   )
-  .action(async (fileId: string, opts: { file?: string }) => {
+  .action(async (fileId: string, opts: { file?: string; overwrite?: boolean }) => {
     const { getSupplierInvoiceFile } = await import('./operations/supplier-invoices.js');
     const { extensionForMime } = await import('./operations/vouchers.js');
+    const { safeLocalOutputPath, writeBinaryFile } = await import('./safe-file-output.js');
     const toStdout = opts.file === '-';
 
     if (toStdout && program.opts().output === 'json') {
@@ -2479,14 +2481,15 @@ Examples:
     }
 
     const path =
-      opts.file ?? `supplier-invoice-file-${fileId}${extensionForMime(file.contentType)}`;
-    writeFileSync(path, file.buffer);
+      opts.file ??
+      safeLocalOutputPath('supplier-invoice-file-', fileId, extensionForMime(file.contentType));
+    const savedPath = writeBinaryFile(path, file.buffer, opts.overwrite);
     outputConfirmation(
-      `File saved to ${path} (${file.contentType}, ${file.buffer.length} bytes).`,
+      `File saved to ${savedPath} (${file.contentType}, ${file.buffer.length} bytes).`,
       json(),
       {
         FileId: fileId,
-        Path: path,
+        Path: savedPath,
         ContentType: file.contentType,
         Bytes: file.buffer.length,
       },

--- a/src/safe-file-output.ts
+++ b/src/safe-file-output.ts
@@ -16,6 +16,12 @@ export function privateOutputPath(prefix: string, fileName: string): string {
   return join(directory, safeName);
 }
 
+export function safeLocalOutputPath(prefix: string, fileName: string, extension = ''): string {
+  const candidate = basename(fileName);
+  const safeName = !candidate || candidate === '.' || candidate === '..' ? 'download' : candidate;
+  return resolve(`${prefix}${safeName}${extension}`);
+}
+
 export function writeBinaryFile(targetPath: string, data: Buffer, overwrite = false): string {
   const target = resolve(targetPath);
   const { O_WRONLY, O_CREAT, O_TRUNC, O_EXCL, O_NOFOLLOW } = fsConstants;

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -14,6 +14,8 @@ const CustomerNumberSchema = z
   .string()
   .regex(/^[A-Za-z0-9][A-Za-z0-9_-]{0,49}$/, 'Customer number must be alphanumeric');
 
+const CustomerDeliveryTypeSchema = z.enum(['PRINT', 'EMAIL', 'PRINTSERVICE']);
+
 // The full writable Customer field set (Fortnox `CustomerSinglePayloadItem`).
 // The MCP SDK silently strips any argument the schema does not declare, so a
 // field missing here never reaches Fortnox and never raises an error — it just
@@ -28,8 +30,26 @@ const CustomerNumberSchema = z
 // into create/update still works, but the tool schema should not offer a
 // field that would then be silently dropped a second time.
 const customerWritableFields = {
+  CustomerNumber: CustomerNumberSchema.optional().describe('Kundnummer'),
   Name: z.string().optional().describe('Kundnamn'),
   Type: z.enum(['PRIVATE', 'COMPANY']).optional().describe('Kundtyp: privatperson eller företag'),
+  DefaultDeliveryTypes: z
+    .strictObject({
+      Invoice: CustomerDeliveryTypeSchema.optional().describe('Leveranssätt för fakturor'),
+      Offer: CustomerDeliveryTypeSchema.optional().describe('Leveranssätt för offerter'),
+      Order: CustomerDeliveryTypeSchema.optional().describe('Leveranssätt för ordrar'),
+    })
+    .optional()
+    .describe('Förvalda leveranssätt för fakturor, offerter och ordrar'),
+  DefaultTemplates: z
+    .strictObject({
+      CashInvoice: z.string().optional().describe('Mall för kontantfakturor'),
+      Invoice: z.string().optional().describe('Mall för fakturor'),
+      Offer: z.string().optional().describe('Mall för offerter'),
+      Order: z.string().optional().describe('Mall för ordrar'),
+    })
+    .optional()
+    .describe('Förvalda dokumentmallar'),
   OrganisationNumber: z.string().optional().describe('Organisations- eller personnummer'),
   Email: z.string().optional().describe('E-postadress'),
   Phone1: z.string().optional().describe('Telefonnummer'),

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -271,6 +271,16 @@ describe('CLI smoke tests', () => {
     expect(output).toContain('bookkeep');
   });
 
+  it('noxctl supplier-invoices file --help requires explicit overwrite opt-in', () => {
+    const output = execFileSync(
+      'node',
+      [CLI_PATH, 'supplier-invoices', 'file', '--help'],
+      execOpts,
+    ) as string;
+    expect(output).toContain('--file');
+    expect(output).toContain('--overwrite');
+  });
+
   it('noxctl articles --help shows subcommands', () => {
     const output = execFileSync('node', [CLI_PATH, 'articles', '--help'], execOpts) as string;
     expect(output).toContain('list');

--- a/tests/safe-file-output.test.ts
+++ b/tests/safe-file-output.test.ts
@@ -1,7 +1,11 @@
 import { lstatSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { privateOutputPath, writeBinaryFile } from '../src/safe-file-output.js';
+import {
+  privateOutputPath,
+  safeLocalOutputPath,
+  writeBinaryFile,
+} from '../src/safe-file-output.js';
 
 describe('safe binary file output', () => {
   it('creates private temporary destinations and exact bytes', () => {
@@ -17,6 +21,12 @@ describe('safe binary file output', () => {
     const path = privateOutputPath('noxctl-test-', 'archive-x/../../../../outside.bin');
     expect(basename(path)).toBe('outside.bin');
     expect(basename(dirname(path))).toMatch(/^noxctl-test-/);
+  });
+
+  it('keeps untrusted local download names inside the working directory', () => {
+    const path = safeLocalOutputPath('supplier-invoice-file-', '../../nested/scan', '.pdf');
+    expect(dirname(path)).toBe(process.cwd());
+    expect(basename(path)).toBe('supplier-invoice-file-scan.pdf');
   });
 
   it('refuses overwrite unless explicitly allowed', () => {

--- a/tests/tools/customers.test.ts
+++ b/tests/tools/customers.test.ts
@@ -239,6 +239,7 @@ describe('customer tools', () => {
   // Fortnox's Customer resource doesn't have (only Phone1/Phone2 exist).
   describe('customer write schemas cover the real Customer resource', () => {
     const extendedFields = {
+      CustomerNumber: 'CUSTOM-3',
       Type: 'PRIVATE',
       Phone1: '08-123456',
       Phone2: '070-1234567',
@@ -272,6 +273,17 @@ describe('customer tools', () => {
       InvoiceRemark: 'Handle with care',
       ShowPriceVATIncluded: false,
       EmailInvoice: 'invoices@example.test',
+      DefaultDeliveryTypes: {
+        Invoice: 'EMAIL',
+        Offer: 'PRINT',
+        Order: 'PRINTSERVICE',
+      },
+      DefaultTemplates: {
+        CashInvoice: 'CASH-TEMPLATE',
+        Invoice: 'INVOICE-TEMPLATE',
+        Offer: 'OFFER-TEMPLATE',
+        Order: 'ORDER-TEMPLATE',
+      },
       Active: true,
     };
 
@@ -353,6 +365,38 @@ describe('customer tools', () => {
       });
 
       expect(result.isError).toBe(true);
+    });
+
+    it('rejects unsupported nested delivery defaults', async () => {
+      global.fetch = vi.fn();
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_create_customer',
+        arguments: {
+          Name: 'Bad Delivery Default',
+          DefaultDeliveryTypes: { Invoice: 'SMS' },
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown nested customer-default fields', async () => {
+      global.fetch = vi.fn();
+      const { client } = await setupClientServer();
+      const result = await client.callTool({
+        name: 'fortnox_update_customer',
+        arguments: {
+          customerNumber: '3',
+          DefaultTemplates: { Invoice: 'INVOICE-TEMPLATE', Unknown: 'TYPO' },
+          confirm: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- expose `CustomerNumber`, `DefaultDeliveryTypes`, and `DefaultTemplates` on both customer create/update MCP schemas
- validate nested delivery defaults strictly against Fortnox's supported delivery methods
- make supplier-invoice attachment downloads refuse overwrite by default, reject destination symlinks, use private file modes, and sanitize the default local filename
- add explicit CLI `--overwrite` opt-in and regression coverage
- update the opaque schema-audit baseline for the three newly covered customer fields

This is a focused follow-up to #157 for the two integration gaps identified while reviewing #148 and #149. The deliberately read-only customer fields `Country`, `DeliveryCountry`, and `VisitingCountry` remain excluded.

## Verification

- `npm run check:release` (all deterministic stages passed; the network audit was rerun separately after the sandbox DNS boundary)
- 92 test files / 1,056 tests passed
- offline API coverage: 405 public operations, 0 missing
- schema audit passed; customer create/update missing-field count reduced from 6 to the 3 intentional read-only exclusions
- `npm audit --omit=dev`: 0 vulnerabilities
- embedded consumer check and package dry-run passed
- independent M5 review with `gpt-oss-120b`: no findings

## M5 implementation note

The isolated customer-schema leaf was attempted with `qwen3-coder-next-80b`. Its core field additions were useful, but strict nested validation and Swedish terminology were corrected on L1 before the final test and review gates.
