### PR TITLE
chore: align Node types with runtime support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     # rest to rebase. Batch the low-risk updates into one PR per week and leave
     # major bumps as individual PRs, since those are the ones worth reviewing
     # one at a time.
+    # Keep Node type definitions aligned with the oldest supported runtime major.
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       dev-minor-and-patch:
         dependency-type: "development"


### PR DESCRIPTION
## Summary

- ignore semver-major Dependabot updates for `@types/node`
- keep minor and patch updates within the current Node types major enabled
- preserve the existing weekly schedule and grouped dev/production updates

## Why

noxctl supports Node `>=22.12.0`, so its Node type definitions should remain aligned with the oldest supported runtime major. Compiling against `@types/node@26` could allow APIs that are unavailable to supported Node 22 users. Major type updates can be reconsidered when the runtime support floor moves.

This is the repository-owned follow-up to the intentionally closed #106.

## Verification

- YAML parsed successfully and the extracted ignore rule matched exactly
- rule shape verified against GitHub's current Dependabot options reference
- independent M5 review with `qwen3-30b-instruct`: no findings
- isolated M5 edit with `qwen3-coder-next-80b`: adopted with a trivial comment wording adjustment
