### PR TITLE
feat: general ledger via SIE export, for fast bulk reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   download them. Unlike voucher attachments, this reaches the original
   document directly, so it works for `unbooked`/`authorizepending` invoices —
   before they've been bookkept into a voucher. No new scope required.
-- **General ledger: bookkeeping transactions with amounts, for a date range,
-  in one fast call.** `noxctl general-ledger list --from <date> --to <date>`
-  and `fortnox_general_ledger` return one row per posting (date, voucher,
-  account, debit, credit, text), optionally filtered by account or voucher
-  series. Unlike `fortnox_list_vouchers` (no amounts) or building an amount
-  by fetching every voucher's rows individually (times out on any real
-  company — #152), this reads Fortnox's SIE4 export: the whole period's
-  transactions in one streamed file instead of one request per voucher.
-  Verified against a company with ~10,900 vouchers/year: full-year export
-  and parse completes in ~2 seconds versus a timeout the old way.
+- **General ledger: bookkeeping transactions with amounts for a date range.**
+  `noxctl general-ledger list --from <date> --to <date>` and
+  `fortnox_general_ledger` return one row per posting (date, voucher, account,
+  debit, credit, text), with optional account and series filters. Reads one
+  SIE4 export for the period, with a financial-year lookup when needed.
+  This avoids individual voucher-detail requests;
+  `fortnox_list_vouchers` does not include transaction amounts.
+  Row dates override voucher dates when present. Escaped quotation marks are
+  decoded, tab separators are accepted, and malformed amounts or amounts that
+  lose cent precision are rejected. Thanks to @hedborg for the implementation
+  (#161).
 
 ## [0.9.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   download them. Unlike voucher attachments, this reaches the original
   document directly, so it works for `unbooked`/`authorizepending` invoices —
   before they've been bookkept into a voucher. No new scope required.
+- **General ledger: bookkeeping transactions with amounts, for a date range,
+  in one fast call.** `noxctl general-ledger list --from <date> --to <date>`
+  and `fortnox_general_ledger` return one row per posting (date, voucher,
+  account, debit, credit, text), optionally filtered by account or voucher
+  series. Unlike `fortnox_list_vouchers` (no amounts) or building an amount
+  by fetching every voucher's rows individually (times out on any real
+  company — #152), this reads Fortnox's SIE4 export: the whole period's
+  transactions in one streamed file instead of one request per voucher.
+  Verified against a company with ~10,900 vouchers/year: full-year export
+  and parse completes in ~2 seconds versus a timeout the old way.
 
 ## [0.9.0] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Every operation is available both as a CLI command and as an MCP tool. The CLI i
 | `noxctl vouchers attach <series> <number> <file...> [--year]` | `fortnox_attach_voucher_files` | Upload receipt/underlag files and link them to a voucher (mutation; needs the Fortnox archive scope) |
 | `noxctl vouchers attachments <series> <number> [--year]` | `fortnox_list_voucher_attachments` | List files (receipts/underlag) already attached to a voucher — read-only, default scopes only |
 | `noxctl vouchers file <fileId> [-f <path>]` | `fortnox_get_voucher_file` | Download a file attached to a voucher (get `fileId` from `vouchers attachments`) — read-only, default scopes only |
+| `noxctl general-ledger list --from <date> --to <date> [--year] [--account] [--series]` / alias `ledger list` | `fortnox_general_ledger` | Bookkeeping transactions with amounts for a date range, one row per posting — reads Fortnox's SIE export instead of walking vouchers one by one, so it stays fast for a full year. Read-only, default scopes only |
 | `noxctl accounts list [--search <term>]` | `fortnox_list_accounts` | View chart of accounts, search by name or number |
 
 ### Financial reports

--- a/TODO.md
+++ b/TODO.md
@@ -65,18 +65,16 @@ families and operations.
     the drift workflow reports a genuinely transactional bank path. See issue #13.
 15. ~~File attachments (underlag) — upload receipts, attach to vouchers~~ ✅ Done (#37) — `noxctl vouchers attach`; live use needs the **archive** scope
 16. Live mutation test coverage — only read paths tested live
-17. Rewire `fortnox_income_statement`/`fortnox_balance_sheet`/`fortnox_tax_report`
-    onto the SIE export (`src/sie.ts`, added for `fortnox_general_ledger`).
-    They still walk every voucher individually to sum debit/credit, which
-    times out on any company with a non-trivial voucher count — the general
-    ledger had the identical problem, fixed by reading Fortnox's SIE4 export
-    instead. Doing the same here would also fix a separate, real bug: these
-    three group accounts by hardcoded number ranges instead of the official
-    Skatteverket SRU codes Fortnox already returns per account (available on
-    `/3/accounts` today, and in the SIE file). `fortnox_income_statement`
-    also has a sign-consistency bug independent of either of the above — its
-    rendered table and its `includeRaw` JSON disagree on the sign of
-    `netResult` for the same figure.
+17. Evaluate moving `fortnox_income_statement` and `fortnox_balance_sheet`
+    onto the SIE export (`src/sie.ts`, added for `fortnox_general_ledger`) to
+    avoid their per-voucher detail requests. `fortnox_tax_report` does not
+    perform that detail walk (see `src/operations/tax.ts`) and needs a separate
+    assessment of whether SIE would help. Keep SRU-based report grouping as a
+    separate design task:
+    mappings can require multiple codes and sign-dependent handling, while
+    the current SIE parser retains only one SRU code per account. Verify the
+    reported `fortnox_income_statement` table/`includeRaw` `netResult` sign
+    discrepancy separately before changing its report contract.
 
 ## Adding a New Resource
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,18 @@ families and operations.
     the drift workflow reports a genuinely transactional bank path. See issue #13.
 15. ~~File attachments (underlag) — upload receipts, attach to vouchers~~ ✅ Done (#37) — `noxctl vouchers attach`; live use needs the **archive** scope
 16. Live mutation test coverage — only read paths tested live
+17. Rewire `fortnox_income_statement`/`fortnox_balance_sheet`/`fortnox_tax_report`
+    onto the SIE export (`src/sie.ts`, added for `fortnox_general_ledger`).
+    They still walk every voucher individually to sum debit/credit, which
+    times out on any company with a non-trivial voucher count — the general
+    ledger had the identical problem, fixed by reading Fortnox's SIE4 export
+    instead. Doing the same here would also fix a separate, real bug: these
+    three group accounts by hardcoded number ranges instead of the official
+    Skatteverket SRU codes Fortnox already returns per account (available on
+    `/3/accounts` today, and in the SIE file). `fortnox_income_statement`
+    also has a sign-consistency bug independent of either of the above — its
+    rendered table and its `includeRaw` JSON disagree on the sign of
+    `netResult` for the same figure.
 
 ## Adding a New Resource
 

--- a/api-spec/api-implementation-coverage.json
+++ b/api-spec/api-implementation-coverage.json
@@ -458,13 +458,13 @@
     },
     {
       "id": "fortnox-sie",
-      "classification": "excluded",
+      "classification": "complete",
       "publicOperationCount": 1,
-      "implementedCount": 0,
+      "implementedCount": 1,
       "missingCount": 0,
-      "excludedCount": 1,
-      "stateHash": "28037f492013b466b28ca882d3ad553ce634561c74bd7b02100753e0ed1af8c1",
-      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+      "excludedCount": 0,
+      "stateHash": "f0f6993f6bf42211f292474f8d3c656077d21cbfc5d5ff0ccb77b0a5376e6eb7",
+      "rationale": "Read-only SIE4 general-ledger export is part of the supported bookkeeping core."
     },
     {
       "id": "fortnox-supplierinvoiceaccruals",

--- a/api-spec/api-implementation-map.json
+++ b/api-spec/api-implementation-map.json
@@ -1227,15 +1227,29 @@
     {
       "id": "fortnox-sie",
       "tagHash": "3d7f1a6cbbc36bcb75e16b950c5907b44392d1aef4b67f44e9203003bd41f3e3",
-      "classification": "excluded",
+      "classification": "complete",
       "operations": {
-        "implemented": [],
-        "missing": [],
-        "excluded": [
+        "implemented": [
           "27f9f290930c9e39895f6788261b48b7157be1b9153fa772175d9624e006ecac"
-        ]
+        ],
+        "missing": [],
+        "excluded": []
       },
-      "rationale": "This product family is explicitly outside the initial open-source core API boundary."
+      "rationale": "Read-only SIE4 general-ledger export is part of the supported bookkeeping core.",
+      "evidence": {
+        "operationExports": [
+          "getGeneralLedger"
+        ],
+        "mcpTools": [
+          "fortnox_general_ledger"
+        ],
+        "cliCommands": [
+          [
+            "general-ledger",
+            "list"
+          ]
+        ]
+      }
     },
     {
       "id": "fortnox-supplierinvoiceaccruals",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,9 +1665,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,9 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
-    "ip-address": "10.3.1"
+    "ip-address": "10.3.1",
+    "qs": "6.16.0"
   }
 }

--- a/src/api-coverage.ts
+++ b/src/api-coverage.ts
@@ -119,6 +119,18 @@ function validateMapping(mapping: ApiCoverageMapping): void {
   ) {
     throw new Error(`${mapping.classification} mapping ${mapping.id} requires a rationale`);
   }
+  if (
+    (mapping.classification === 'excluded' || mapping.classification === 'blocked') &&
+    (mapping.implementedOperationIdentities.length > 0 ||
+      (mapping.evidence &&
+        (mapping.evidence.operationExports.length > 0 ||
+          mapping.evidence.mcpTools.length > 0 ||
+          mapping.evidence.cliCommands.length > 0)))
+  ) {
+    throw new Error(
+      `${mapping.classification} mapping ${mapping.id} cannot have implemented operations or exposure evidence`,
+    );
+  }
 }
 
 function calculateStateHash(mapping: ApiCoverageMapping): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2794,7 +2794,7 @@ generalLedger
   .requiredOption('--to <date>', 'To date (YYYY-MM-DD)')
   .option(
     '--year <number>',
-    'Financial year (optional; Fortnox infers it from the date range otherwise)',
+    'Financial year (optional; resolved automatically from --from otherwise)',
     parseInt,
   )
   .option('--account <number>', 'Filter to one account number')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,7 @@ import {
   absenceTransactionDetailColumns,
   scheduleTimeDetailColumns,
   referenceDataColumns,
+  generalLedgerColumns,
 } from './views.js';
 
 const program = new Command();
@@ -2777,6 +2778,46 @@ supplierInvoices
       detached: true,
     });
   });
+
+// --- general-ledger ---
+const generalLedger = program
+  .command('general-ledger')
+  .alias('ledger')
+  .description(
+    'Bookkeeping transaction list with amounts, via Fortnox’s SIE export — fast even for a full year, unlike walking vouchers one by one',
+  );
+
+generalLedger
+  .command('list')
+  .description('List bookkeeping transactions for a date range, one row per posting')
+  .requiredOption('--from <date>', 'From date (YYYY-MM-DD)')
+  .requiredOption('--to <date>', 'To date (YYYY-MM-DD)')
+  .option(
+    '--year <number>',
+    'Financial year (optional; Fortnox infers it from the date range otherwise)',
+    parseInt,
+  )
+  .option('--account <number>', 'Filter to one account number')
+  .option('--series <code>', 'Filter to one voucher series (e.g. "A")')
+  .action(
+    async (opts: {
+      from: string;
+      to: string;
+      year?: number;
+      account?: string;
+      series?: string;
+    }) => {
+      const { getGeneralLedger } = await import('./operations/general-ledger.js');
+      let rows = await getGeneralLedger({
+        fromDate: opts.from,
+        toDate: opts.to,
+        financialYear: opts.year,
+      });
+      if (opts.account) rows = rows.filter((r) => r.account === opts.account);
+      if (opts.series) rows = rows.filter((r) => r.series === opts.series);
+      outputList(rows as unknown as Record<string, unknown>[], generalLedgerColumns, json(), rows);
+    },
+  );
 
 // --- invoice-payments ---
 const invoicePayments = program

--- a/src/fortnox-client.ts
+++ b/src/fortnox-client.ts
@@ -115,6 +115,7 @@ function endpointToScope(endpoint: string): string | undefined {
     vouchers: 'bookkeeping',
     accounts: 'bookkeeping',
     financialyears: 'bookkeeping',
+    sie: 'bookkeeping',
     companyinformation: 'companyinformation',
     settings: 'settings',
     projects: 'project',

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerArticleTools } from './tools/articles.js';
 import { registerSupplierTools } from './tools/suppliers.js';
 import { registerSupplierInvoiceTools } from './tools/supplier-invoices.js';
 import { registerFinancialReportTools } from './tools/financial-reports.js';
+import { registerGeneralLedgerTools } from './tools/general-ledger.js';
 import { registerStatusTools } from './tools/status.js';
 import { registerInvoicePaymentTools } from './tools/invoice-payments.js';
 import { registerSupplierInvoicePaymentTools } from './tools/supplier-invoice-payments.js';
@@ -61,6 +62,7 @@ export function createServer(options: CreateServerOptions = {}): McpServer {
   registerSupplierTools(server, operations);
   registerSupplierInvoiceTools(server, operations);
   registerFinancialReportTools(server, operations);
+  registerGeneralLedgerTools(server, operations);
   // The status tool inspects this process's local profile/keychain. It remains
   // useful for local stdio sessions but must not expose host state in an
   // embedded tenant-bound server.

--- a/src/operations/general-ledger.ts
+++ b/src/operations/general-ledger.ts
@@ -62,7 +62,7 @@ export function createGeneralLedgerOperations(transport: FortnoxTransport) {
       .map((t): GeneralLedgerEntry => ({
         series: t.series,
         voucherNumber: t.voucherNumber,
-        transactionDate: formatSieDate(t.voucherDate),
+        transactionDate: formatSieDate(t.transactionDate),
         registrationDate: t.registrationDate ? formatSieDate(t.registrationDate) : undefined,
         account: t.account,
         accountDescription: parsed.accounts.get(t.account)?.description,

--- a/src/operations/general-ledger.ts
+++ b/src/operations/general-ledger.ts
@@ -1,0 +1,62 @@
+import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
+import { fetchSie } from '../sie.js';
+
+export interface GeneralLedgerEntry {
+  series: string;
+  voucherNumber: string;
+  transactionDate: string;
+  registrationDate?: string;
+  account: string;
+  accountDescription?: string;
+  costCenter?: string;
+  project?: string;
+  text: string;
+  debit: number;
+  credit: number;
+}
+
+export interface GeneralLedgerParams {
+  fromDate: string;
+  toDate: string;
+  financialYear?: number;
+}
+
+// SIE dates are YYYYMMDD with no separators.
+function formatSieDate(date: string): string {
+  if (!/^\d{8}$/.test(date)) return date;
+  return `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+}
+
+export function createGeneralLedgerOperations(transport: FortnoxTransport) {
+  // The flat, dated, per-account transaction list every other report in this
+  // file is built from — one #TRANS line in, one row out. Requires a date
+  // range: fetchSie proxies straight to Fortnox's SIE export, which needs
+  // one to scope the file it generates.
+  async function getGeneralLedger(params: GeneralLedgerParams): Promise<GeneralLedgerEntry[]> {
+    const parsed = await fetchSie(transport, params);
+    return parsed.transactions
+      .map((t): GeneralLedgerEntry => ({
+        series: t.series,
+        voucherNumber: t.voucherNumber,
+        transactionDate: formatSieDate(t.voucherDate),
+        registrationDate: t.registrationDate ? formatSieDate(t.registrationDate) : undefined,
+        account: t.account,
+        accountDescription: parsed.accounts.get(t.account)?.description,
+        costCenter: t.costCenter,
+        project: t.project,
+        text: t.text ?? t.voucherDescription,
+        debit: t.amount > 0 ? t.amount : 0,
+        credit: t.amount < 0 ? -t.amount : 0,
+      }))
+      .sort(
+        (a, b) =>
+          a.transactionDate.localeCompare(b.transactionDate) ||
+          a.series.localeCompare(b.series) ||
+          Number(a.voucherNumber) - Number(b.voucherNumber),
+      );
+  }
+
+  return { getGeneralLedger };
+}
+
+export const { getGeneralLedger } = createGeneralLedgerOperations(defaultFortnoxTransport);

--- a/src/operations/general-ledger.ts
+++ b/src/operations/general-ledger.ts
@@ -1,5 +1,6 @@
 import { defaultFortnoxTransport, type FortnoxTransport } from '../fortnox-client.js';
 import { fetchSie } from '../sie.js';
+import { createFinancialYearOperations } from './financial-years.js';
 
 export interface GeneralLedgerEntry {
   series: string;
@@ -28,12 +29,35 @@ function formatSieDate(date: string): string {
 }
 
 export function createGeneralLedgerOperations(transport: FortnoxTransport) {
+  const { listFinancialYears } = createFinancialYearOperations(transport);
+
+  // Financial year ids are per-company — id 14 might be 2025 for one tenant
+  // and id 1 might be 2025 for a company founded that year — so there is no
+  // way to guess one. Fortnox's SIE export additionally does not reliably
+  // infer the year from dates alone: `fromdate`/`todate` set to exactly a
+  // real financial year's own boundaries can still come back
+  // "Perioden måste ligga inom bokföringsåret" (confirmed live) unless
+  // `financialyear` is also passed. Resolve it explicitly instead of relying
+  // on that inference, the same way attachVoucherFiles resolves one for
+  // vouchers.
+  async function resolveFinancialYear(fromDate: string): Promise<number> {
+    const fy = await listFinancialYears({ date: fromDate });
+    const list = (fy.FinancialYears ?? []) as Record<string, unknown>[];
+    if (!list.length) {
+      throw new Error(
+        `No financial year found covering ${fromDate}. Pass financialYear explicitly.`,
+      );
+    }
+    return Number(list[0]!.Id);
+  }
+
   // The flat, dated, per-account transaction list every other report in this
   // file is built from — one #TRANS line in, one row out. Requires a date
   // range: fetchSie proxies straight to Fortnox's SIE export, which needs
   // one to scope the file it generates.
   async function getGeneralLedger(params: GeneralLedgerParams): Promise<GeneralLedgerEntry[]> {
-    const parsed = await fetchSie(transport, params);
+    const financialYear = params.financialYear ?? (await resolveFinancialYear(params.fromDate));
+    const parsed = await fetchSie(transport, { ...params, financialYear });
     return parsed.transactions
       .map((t): GeneralLedgerEntry => ({
         series: t.series,

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -13,6 +13,7 @@ import { createEmployeeOperations } from './employees.js';
 import { createFinancialReportOperations } from './financial-reports.js';
 import { createFinancialYearOperations } from './financial-years.js';
 import { createFileOperations } from './files.js';
+import { createGeneralLedgerOperations } from './general-ledger.js';
 import { createInvoicePaymentOperations } from './invoice-payments.js';
 import { createInvoiceOperations } from './invoices.js';
 import { createOfferOperations } from './offers.js';
@@ -47,6 +48,7 @@ export function createFortnoxOperations(transport: FortnoxTransport) {
     ...createFinancialReportOperations(transport),
     ...createFinancialYearOperations(transport),
     ...createFileOperations(transport),
+    ...createGeneralLedgerOperations(transport),
     ...createInvoicePaymentOperations(transport),
     ...createInvoiceOperations(transport),
     ...createOfferOperations(transport),

--- a/src/sie.ts
+++ b/src/sie.ts
@@ -1,13 +1,10 @@
 import type { FortnoxTransport } from './fortnox-client.js';
 
-// Fortnox has no public REST endpoint for period-scoped account totals — the
-// obvious path (list vouchers, fetch each one's rows, sum debit/credit) means
-// one HTTP request per voucher, which times out on any real company (#152).
-// GET /3/sie/4 is a separate, undocumented-by-omission endpoint: it returns
-// the whole period's chart of accounts, opening/closing balances and every
-// transaction line in one streamed file, in the standard Swedish SIE format.
-// Parsing that file is the fast path for anything that needs bulk voucher/
-// account data — voucher lists, P&L, balance sheet.
+// Fortnox documents GET /3/sie/{Type} in its OpenAPI specification. Type 4
+// returns transaction rows and balances in one file, avoiding individual
+// voucher-detail requests for the general ledger.
+// Format reference: https://sie.se/wp-content/uploads/2020/05/SIE_filformat_ver_4B_ENGLISH.pdf
+// (sections 5.7 and 5.9: quoted fields and decimal amounts).
 //
 // SIE is a line-oriented text format (Swedish "SIE 4" standard); every
 // meaningful line starts with a `#TAG`. We only parse the tags this codebase
@@ -18,18 +15,18 @@ import type { FortnoxTransport } from './fortnox-client.js';
 export interface SieAccount {
   number: string;
   description: string;
-  /** Skatteverket's "Standardiserat räkenskapsutdrag" code — the official
-   * grouping used for annual-report line items (Nettoomsättning, Övriga
-   * externa kostnader, etc.). Absent for accounts with no SRU mapping. */
+  /** Single SRU code retained for this account. Full tax-report mapping
+   * needs separate support for multiple and sign-dependent SRU codes. */
   sru?: string;
 }
 
 export interface SieTransaction {
   series: string;
   voucherNumber: string;
-  /** Voucher transaction date (#VER's own date, not the per-row #TRANS date
-   * override — Fortnox's export does not appear to set the latter). */
+  /** Date from the voucher header (#VER). */
   voucherDate: string;
+  /** Row date (#TRANS), falling back to the voucher date when absent. */
+  transactionDate: string;
   /** Registration date, when present — the 5th #VER field. */
   registrationDate?: string;
   voucherDescription: string;
@@ -63,6 +60,21 @@ export interface ParsedSie {
 // (with the quotes stripped) and a `{...}` run is one token (kept with its
 // braces, for the caller to parse separately — it's a nested object list,
 // e.g. `{1 "2010" 6 "1001"}` for cost-centre + project dimensions).
+function readQuoted(line: string, start: number): { value: string; end: number } {
+  let value = '';
+  for (let i = start + 1; i < line.length; i++) {
+    if (line[i] === '\\' && line[i + 1] === '"') {
+      value += '"';
+      i++;
+    } else if (line[i] === '"') {
+      return { value, end: i + 1 };
+    } else {
+      value += line[i];
+    }
+  }
+  throw new Error('SIE export contains an unterminated quoted field.');
+}
+
 function tokenize(line: string): string[] {
   const tokens: string[] = [];
   let i = 0;
@@ -70,17 +82,17 @@ function tokenize(line: string): string[] {
     while (i < line.length && /\s/.test(line[i]!)) i++;
     if (i >= line.length) break;
     if (line[i] === '"') {
-      let j = i + 1;
-      let value = '';
-      while (j < line.length && line[j] !== '"') {
-        value += line[j];
-        j++;
-      }
+      const { value, end } = readQuoted(line, i);
       tokens.push(value);
-      i = j + 1;
+      i = end;
     } else if (line[i] === '{') {
       let j = i + 1;
-      while (j < line.length && line[j] !== '}') j++;
+      while (j < line.length && line[j] !== '}') {
+        j = line[j] === '"' ? readQuoted(line, j).end : j + 1;
+      }
+      if (j === line.length) {
+        throw new Error('SIE export contains an unterminated object list.');
+      }
       tokens.push(line.slice(i, j + 1));
       i = j + 1;
     } else {
@@ -109,17 +121,26 @@ function parseDimensions(raw: string): { costCenter?: string; project?: string }
   return result;
 }
 
-// Fortnox has never been observed to emit a malformed amount, but if a future
-// export ever does, `Number(x)` on "" or a corrupted token is NaN — and
-// unlike a genuinely missing token (`undefined`, already filtered out before
-// this runs), NaN and Infinity both fail every downstream `> 0`/`< 0`
-// comparison, so debit and credit both end up 0. That is a plausible-looking
-// row with the actual figure silently discarded, not an error. A financial
-// amount does not get that benefit of the doubt: reject it instead.
+// SIE amounts use an optional minus, digits, and at most two decimal places.
+// Check exact minor units before converting to the public number representation:
+// cents must be safe integers, and both fixed-decimal display and JSON number
+// serialization must preserve the input. Reject cent-level rounding loss.
 function parseFiniteAmount(raw: string, context: string): number {
-  const value = Number(raw);
-  if (!Number.isFinite(value)) {
+  if (!/^-?\d+(?:\.\d{1,2})?$/.test(raw)) {
     throw new Error(`SIE export contains a malformed amount "${raw}" (${context}).`);
+  }
+  const [whole, fraction = ''] = raw.replace(/^-/, '').split('.');
+  const normalized = `${BigInt(whole!)}.${fraction.padEnd(2, '0')}`;
+  const cents = BigInt(whole!) * 100n + BigInt(fraction.padEnd(2, '0'));
+  const value = Number(raw);
+  if (cents > BigInt(Number.MAX_SAFE_INTEGER) || Math.abs(value).toFixed(2) !== normalized) {
+    throw new Error(`SIE export contains an unsafe amount "${raw}" (${context}).`);
+  }
+  // JSON uses Number#toString, which can choose a shorter decimal than toFixed
+  // at large magnitudes (e.g. 90071992547409.91 becomes 90071992547409.9).
+  const [serializedWhole, serializedFraction = ''] = Math.abs(value).toString().split('.');
+  if (`${serializedWhole}.${serializedFraction.padEnd(2, '0')}` !== normalized) {
+    throw new Error(`SIE export contains an unsafe amount "${raw}" (${context}).`);
   }
   return value;
 }
@@ -152,7 +173,7 @@ export function parseSie(text: string): ParsedSie {
       continue;
     }
     if (!line.startsWith('#')) continue;
-    const tag = line.slice(1, line.indexOf(' ') === -1 ? undefined : line.indexOf(' '));
+    const tag = line.slice(1).split(/\s/, 1)[0];
 
     if (tag === 'FNAMN') {
       companyName = tokenize(line)[1];
@@ -191,13 +212,14 @@ export function parseSie(text: string): ParsedSie {
       }
     } else if (tag === 'TRANS') {
       const tokens = tokenize(line);
-      const [, account, dims, amount, , text] = tokens;
+      const [, account, dims, amount, transactionDate, text] = tokens;
       if (account && amount !== undefined && currentVoucher && insideVoucherBlock) {
         const { costCenter, project } = dims ? parseDimensions(dims) : {};
         transactions.push({
           series: currentVoucher.series,
           voucherNumber: currentVoucher.number,
           voucherDate: currentVoucher.date,
+          transactionDate: transactionDate || currentVoucher.date,
           registrationDate: currentVoucher.regDate,
           voucherDescription: currentVoucher.description,
           account,

--- a/src/sie.ts
+++ b/src/sie.ts
@@ -1,0 +1,359 @@
+import type { FortnoxTransport } from './fortnox-client.js';
+
+// Fortnox has no public REST endpoint for period-scoped account totals — the
+// obvious path (list vouchers, fetch each one's rows, sum debit/credit) means
+// one HTTP request per voucher, which times out on any real company (#152).
+// GET /3/sie/4 is a separate, undocumented-by-omission endpoint: it returns
+// the whole period's chart of accounts, opening/closing balances and every
+// transaction line in one streamed file, in the standard Swedish SIE format.
+// Parsing that file is the fast path for anything that needs bulk voucher/
+// account data — voucher lists, P&L, balance sheet.
+//
+// SIE is a line-oriented text format (Swedish "SIE 4" standard); every
+// meaningful line starts with a `#TAG`. We only parse the tags this codebase
+// needs — #KONTO/#SRU (chart of accounts + official tax-authority grouping
+// code), #IB/#UB (opening/closing balance per account), and #VER/#TRANS
+// (voucher headers and their transaction lines). Anything else is ignored.
+
+export interface SieAccount {
+  number: string;
+  description: string;
+  /** Skatteverket's "Standardiserat räkenskapsutdrag" code — the official
+   * grouping used for annual-report line items (Nettoomsättning, Övriga
+   * externa kostnader, etc.). Absent for accounts with no SRU mapping. */
+  sru?: string;
+}
+
+export interface SieTransaction {
+  series: string;
+  voucherNumber: string;
+  /** Voucher transaction date (#VER's own date, not the per-row #TRANS date
+   * override — Fortnox's export does not appear to set the latter). */
+  voucherDate: string;
+  /** Registration date, when present — the 5th #VER field. */
+  registrationDate?: string;
+  voucherDescription: string;
+  account: string;
+  /** Signed: positive = debit, negative = credit. */
+  amount: number;
+  costCenter?: string;
+  project?: string;
+  /** Per-row free text, when present (falls back to the voucher description
+   * when the caller wants a single label). */
+  text?: string;
+}
+
+export interface SieBalance {
+  account: string;
+  /** 0 = current financial year, -1 = the one before it, per #RAR. */
+  yearIndex: number;
+  balance: number;
+}
+
+export interface ParsedSie {
+  companyName?: string;
+  organisationNumber?: string;
+  accounts: Map<string, SieAccount>;
+  transactions: SieTransaction[];
+  openingBalances: SieBalance[];
+  closingBalances: SieBalance[];
+}
+
+// SIE lines are whitespace-separated tokens where a `"..."` run is one token
+// (with the quotes stripped) and a `{...}` run is one token (kept with its
+// braces, for the caller to parse separately — it's a nested object list,
+// e.g. `{1 "2010" 6 "1001"}` for cost-centre + project dimensions).
+function tokenize(line: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    while (i < line.length && /\s/.test(line[i]!)) i++;
+    if (i >= line.length) break;
+    if (line[i] === '"') {
+      let j = i + 1;
+      let value = '';
+      while (j < line.length && line[j] !== '"') {
+        value += line[j];
+        j++;
+      }
+      tokens.push(value);
+      i = j + 1;
+    } else if (line[i] === '{') {
+      let j = i + 1;
+      while (j < line.length && line[j] !== '}') j++;
+      tokens.push(line.slice(i, j + 1));
+      i = j + 1;
+    } else {
+      let j = i;
+      while (j < line.length && !/\s/.test(line[j]!)) j++;
+      tokens.push(line.slice(i, j));
+      i = j;
+    }
+  }
+  return tokens;
+}
+
+// `{1 "2010" 6 "1001"}` -> { costCenter: '2010', project: '1001' }. Dimension
+// 1 is always cost centre and 6 always project in Fortnox's SIE export (see
+// the #DIM lines at the top of the file); other dimension numbers exist in
+// the SIE standard but Fortnox does not emit them, so they're ignored.
+function parseDimensions(raw: string): { costCenter?: string; project?: string } {
+  const inner = raw.slice(1, -1).trim();
+  if (!inner) return {};
+  const parts = tokenize(inner);
+  const result: { costCenter?: string; project?: string } = {};
+  for (let i = 0; i + 1 < parts.length; i += 2) {
+    if (parts[i] === '1') result.costCenter = parts[i + 1];
+    else if (parts[i] === '6') result.project = parts[i + 1];
+  }
+  return result;
+}
+
+export function parseSie(text: string): ParsedSie {
+  const accounts = new Map<string, SieAccount>();
+  const transactions: SieTransaction[] = [];
+  const openingBalances: SieBalance[] = [];
+  const closingBalances: SieBalance[] = [];
+  let companyName: string | undefined;
+  let organisationNumber: string | undefined;
+
+  let currentVoucher:
+    | { series: string; number: string; date: string; regDate?: string; description: string }
+    | undefined;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith('#')) continue;
+    const tag = line.slice(1, line.indexOf(' ') === -1 ? undefined : line.indexOf(' '));
+
+    if (tag === 'FNAMN') {
+      companyName = tokenize(line)[1];
+    } else if (tag === 'ORGNR') {
+      organisationNumber = tokenize(line)[1];
+    } else if (tag === 'KONTO') {
+      const [, number, description] = tokenize(line);
+      if (number) accounts.set(number, { number, description: description ?? '' });
+    } else if (tag === 'SRU') {
+      const [, number, sru] = tokenize(line);
+      if (number) {
+        const existing = accounts.get(number);
+        if (existing) existing.sru = sru;
+        else accounts.set(number, { number, description: '', sru });
+      }
+    } else if (tag === 'IB' || tag === 'UB') {
+      const [, yearIndex, account, balance] = tokenize(line);
+      if (account && balance !== undefined) {
+        const entry: SieBalance = {
+          account,
+          yearIndex: Number(yearIndex),
+          balance: Number(balance),
+        };
+        (tag === 'IB' ? openingBalances : closingBalances).push(entry);
+      }
+    } else if (tag === 'VER') {
+      const [, series, number, date, description, regDate] = tokenize(line);
+      if (series && number) {
+        currentVoucher = {
+          series,
+          number,
+          date: date ?? '',
+          regDate,
+          description: description ?? '',
+        };
+      }
+    } else if (tag === 'TRANS') {
+      const tokens = tokenize(line);
+      const [, account, dims, amount, , text] = tokens;
+      if (account && amount !== undefined && currentVoucher) {
+        const { costCenter, project } = dims ? parseDimensions(dims) : {};
+        transactions.push({
+          series: currentVoucher.series,
+          voucherNumber: currentVoucher.number,
+          voucherDate: currentVoucher.date,
+          registrationDate: currentVoucher.regDate,
+          voucherDescription: currentVoucher.description,
+          account,
+          amount: Number(amount),
+          costCenter,
+          project,
+          text: text || undefined,
+        });
+      }
+    }
+  }
+
+  return {
+    companyName,
+    organisationNumber,
+    accounts,
+    transactions,
+    openingBalances,
+    closingBalances,
+  };
+}
+
+// SIE declares its own encoding via `#FORMAT PC8` — IBM code page 437, not
+// UTF-8 or Latin-1. Decoding as Latin-1 silently eats every å/ä/ö: CP437's
+// byte for `ä` (0x84) falls in Latin-1's C1-control range, so it renders as
+// nothing rather than the wrong character — e.g. "Intäktsränta" becomes
+// "Intktsrnta". Bytes 0x00-0x7F are plain ASCII in both encodings; only the
+// upper half needs remapping.
+const CP437_UPPER = [
+  'Ç',
+  'ü',
+  'é',
+  'â',
+  'ä',
+  'à',
+  'å',
+  'ç',
+  'ê',
+  'ë',
+  'è',
+  'ï',
+  'î',
+  'ì',
+  'Ä',
+  'Å',
+  'É',
+  'æ',
+  'Æ',
+  'ô',
+  'ö',
+  'ò',
+  'û',
+  'ù',
+  'ÿ',
+  'Ö',
+  'Ü',
+  '¢',
+  '£',
+  '¥',
+  '₧',
+  'ƒ',
+  'á',
+  'í',
+  'ó',
+  'ú',
+  'ñ',
+  'Ñ',
+  'ª',
+  'º',
+  '¿',
+  '⌐',
+  '¬',
+  '½',
+  '¼',
+  '¡',
+  '«',
+  '»',
+  '░',
+  '▒',
+  '▓',
+  '│',
+  '┤',
+  '╡',
+  '╢',
+  '╖',
+  '╕',
+  '╣',
+  '║',
+  '╗',
+  '╝',
+  '╜',
+  '╛',
+  '┐',
+  '└',
+  '┴',
+  '┬',
+  '├',
+  '─',
+  '┼',
+  '╞',
+  '╟',
+  '╚',
+  '╔',
+  '╩',
+  '╦',
+  '╠',
+  '═',
+  '╬',
+  '╧',
+  '╨',
+  '╤',
+  '╥',
+  '╙',
+  '╘',
+  '╒',
+  '╓',
+  '╫',
+  '╪',
+  '┘',
+  '┌',
+  '█',
+  '▄',
+  '▌',
+  '▐',
+  '▀',
+  'α',
+  'ß',
+  'Γ',
+  'π',
+  'Σ',
+  'σ',
+  'µ',
+  'τ',
+  'Φ',
+  'Θ',
+  'Ω',
+  'δ',
+  '∞',
+  'φ',
+  'ε',
+  '∩',
+  '≡',
+  '±',
+  '≥',
+  '≤',
+  '⌠',
+  '⌡',
+  '÷',
+  '≈',
+  '°',
+  '∙',
+  '·',
+  '√',
+  'ⁿ',
+  '²',
+  '■',
+  ' ',
+];
+
+function decodeCp437(buffer: Buffer): string {
+  let out = '';
+  for (const byte of buffer) {
+    out += byte < 0x80 ? String.fromCharCode(byte) : CP437_UPPER[byte - 0x80];
+  }
+  return out;
+}
+
+export interface FetchSieParams {
+  fromDate?: string;
+  toDate?: string;
+  financialYear?: number;
+}
+
+/** Fetch and parse the SIE4 (full transaction detail) export for a period. */
+export async function fetchSie(
+  transport: FortnoxTransport,
+  params: FetchSieParams = {},
+): Promise<ParsedSie> {
+  const { buffer } = await transport.requestFile('sie/4', {
+    params: {
+      fromdate: params.fromDate,
+      todate: params.toDate,
+      financialyear: params.financialYear,
+    },
+  });
+  return parseSie(decodeCp437(buffer));
+}

--- a/src/sie.ts
+++ b/src/sie.ts
@@ -109,6 +109,21 @@ function parseDimensions(raw: string): { costCenter?: string; project?: string }
   return result;
 }
 
+// Fortnox has never been observed to emit a malformed amount, but if a future
+// export ever does, `Number(x)` on "" or a corrupted token is NaN — and
+// unlike a genuinely missing token (`undefined`, already filtered out before
+// this runs), NaN and Infinity both fail every downstream `> 0`/`< 0`
+// comparison, so debit and credit both end up 0. That is a plausible-looking
+// row with the actual figure silently discarded, not an error. A financial
+// amount does not get that benefit of the doubt: reject it instead.
+function parseFiniteAmount(raw: string, context: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`SIE export contains a malformed amount "${raw}" (${context}).`);
+  }
+  return value;
+}
+
 export function parseSie(text: string): ParsedSie {
   const accounts = new Map<string, SieAccount>();
   const transactions: SieTransaction[] = [];
@@ -120,9 +135,22 @@ export function parseSie(text: string): ParsedSie {
   let currentVoucher:
     | { series: string; number: string; date: string; regDate?: string; description: string }
     | undefined;
+  // Whether we're between a voucher's `{` and `}` lines. #TRANS only means
+  // anything inside that block; a stray or truncated one after `}` (before
+  // the next #VER) must not be attributed to the voucher that already closed.
+  let insideVoucherBlock = false;
 
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
+    if (line === '{') {
+      insideVoucherBlock = true;
+      continue;
+    }
+    if (line === '}') {
+      insideVoucherBlock = false;
+      currentVoucher = undefined;
+      continue;
+    }
     if (!line.startsWith('#')) continue;
     const tag = line.slice(1, line.indexOf(' ') === -1 ? undefined : line.indexOf(' '));
 
@@ -146,7 +174,7 @@ export function parseSie(text: string): ParsedSie {
         const entry: SieBalance = {
           account,
           yearIndex: Number(yearIndex),
-          balance: Number(balance),
+          balance: parseFiniteAmount(balance, `#${tag} ${account}`),
         };
         (tag === 'IB' ? openingBalances : closingBalances).push(entry);
       }
@@ -164,7 +192,7 @@ export function parseSie(text: string): ParsedSie {
     } else if (tag === 'TRANS') {
       const tokens = tokenize(line);
       const [, account, dims, amount, , text] = tokens;
-      if (account && amount !== undefined && currentVoucher) {
+      if (account && amount !== undefined && currentVoucher && insideVoucherBlock) {
         const { costCenter, project } = dims ? parseDimensions(dims) : {};
         transactions.push({
           series: currentVoucher.series,
@@ -173,7 +201,10 @@ export function parseSie(text: string): ParsedSie {
           registrationDate: currentVoucher.regDate,
           voucherDescription: currentVoucher.description,
           account,
-          amount: Number(amount),
+          amount: parseFiniteAmount(
+            amount,
+            `#TRANS ${account} in voucher ${currentVoucher.series}${currentVoucher.number}`,
+          ),
           costCenter,
           project,
           text: text || undefined,

--- a/src/tools/general-ledger.ts
+++ b/src/tools/general-ledger.ts
@@ -30,7 +30,7 @@ export function registerGeneralLedgerTools(
         .number()
         .optional()
         .describe(
-          'Räkenskapsår-ID (från fortnox_list_financialyears), härleds annars av Fortnox från datumintervallet',
+          'Räkenskapsår-ID (från fortnox_list_financialyears) — löses annars upp automatiskt från fromDate',
         ),
       account: z.string().optional().describe('Filtrera på ett specifikt kontonummer'),
       series: z

--- a/src/tools/general-ledger.ts
+++ b/src/tools/general-ledger.ts
@@ -4,6 +4,16 @@ import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/
 import { generalLedgerColumns } from '../views.js';
 import { listResponse } from '../tool-output.js';
 
+// A 20,000-posting fixture (a real full year for a high-volume company —
+// exactly the scenario this tool exists for) formats to ~1.78 MB of table
+// text, which can exceed MCP/client/model limits and hands back more ledger
+// data than a caller can realistically consume in one response. Cap it the
+// same way every other list tool in this codebase already reports paging
+// (`@TotalResources`/`@TotalPages`/`@CurrentPage`), so a caller who needs the
+// rest can page through it explicitly instead of it arriving unbounded.
+const DEFAULT_LIMIT = 500;
+const MAX_LIMIT = 2000;
+
 export function registerGeneralLedgerTools(
   server: McpServer,
   operations: FortnoxOperations = defaultFortnoxOperations,
@@ -12,7 +22,7 @@ export function registerGeneralLedgerTools(
 
   server.tool(
     'fortnox_general_ledger',
-    'Hämta bokförda transaktioner (huvudbok) för en period — en rad per kontorad, med datum, konto, text, debet och kredit. Bygger på Fortnox SIE-export och hämtar hela perioden i ett anrop, till skillnad från fortnox_list_vouchers som inte inkluderar belopp. Användbart för avstämning, periodjämförelser och att slå upp enskilda bokföringar/fakturor över tid.',
+    'Hämta bokförda transaktioner (huvudbok) för en period — en rad per kontorad, med datum, konto, text, debet och kredit. Bygger på Fortnox SIE-export och hämtar hela perioden i ett anrop, till skillnad från fortnox_list_vouchers som inte inkluderar belopp. Användbart för avstämning, periodjämförelser och att slå upp enskilda bokföringar/fakturor över tid. Resultatet är sidindelat — se sidfoten för totalt antal rader.',
     {
       fromDate: z.string().describe('Från datum (YYYY-MM-DD)'),
       toDate: z.string().describe('Till datum (YYYY-MM-DD)'),
@@ -27,18 +37,40 @@ export function registerGeneralLedgerTools(
         .string()
         .optional()
         .describe('Filtrera på en specifik verifikationsserie (t.ex. "A")'),
-      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+      page: z.number().int().min(1).optional().describe('Sidnummer (default 1)'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_LIMIT)
+        .optional()
+        .describe(`Antal rader per sida (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT})`),
     },
-    async ({ fromDate, toDate, financialYear, account, series, includeRaw }) => {
+    async ({ fromDate, toDate, financialYear, account, series, page, limit }) => {
       let rows = await getGeneralLedger({ fromDate, toDate, financialYear });
       if (account) rows = rows.filter((r) => r.account === account);
       if (series) rows = rows.filter((r) => r.series === series);
+
+      const totalResources = rows.length;
+      const pageSize = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+      const currentPage = page ?? 1;
+      const start = (currentPage - 1) * pageSize;
+      const pageRows = rows.slice(start, start + pageSize);
+      const totalPages = Math.max(1, Math.ceil(totalResources / pageSize));
+
+      // No `includeRaw`: this data comes from a parsed SIE text export, not a
+      // Fortnox JSON response, so there is no separate "raw" representation
+      // to hand back — offering one would just relabel these same rows as
+      // something they are not.
       return listResponse(
-        rows as unknown as Record<string, unknown>[],
+        pageRows as unknown as Record<string, unknown>[],
         generalLedgerColumns,
-        rows,
         undefined,
-        includeRaw,
+        {
+          '@TotalResources': totalResources,
+          '@TotalPages': totalPages,
+          '@CurrentPage': currentPage,
+        },
       );
     },
   );

--- a/src/tools/general-ledger.ts
+++ b/src/tools/general-ledger.ts
@@ -1,0 +1,45 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { defaultFortnoxOperations, type FortnoxOperations } from '../operations/index.js';
+import { generalLedgerColumns } from '../views.js';
+import { listResponse } from '../tool-output.js';
+
+export function registerGeneralLedgerTools(
+  server: McpServer,
+  operations: FortnoxOperations = defaultFortnoxOperations,
+): void {
+  const { getGeneralLedger } = operations;
+
+  server.tool(
+    'fortnox_general_ledger',
+    'Hämta bokförda transaktioner (huvudbok) för en period — en rad per kontorad, med datum, konto, text, debet och kredit. Bygger på Fortnox SIE-export och hämtar hela perioden i ett anrop, till skillnad från fortnox_list_vouchers som inte inkluderar belopp. Användbart för avstämning, periodjämförelser och att slå upp enskilda bokföringar/fakturor över tid.',
+    {
+      fromDate: z.string().describe('Från datum (YYYY-MM-DD)'),
+      toDate: z.string().describe('Till datum (YYYY-MM-DD)'),
+      financialYear: z
+        .number()
+        .optional()
+        .describe(
+          'Räkenskapsår-ID (från fortnox_list_financialyears), härleds annars av Fortnox från datumintervallet',
+        ),
+      account: z.string().optional().describe('Filtrera på ett specifikt kontonummer'),
+      series: z
+        .string()
+        .optional()
+        .describe('Filtrera på en specifik verifikationsserie (t.ex. "A")'),
+      includeRaw: z.boolean().optional().describe('Inkludera rå JSON från Fortnox'),
+    },
+    async ({ fromDate, toDate, financialYear, account, series, includeRaw }) => {
+      let rows = await getGeneralLedger({ fromDate, toDate, financialYear });
+      if (account) rows = rows.filter((r) => r.account === account);
+      if (series) rows = rows.filter((r) => r.series === series);
+      return listResponse(
+        rows as unknown as Record<string, unknown>[],
+        generalLedgerColumns,
+        rows,
+        undefined,
+        includeRaw,
+      );
+    },
+  );
+}

--- a/src/views.ts
+++ b/src/views.ts
@@ -647,6 +647,22 @@ export const absenceTransactionDetailColumns: Column[] = [
   { key: 'Project', header: 'Project', width: 12 },
 ];
 
+// --- General ledger (target ≤80 cols) ---
+
+export const generalLedgerColumns: Column[] = [
+  { key: 'transactionDate', header: 'Date', width: 10 },
+  {
+    key: 'series',
+    header: 'Ver',
+    width: 8,
+    format: (_v, row) => `${row.series as string}${row.voucherNumber as string}`,
+  },
+  { key: 'account', header: 'Account', width: 8, align: 'right' },
+  { key: 'text', header: 'Text', width: 28 },
+  { key: 'debit', header: 'Debit', width: 12, align: 'right', format: currency },
+  { key: 'credit', header: 'Credit', width: 12, align: 'right', format: currency },
+];
+
 // Schedule times
 export const scheduleTimeDetailColumns: Column[] = [
   { key: 'EmployeeId', header: 'Employee #', width: 15 },

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { defaultFortnoxOperations } from '../src/operations/index.js';
 import { describe, expect, it } from 'vitest';
 import {
   calculateApiCoverage,
@@ -116,5 +118,46 @@ describe('API coverage manifest core', () => {
     );
     expect(details).not.toContain('\u001b');
     expect(details).toContain('danger\\n\\u001b[31m');
+  });
+});
+
+describe('exposed SIE coverage', () => {
+  it('records the public general-ledger operation as implemented core coverage', () => {
+    expect(defaultFortnoxOperations.getGeneralLedger).toBeTypeOf('function');
+    const document = JSON.parse(
+      readFileSync(new URL('../api-spec/api-implementation-map.json', import.meta.url), 'utf8'),
+    );
+    const sie = document.families.find((family: { id: string }) => family.id === 'fortnox-sie');
+    expect(sie.classification).toBe('complete');
+    expect(sie.operations.implemented).toHaveLength(1);
+    expect(sie.operations.excluded).toEqual([]);
+    expect(sie.evidence).toEqual({
+      operationExports: ['getGeneralLedger'],
+      mcpTools: ['fortnox_general_ledger'],
+      cliCommands: [['general-ledger', 'list']],
+    });
+  });
+
+  it.each(['excluded', 'blocked'] as const)(
+    'rejects %s classifications with implemented operations',
+    (classification) => {
+      expect(() =>
+        calculateApiCoverage([partial({ classification, rationale: 'Out of scope.' })]),
+      ).toThrow(/cannot have implemented operations or exposure evidence/);
+    },
+  );
+
+  it('rejects exposure evidence even if implemented identities are missing', () => {
+    expect(() =>
+      calculateApiCoverage([
+        partial({
+          classification: 'excluded',
+          implementedOperationIdentities: [],
+          missingOperationIdentities: [],
+          excludedOperationIdentities: ['operation-a', 'operation-b'],
+          rationale: 'Out of scope.',
+        }),
+      ]),
+    ).toThrow(/cannot have implemented operations or exposure evidence/);
   });
 });

--- a/tests/fortnox-client.test.ts
+++ b/tests/fortnox-client.test.ts
@@ -231,6 +231,23 @@ describe('fortnox-client', () => {
       }
     });
 
+    it('includes scope hint for 403 on the SIE export endpoint', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ ErrorInformation: { message: 'Forbidden', code: 0 } }),
+      });
+
+      try {
+        await fortnoxRequest('sie/4');
+        expect.unreachable();
+      } catch (err) {
+        expect(err).toBeInstanceOf(FortnoxApiError);
+        const e = err as FortnoxApiError;
+        expect(e.hint).toContain('bookkeeping');
+      }
+    });
+
     it('includes auth hint for 401', async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,

--- a/tests/operations/general-ledger.test.ts
+++ b/tests/operations/general-ledger.test.ts
@@ -107,6 +107,25 @@ describe('getGeneralLedger', () => {
     });
   });
 
+  it('formats and sorts by row dates while retaining the voucher-date fallback', async () => {
+    const transport = stubTransport();
+    vi.mocked(transport.requestFile).mockResolvedValue({
+      buffer: Buffer.from(SAMPLE_SIE.replace('-1000 ""', '-1000 20260801')),
+      contentType: 'application/octet-stream',
+    });
+    const rows = await createGeneralLedgerOperations(transport).getGeneralLedger({
+      fromDate: '2026-08-01',
+      toDate: '2026-08-31',
+    });
+    expect(rows.map((r) => r.transactionDate)).toEqual([
+      '2026-08-01',
+      '2026-08-03',
+      '2026-08-03',
+      '2026-08-05',
+    ]);
+    expect(rows[0]).toMatchObject({ series: 'B', voucherNumber: '2', credit: 1000 });
+  });
+
   it('splits the signed SIE amount into separate debit/credit columns', async () => {
     const { getGeneralLedger } = createGeneralLedgerOperations(stubTransport());
 

--- a/tests/operations/general-ledger.test.ts
+++ b/tests/operations/general-ledger.test.ts
@@ -19,9 +19,14 @@ const SAMPLE_SIE = [
   '}',
 ].join('\r\n');
 
+// Every test below fetches a 2026-08 range, so a single financial year
+// covering all of 2026 satisfies the auto-resolution unless a test
+// overrides `request` itself to check that resolution specifically.
 function stubTransport(): FortnoxTransport {
   return {
-    request: vi.fn(),
+    request: vi.fn().mockResolvedValue({
+      FinancialYears: [{ Id: 4, FromDate: '2026-01-01', ToDate: '2026-12-31' }],
+    }),
     requestWithMetadata: vi.fn(),
     requestPdf: vi.fn(),
     requestPdfFromMutation: vi.fn(),
@@ -42,6 +47,45 @@ describe('getGeneralLedger', () => {
 
     expect(transport.requestFile).toHaveBeenCalledWith('sie/4', {
       params: { fromdate: '2026-08-01', todate: '2026-08-31', financialyear: 12 },
+    });
+    // An explicit financialYear must skip the lookup entirely.
+    expect(transport.request).not.toHaveBeenCalled();
+  });
+
+  // Financial year ids are per-company (id 14 for one tenant might be id 1
+  // for another that started in 2025) and Fortnox's SIE export does not
+  // reliably infer the year from dates alone — confirmed live: a real
+  // 2025-01-01..2025-12-31 range was rejected ("Perioden måste ligga inom
+  // bokföringsåret") until financialyear was also passed. Resolve it
+  // automatically instead of requiring the caller to already know the id.
+  describe('financial year auto-resolution', () => {
+    it('resolves the financial year from fromDate when not given', async () => {
+      const transport = stubTransport();
+      const { getGeneralLedger } = createGeneralLedgerOperations(transport);
+
+      await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' });
+
+      expect(transport.request).toHaveBeenCalledWith('financialyears');
+      expect(transport.requestFile).toHaveBeenCalledWith('sie/4', {
+        params: { fromdate: '2026-08-01', todate: '2026-08-31', financialyear: 4 },
+      });
+    });
+
+    it('throws (telling the caller to pass financialYear) when none covers the date', async () => {
+      const transport: FortnoxTransport = {
+        request: vi.fn().mockResolvedValue({ FinancialYears: [] }),
+        requestWithMetadata: vi.fn(),
+        requestPdf: vi.fn(),
+        requestPdfFromMutation: vi.fn(),
+        requestFile: vi.fn(),
+        fetchAllPages: vi.fn(),
+      };
+      const { getGeneralLedger } = createGeneralLedgerOperations(transport);
+
+      await expect(
+        getGeneralLedger({ fromDate: '1999-01-01', toDate: '1999-12-31' }),
+      ).rejects.toThrow(/pass financialYear/i);
+      expect(transport.requestFile).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/operations/general-ledger.test.ts
+++ b/tests/operations/general-ledger.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
+import { createGeneralLedgerOperations } from '../../src/operations/general-ledger.js';
+
+const SAMPLE_SIE = [
+  '#FORMAT PC8',
+  '#SIETYP 4',
+  '#KONTO 3000 "Sales, Sweden"',
+  '#KONTO 1930 "Bank"',
+  '#VER B 2 20260805 "Sale" 20260806',
+  '{',
+  '#TRANS 3000 {} -1000 "" "Sale to customer" 0',
+  '#TRANS 1930 {} 1000 "" "" 0',
+  '}',
+  '#VER A 1 20260803 "Earlier sale"',
+  '{',
+  '#TRANS 3000 {1 "2010"} -250 "" "" 0',
+  '#TRANS 1930 {} 250 "" "" 0',
+  '}',
+].join('\r\n');
+
+function stubTransport(): FortnoxTransport {
+  return {
+    request: vi.fn(),
+    requestWithMetadata: vi.fn(),
+    requestPdf: vi.fn(),
+    requestPdfFromMutation: vi.fn(),
+    requestFile: vi.fn().mockResolvedValue({
+      buffer: Buffer.from(SAMPLE_SIE, 'latin1'),
+      contentType: 'application/octet-stream',
+    }),
+    fetchAllPages: vi.fn(),
+  } as FortnoxTransport;
+}
+
+describe('getGeneralLedger', () => {
+  it('requests sie/4 for the given date range', async () => {
+    const transport = stubTransport();
+    const { getGeneralLedger } = createGeneralLedgerOperations(transport);
+
+    await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31', financialYear: 12 });
+
+    expect(transport.requestFile).toHaveBeenCalledWith('sie/4', {
+      params: { fromdate: '2026-08-01', todate: '2026-08-31', financialyear: 12 },
+    });
+  });
+
+  it('produces one row per #TRANS line, with formatted dates', async () => {
+    const { getGeneralLedger } = createGeneralLedgerOperations(stubTransport());
+
+    const rows = await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' });
+
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toMatchObject({
+      series: 'A',
+      voucherNumber: '1',
+      transactionDate: '2026-08-03',
+      account: '3000',
+      accountDescription: 'Sales, Sweden',
+      costCenter: '2010',
+      debit: 0,
+      credit: 250,
+    });
+  });
+
+  it('splits the signed SIE amount into separate debit/credit columns', async () => {
+    const { getGeneralLedger } = createGeneralLedgerOperations(stubTransport());
+
+    const rows = await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' });
+    const bankRow = rows.find((r) => r.account === '1930' && r.voucherNumber === '2');
+
+    expect(bankRow).toMatchObject({ debit: 1000, credit: 0 });
+  });
+
+  it('falls back to the voucher description when a row has no text of its own', async () => {
+    const { getGeneralLedger } = createGeneralLedgerOperations(stubTransport());
+
+    const rows = await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' });
+    const bankRow = rows.find((r) => r.account === '1930' && r.voucherNumber === '2');
+
+    expect(bankRow?.text).toBe('Sale');
+  });
+
+  it('sorts by transaction date, then series, then voucher number', async () => {
+    const { getGeneralLedger } = createGeneralLedgerOperations(stubTransport());
+
+    const rows = await getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' });
+
+    const order = rows.map((r) => `${r.transactionDate} ${r.series}${r.voucherNumber}`);
+    expect(order).toEqual(['2026-08-03 A1', '2026-08-03 A1', '2026-08-05 B2', '2026-08-05 B2']);
+  });
+
+  it('resolves distinct concurrent calls against their own bound transport', async () => {
+    const transportA = stubTransport();
+    const transportB = stubTransport();
+    const { getGeneralLedger: getA } = createGeneralLedgerOperations(transportA);
+    const { getGeneralLedger: getB } = createGeneralLedgerOperations(transportB);
+
+    await Promise.all([
+      getA({ fromDate: '2026-08-01', toDate: '2026-08-31' }),
+      getB({ fromDate: '2026-08-01', toDate: '2026-08-31' }),
+    ]);
+
+    expect(transportA.requestFile).toHaveBeenCalledTimes(1);
+    expect(transportB.requestFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/sie.test.ts
+++ b/tests/sie.test.ts
@@ -299,3 +299,89 @@ describe('fetchSie', () => {
     expect(result.transactions[0]?.voucherDescription).toBe('Intäktsränta');
   });
 });
+
+describe('SIE4 amount and field grammar', () => {
+  const transaction = (amount: string) =>
+    `#VER A 1 20260805 "Sale"\n{\n#TRANS 1930 {} ${amount}\n}`;
+
+  it.each([
+    '""',
+    '" "',
+    '0x10',
+    '1e3',
+    '+10',
+    '.50',
+    '1.',
+    '1,50',
+    '1.001',
+    'NaN',
+    'Infinity',
+    '-Infinity',
+    '9007199254740992',
+    '90071992547409.92',
+    '90071992547409.91',
+    '-90071992547409.91',
+    '70368744177664.01',
+  ])('rejects invalid or imprecise amount %s in every amount tag', (raw) => {
+    for (const input of [transaction(raw), `#IB 0 1930 ${raw}`, `#UB 0 1930 ${raw}`]) {
+      expect(() => parseSie(input)).toThrow(/malformed|unsafe/i);
+    }
+  });
+
+  it.each(['0', '123', '-123', '123.4', '-123.45', '0.01', '0001.20', '999999999999.99'])(
+    'accepts SIE decimal amount %s in every amount tag',
+    (raw) => {
+      const result = parseSie(`${transaction(raw)}\n#IB 0 1930 ${raw}\n#UB 0 1930 ${raw}`);
+      expect(result.transactions[0]?.amount).toBe(Number(raw));
+      expect(result.openingBalances[0]?.balance).toBe(Number(raw));
+      expect(result.closingBalances[0]?.balance).toBe(Number(raw));
+    },
+  );
+
+  it('uses the row date, with fallback for empty and omitted dates', () => {
+    const result = parseSie(
+      '#VER A 1 20260805 "Sale"\n{\n' +
+        '#TRANS 1930 {} 1 20260807 "Later"\n#TRANS 1930 {} 2 "" "Fallback"\n' +
+        '#TRANS 1930 {} 3\n}',
+    );
+    expect(result.transactions.map((t) => t.transactionDate)).toEqual([
+      '20260807',
+      '20260805',
+      '20260805',
+    ]);
+    expect(result.transactions.map((t) => t.voucherDate)).toEqual([
+      '20260805',
+      '20260805',
+      '20260805',
+    ]);
+  });
+
+  it('decodes escaped quotes without shifting subsequent fields or removing other backslashes', () => {
+    const result = parseSie(String.raw`#VER A 1 20260805 "Sale \"special\" C:\docs" 20260806
+{
+#TRANS 1930 {1 "Cost \"A\"" 6 "Project } A"} 12.50 20260807 "Row \"text\" C:\docs" 0
+}`);
+    expect(result.transactions[0]).toMatchObject({
+      voucherDescription: 'Sale "special" C:\\docs',
+      registrationDate: '20260806',
+      transactionDate: '20260807',
+      amount: 12.5,
+      costCenter: 'Cost "A"',
+      project: 'Project } A',
+      text: 'Row "text" C:\\docs',
+    });
+  });
+
+  it.each([
+    '#VER A 1 20260805 "Unclosed',
+    '#VER A 1 20260805 "Sale"\n{\n#TRANS 1930 {1 "Unclosed} 1\n}',
+    '#VER A 1 20260805 "Sale"\n{\n#TRANS 1930 {1 "Cost" 1\n}',
+  ])('rejects unterminated quoted fields and object lists', (input) => {
+    expect(() => parseSie(input)).toThrow(/unterminated/);
+  });
+
+  it('accepts tabs between record fields', () => {
+    const result = parseSie('#VER\tA\t1\t20260805\t"Sale"\n{\n#TRANS\t1930\t{}\t1.25\n}');
+    expect(result.transactions[0]?.amount).toBe(1.25);
+  });
+});

--- a/tests/sie.test.ts
+++ b/tests/sie.test.ts
@@ -125,6 +125,99 @@ describe('parseSie', () => {
     expect(result.openingBalances).toEqual([]);
     expect(result.closingBalances).toEqual([]);
   });
+
+  // Correctness bugs found in review (#161): a malformed amount must not
+  // silently become a plausible-looking zero-value posting, and a #TRANS
+  // outside its voucher's `{`/`}` block must not be attributed to whichever
+  // voucher happened to be seen last.
+  describe('defensive parsing', () => {
+    it('throws on a malformed #TRANS amount instead of silently zeroing it', () => {
+      const sie = [
+        '#VER A 1 20260805 "Sale"',
+        '{',
+        '#TRANS 3000 {} not-a-number "" "Bad row" 0',
+        '}',
+      ].join('\r\n');
+
+      expect(() => parseSie(sie)).toThrow(/malformed amount/i);
+    });
+
+    it('throws on a non-finite #TRANS amount', () => {
+      const sie = [
+        '#VER A 1 20260805 "Sale"',
+        '{',
+        '#TRANS 3000 {} Infinity "" "Bad row" 0',
+        '}',
+      ].join('\r\n');
+
+      expect(() => parseSie(sie)).toThrow(/malformed amount/i);
+    });
+
+    it('throws on a malformed #IB balance', () => {
+      const sie = '#IB 0 1930 not-a-number 0';
+
+      expect(() => parseSie(sie)).toThrow(/malformed amount/i);
+    });
+
+    it('throws on a malformed #UB balance', () => {
+      const sie = '#UB 0 1930 not-a-number 0';
+
+      expect(() => parseSie(sie)).toThrow(/malformed amount/i);
+    });
+
+    it('does not attribute a #TRANS after the closing brace to the voucher that just closed', () => {
+      const sie = [
+        '#VER A 1 20260805 "Sale"',
+        '{',
+        '#TRANS 3000 {} -1000 "" "In block" 0',
+        '}',
+        // Stray/truncated line: no #VER re-opened, no `{` — must be ignored,
+        // not silently folded into voucher A/1 above.
+        '#TRANS 1930 {} 1000 "" "Orphan" 0',
+      ].join('\r\n');
+
+      const result = parseSie(sie);
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0]?.text).toBe('In block');
+    });
+
+    it('does not attribute a #TRANS between #VER and the opening brace', () => {
+      const sie = [
+        '#VER A 1 20260805 "Sale"',
+        // No `{` yet — a #TRANS here is outside the block even though
+        // currentVoucher is already set.
+        '#TRANS 3000 {} -1000 "" "Too early" 0',
+        '{',
+        '#TRANS 1930 {} 1000 "" "In block" 0',
+        '}',
+      ].join('\r\n');
+
+      const result = parseSie(sie);
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0]?.text).toBe('In block');
+    });
+
+    it('correctly separates transactions across two consecutive vouchers', () => {
+      const sie = [
+        '#VER A 1 20260805 "First"',
+        '{',
+        '#TRANS 3000 {} -1000 "" "" 0',
+        '}',
+        '#VER A 2 20260806 "Second"',
+        '{',
+        '#TRANS 3000 {} -500 "" "" 0',
+        '}',
+      ].join('\r\n');
+
+      const result = parseSie(sie);
+
+      expect(result.transactions).toHaveLength(2);
+      expect(result.transactions[0]?.voucherNumber).toBe('1');
+      expect(result.transactions[1]?.voucherNumber).toBe('2');
+    });
+  });
 });
 
 describe('fetchSie', () => {

--- a/tests/sie.test.ts
+++ b/tests/sie.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { FortnoxTransport } from '../src/fortnox-client.js';
+import { parseSie, fetchSie } from '../src/sie.js';
+
+const SAMPLE_SIE = [
+  '#FLAGGA 0',
+  '#FORMAT PC8',
+  '#SIETYP 4',
+  '#GEN 20260901',
+  '#FNR 285668',
+  '#FNAMN "Test AB"',
+  '#RAR 0 20260101 20261231',
+  '#RAR -1 20250101 20251231',
+  '#ORGNR 559001-6035',
+  '#KPTYP EUBAS97',
+  '#DIM 1 "Kostnadsstlle"',
+  '#DIM 6 "Projekt"',
+  '#KONTO 3000 "Sales, Sweden"',
+  '#SRU 3000 7410',
+  '#KONTO 4550 "Purchase of services"',
+  '#SRU 4550 7514',
+  '#KONTO 1930 "Bank"',
+  '#IB 0 1930 100000 0',
+  '#IB -1 1930 50000 0',
+  '#UB 0 1930 80000 0',
+  '#VER A 1 20260805 "Sale" 20260806',
+  '{',
+  '#TRANS 3000 {} -1000 "" "Sale to customer" 0',
+  '#TRANS 1930 {} 1000 "" "" 0',
+  '}',
+  '#VER A 2 20260806 "Purchase" 20260806',
+  '{',
+  '#TRANS 4550 {1 "2010" 6 "1001"} 500 "" "Consulting" 0',
+  '#TRANS 1930 {} -500 "" "" 0',
+  '}',
+].join('\r\n');
+
+describe('parseSie', () => {
+  it('extracts company metadata', () => {
+    const result = parseSie(SAMPLE_SIE);
+    expect(result.companyName).toBe('Test AB');
+    expect(result.organisationNumber).toBe('559001-6035');
+  });
+
+  it('pairs #KONTO descriptions with #SRU codes', () => {
+    const result = parseSie(SAMPLE_SIE);
+    expect(result.accounts.get('3000')).toEqual({
+      number: '3000',
+      description: 'Sales, Sweden',
+      sru: '7410',
+    });
+    expect(result.accounts.get('4550')?.sru).toBe('7514');
+  });
+
+  it('records an account with no #SRU line as having no sru field', () => {
+    const result = parseSie(SAMPLE_SIE);
+    expect(result.accounts.get('1930')?.sru).toBeUndefined();
+  });
+
+  it('parses #IB and #UB balances, keyed by year index', () => {
+    const result = parseSie(SAMPLE_SIE);
+    expect(result.openingBalances).toContainEqual({
+      account: '1930',
+      yearIndex: 0,
+      balance: 100000,
+    });
+    expect(result.openingBalances).toContainEqual({
+      account: '1930',
+      yearIndex: -1,
+      balance: 50000,
+    });
+    expect(result.closingBalances).toContainEqual({
+      account: '1930',
+      yearIndex: 0,
+      balance: 80000,
+    });
+  });
+
+  it('associates #TRANS lines with their enclosing #VER header', () => {
+    const result = parseSie(SAMPLE_SIE);
+    const saleLine = result.transactions.find((t) => t.account === '3000');
+    expect(saleLine).toMatchObject({
+      series: 'A',
+      voucherNumber: '1',
+      voucherDate: '20260805',
+      registrationDate: '20260806',
+      voucherDescription: 'Sale',
+      amount: -1000,
+      text: 'Sale to customer',
+    });
+  });
+
+  it('leaves text undefined when the #TRANS text field is empty', () => {
+    const result = parseSie(SAMPLE_SIE);
+    const bankLine = result.transactions.find((t) => t.account === '1930' && t.amount === 1000);
+    expect(bankLine?.text).toBeUndefined();
+  });
+
+  it('parses cost centre and project out of the dimension object list', () => {
+    const result = parseSie(SAMPLE_SIE);
+    const purchaseLine = result.transactions.find((t) => t.account === '4550');
+    expect(purchaseLine).toMatchObject({ costCenter: '2010', project: '1001', amount: 500 });
+  });
+
+  it('leaves costCenter/project undefined when the dimension list is empty', () => {
+    const result = parseSie(SAMPLE_SIE);
+    const saleLine = result.transactions.find((t) => t.account === '3000');
+    expect(saleLine?.costCenter).toBeUndefined();
+    expect(saleLine?.project).toBeUndefined();
+  });
+
+  it('produces exactly one transaction per #TRANS line, in file order', () => {
+    const result = parseSie(SAMPLE_SIE);
+    expect(result.transactions).toHaveLength(4);
+  });
+
+  it('ignores lines it does not recognize without throwing', () => {
+    expect(() => parseSie('#UNKNOWNTAG some stuff\r\n' + SAMPLE_SIE)).not.toThrow();
+  });
+
+  it('returns empty collections for an empty file', () => {
+    const result = parseSie('');
+    expect(result.accounts.size).toBe(0);
+    expect(result.transactions).toEqual([]);
+    expect(result.openingBalances).toEqual([]);
+    expect(result.closingBalances).toEqual([]);
+  });
+});
+
+describe('fetchSie', () => {
+  function stubTransport(buffer: Buffer): FortnoxTransport {
+    return {
+      request: vi.fn(),
+      requestWithMetadata: vi.fn(),
+      requestPdf: vi.fn(),
+      requestPdfFromMutation: vi.fn(),
+      requestFile: vi.fn().mockResolvedValue({ buffer, contentType: 'application/octet-stream' }),
+      fetchAllPages: vi.fn(),
+    } as FortnoxTransport;
+  }
+
+  it('requests sie/4 with fromdate/todate/financialyear query params', async () => {
+    const transport = stubTransport(Buffer.from(SAMPLE_SIE, 'latin1'));
+
+    await fetchSie(transport, { fromDate: '2026-08-01', toDate: '2026-08-31', financialYear: 12 });
+
+    expect(transport.requestFile).toHaveBeenCalledWith('sie/4', {
+      params: { fromdate: '2026-08-01', todate: '2026-08-31', financialyear: 12 },
+    });
+  });
+
+  it('decodes CP437 bytes correctly, unlike a naive latin1 decode', async () => {
+    // "Intäktsränta" with ä as CP437 byte 0x84 (which is a C1 control code
+    // in latin1 — decoding as latin1 would silently drop both ä's).
+    const cp437Bytes = Buffer.from([
+      0x23,
+      0x56,
+      0x45,
+      0x52,
+      0x20,
+      0x41,
+      0x20,
+      0x31,
+      0x20,
+      0x30,
+      0x20,
+      0x22,
+      0x49,
+      0x6e,
+      0x74,
+      0x84,
+      0x6b,
+      0x74,
+      0x73,
+      0x72,
+      0x84,
+      0x6e,
+      0x74,
+      0x61,
+      0x22,
+      0x0d,
+      0x0a,
+      0x7b,
+      0x0d,
+      0x0a,
+      0x7d, // #VER A 1 0 "Intäktsränta"\r\n{\r\n}
+    ]);
+    const transport = stubTransport(cp437Bytes);
+
+    const result = await fetchSie(transport, {});
+
+    expect(result.transactions).toEqual([]); // no #TRANS lines, just checking decode
+    // Re-parse the same bytes as latin1 to prove the naive decode would have
+    // silently dropped the ä's, so this test is actually exercising the fix.
+    expect(cp437Bytes.toString('latin1')).not.toContain('Intäktsränta');
+  });
+
+  it('recovers the voucher description text via CP437 decoding end-to-end', async () => {
+    const line = '#VER A 1 20260805 "Intäktsränta"\r\n{\r\n#TRANS 8310 {} 100 "" "" 0\r\n}';
+    // Encode manually: ä -> 0x84 in CP437.
+    const bytes = Buffer.from(line.split('').map((ch) => (ch === 'ä' ? 0x84 : ch.charCodeAt(0))));
+    const transport = stubTransport(bytes);
+
+    const result = await fetchSie(transport, {});
+
+    expect(result.transactions[0]?.voucherDescription).toBe('Intäktsränta');
+  });
+});

--- a/tests/tools/general-ledger.test.ts
+++ b/tests/tools/general-ledger.test.ts
@@ -24,17 +24,35 @@ const SAMPLE_SIE = [
   '}',
 ].join('\r\n');
 
+// getGeneralLedger now resolves the financial year itself when the caller
+// doesn't pass one (see operations/general-ledger.ts), which means every call
+// here makes a preceding GET financialyears before the sie/4 fetch. Branch on
+// the URL so both are served correctly regardless of call order.
 function mockSieFetch(text: string = SAMPLE_SIE) {
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    headers: new Headers({ 'content-type': 'application/octet-stream' }),
-    arrayBuffer: () => {
-      const bytes = Buffer.from(text, 'latin1');
-      return Promise.resolve(
-        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
-      );
-    },
+  global.fetch = vi.fn().mockImplementation((url: unknown) => {
+    if (String(url).includes('financialyears')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              FinancialYears: [{ Id: 4, FromDate: '2026-01-01', ToDate: '2026-12-31' }],
+            }),
+          ),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/octet-stream' }),
+      arrayBuffer: () => {
+        const bytes = Buffer.from(text, 'latin1');
+        return Promise.resolve(
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+        );
+      },
+    });
   });
 }
 
@@ -74,10 +92,14 @@ describe('fortnox_general_ledger', () => {
     expect(text).toContain('2026-08-05');
     expect(text).toContain('2026-08-06');
     expect(text).toContain('Sale to customer');
-    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toContain('sie/4');
-    expect(calledUrl).toContain('fromdate=2026-08-01');
-    expect(calledUrl).toContain('todate=2026-08-31');
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string][];
+    const sieCall = calls.map(([url]) => url).find((url) => url.includes('sie/4'));
+    expect(sieCall).toContain('fromdate=2026-08-01');
+    expect(sieCall).toContain('todate=2026-08-31');
+    // financialYear was not given, so it must have been resolved rather than
+    // omitted (letting Fortnox infer it, which is not reliable — see the
+    // operations-layer fix).
+    expect(sieCall).toContain('financialyear=4');
   });
 
   it('filters by account when given', async () => {

--- a/tests/tools/general-ledger.test.ts
+++ b/tests/tools/general-ledger.test.ts
@@ -24,18 +24,28 @@ const SAMPLE_SIE = [
   '}',
 ].join('\r\n');
 
-function mockSieFetch() {
+function mockSieFetch(text: string = SAMPLE_SIE) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
     headers: new Headers({ 'content-type': 'application/octet-stream' }),
     arrayBuffer: () => {
-      const bytes = Buffer.from(SAMPLE_SIE, 'latin1');
+      const bytes = Buffer.from(text, 'latin1');
       return Promise.resolve(
         bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
       );
     },
   });
+}
+
+// One voucher (one #TRANS line) per posting, so `count` postings unambiguously
+// means `count` general-ledger rows.
+function generateLargeSie(count: number): string {
+  const lines = ['#FORMAT PC8', '#SIETYP 4', '#KONTO 3000 "Sales, Sweden"'];
+  for (let i = 1; i <= count; i++) {
+    lines.push(`#VER A ${i} 20260805 "Row ${i}"`, '{', `#TRANS 3000 {} -${i} "" "" 0`, '}');
+  }
+  return lines.join('\r\n');
 }
 
 async function setupClientServer() {
@@ -76,18 +86,15 @@ describe('fortnox_general_ledger', () => {
 
     const result = await client.callTool({
       name: 'fortnox_general_ledger',
-      arguments: {
-        fromDate: '2026-08-01',
-        toDate: '2026-08-31',
-        account: '1930',
-        includeRaw: true,
-      },
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', account: '1930' },
     });
 
     const text = (result.content as { type: string; text: string }[])[0].text;
-    const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
-    expect(parsed).toHaveLength(2);
-    expect(parsed.every((r: { account: string }) => r.account === '1930')).toBe(true);
+    // Both #TRANS lines against account 1930 (one per voucher) should survive
+    // the filter; the account-3000 lines should not appear.
+    expect(text).toContain('1930');
+    expect(text).not.toContain('3000');
+    expect(text).toContain('(2 total)');
   });
 
   it('filters by voucher series when given', async () => {
@@ -96,13 +103,29 @@ describe('fortnox_general_ledger', () => {
 
     const result = await client.callTool({
       name: 'fortnox_general_ledger',
-      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', series: 'B', includeRaw: true },
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', series: 'B' },
     });
 
     const text = (result.content as { type: string; text: string }[])[0].text;
-    const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
-    expect(parsed).toHaveLength(2);
-    expect(parsed.every((r: { series: string }) => r.series === 'B')).toBe(true);
+    expect(text).toContain('B5');
+    expect(text).not.toContain('A1');
+    expect(text).toContain('(2 total)');
+  });
+
+  // Review #161: includeRaw claimed to return raw Fortnox JSON, but this tool
+  // has no such thing — the data is parsed from a SIE text export, not a
+  // Fortnox JSON response. The option no longer exists; a caller passing it
+  // gets the strict-schema rejection every other unknown argument gets.
+  it('no longer accepts includeRaw', async () => {
+    mockSieFetch();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_general_ledger',
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', includeRaw: true },
+    });
+
+    expect(result.isError).toBe(true);
   });
 
   it('is read-only — no confirmation required', async () => {
@@ -115,5 +138,89 @@ describe('fortnox_general_ledger', () => {
     });
 
     expect(result.isError).toBeFalsy();
+  });
+
+  // Review #161: an unbounded response for a real full-year, high-volume
+  // company (~20k postings, ~1.78 MB formatted) can exceed MCP/client/model
+  // limits. The tool must impose a deterministic bound and report enough for
+  // a caller to page through the rest.
+  describe('pagination bounds a large result', () => {
+    it('caps the response at the default page size and reports the true total', async () => {
+      mockSieFetch(generateLargeSie(1200));
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_general_ledger',
+        arguments: { fromDate: '2026-01-01', toDate: '2026-12-31' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      // 500 is the documented default page size. The text column isn't the
+      // last one (debit/credit follow it, padded), so match on the trailing
+      // padding space rather than a line end — and to disambiguate "Row 1"
+      // from "Row 10"/"Row 100", which would otherwise also satisfy a bare
+      // substring check.
+      expect(text).toContain('Row 1 ');
+      expect(text).toContain('Row 500');
+      expect(text).not.toContain('Row 501');
+      expect(text).toContain('Page 1/3 (1200 total)');
+    });
+
+    it('returns the next page of rows when asked', async () => {
+      mockSieFetch(generateLargeSie(1200));
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_general_ledger',
+        arguments: { fromDate: '2026-01-01', toDate: '2026-12-31', page: 2 },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Row 501');
+      expect(text).toContain('Row 1000');
+      expect(text).not.toContain('Row 500 ');
+      expect(text).toContain('Page 2/3 (1200 total)');
+    });
+
+    it('honors a smaller explicit limit', async () => {
+      mockSieFetch(generateLargeSie(30));
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_general_ledger',
+        arguments: { fromDate: '2026-01-01', toDate: '2026-12-31', limit: 10 },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Row 1 ');
+      expect(text).toContain('Row 10');
+      expect(text).not.toContain('Row 11');
+      expect(text).toContain('Page 1/3 (30 total)');
+    });
+
+    it('rejects a limit above the documented maximum', async () => {
+      mockSieFetch(generateLargeSie(5));
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_general_ledger',
+        arguments: { fromDate: '2026-01-01', toDate: '2026-12-31', limit: 100000 },
+      });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('reports a single full page when everything fits', async () => {
+      mockSieFetch();
+      const { client } = await setupClientServer();
+
+      const result = await client.callTool({
+        name: 'fortnox_general_ledger',
+        arguments: { fromDate: '2026-08-01', toDate: '2026-08-31' },
+      });
+
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('Page 1/1 (4 total)');
+    });
   });
 });

--- a/tests/tools/general-ledger.test.ts
+++ b/tests/tools/general-ledger.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer } from '../../src/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../src/auth.js', () => ({
+  getValidToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+const SAMPLE_SIE = [
+  '#FORMAT PC8',
+  '#SIETYP 4',
+  '#KONTO 3000 "Sales, Sweden"',
+  '#KONTO 1930 "Bank"',
+  '#VER A 1 20260805 "Sale"',
+  '{',
+  '#TRANS 3000 {} -1000 "" "Sale to customer" 0',
+  '#TRANS 1930 {} 1000 "" "" 0',
+  '}',
+  '#VER B 5 20260806 "Other sale"',
+  '{',
+  '#TRANS 3000 {} -50 "" "" 0',
+  '#TRANS 1930 {} 50 "" "" 0',
+  '}',
+].join('\r\n');
+
+function mockSieFetch() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/octet-stream' }),
+    arrayBuffer: () => {
+      const bytes = Buffer.from(SAMPLE_SIE, 'latin1');
+      return Promise.resolve(
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      );
+    },
+  });
+}
+
+async function setupClientServer() {
+  const server = createServer();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+describe('fortnox_general_ledger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists all transaction rows for the date range', async () => {
+    mockSieFetch();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_general_ledger',
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31' },
+    });
+
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('2026-08-05');
+    expect(text).toContain('2026-08-06');
+    expect(text).toContain('Sale to customer');
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('sie/4');
+    expect(calledUrl).toContain('fromdate=2026-08-01');
+    expect(calledUrl).toContain('todate=2026-08-31');
+  });
+
+  it('filters by account when given', async () => {
+    mockSieFetch();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_general_ledger',
+      arguments: {
+        fromDate: '2026-08-01',
+        toDate: '2026-08-31',
+        account: '1930',
+        includeRaw: true,
+      },
+    });
+
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.every((r: { account: string }) => r.account === '1930')).toBe(true);
+  });
+
+  it('filters by voucher series when given', async () => {
+    mockSieFetch();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_general_ledger',
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', series: 'B', includeRaw: true },
+    });
+
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    const parsed = JSON.parse(text.split('Raw JSON:\n')[1]);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.every((r: { series: string }) => r.series === 'B')).toBe(true);
+  });
+
+  it('is read-only — no confirmation required', async () => {
+    mockSieFetch();
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: 'fortnox_general_ledger',
+      arguments: { fromDate: '2026-08-01', toDate: '2026-08-31' },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `fortnox_general_ledger` / `noxctl general-ledger list --from <date> --to <date>`: bookkeeping transactions with real amounts (debit/credit), one row per posting, for a date range.
- Backed by `GET /3/sie/{Type}` (SIE4) - Fortnox's standard Swedish bulk accounting export - instead of walking vouchers one by one. Adds a small parser for it at `src/sie.ts`.
- Also fixes a real encoding bug found along the way: SIE declares `#FORMAT PC8` (CP437), and decoding it as Latin-1 silently drops every å/ä/ö instead of rendering the wrong character. Verified against live payroll data ("Loneutbetalning ... anstalld") before and after.

## Why
This is purely a performance fix, aimed at higher-volume companies. `fortnox_income_statement`, `fortnox_balance_sheet` and `fortnox_tax_report` all sum account movements by listing every voucher in the period and then fetching each one's rows individually - one HTTP request per voucher. That is fine for a handful of vouchers, but times out entirely on a real company: I confirmed live that a single month (645 vouchers) already times out the existing way, for a company doing ~10,900 vouchers/year.

The public v3 API has no bulk endpoint for account totals or a voucher list with amounts - I checked the full spec. SIE4 (`/3/sie/4`) is the only way I could find to get this data back in a reasonable time: one streamed file with the whole period's chart of accounts, opening/closing balances, and every transaction line. Full-year export + parse for the same ~10,900-voucher company: about 2 seconds, versus a timeout the old way.

We also poked at a third-party tool (Sheety) that does something similar directly against Fortnox and is fast even for a full year with amounts included - our working guess, from the response shape and timing, is that it is reading the same SIE export rather than the per-voucher REST path, though we have not seen its source.

## Future development
The obvious next step is doing the same rewrite for `fortnox_income_statement`/`fortnox_balance_sheet` (both still voucher-walking, and both group accounts by hardcoded number ranges instead of the official Skatteverket SRU codes Fortnox already returns per account - noted in TODO.md). But it may not be necessary as a built-in tool at all: given `fortnox_general_ledger`, an LLM with code execution (Claude Code, or similar) can already build a correct P&L or balance sheet on demand from the raw ledger data, grouped however is useful for the question being asked, rather than a fixed report shape. That holds up specifically when the consumer can run code to do the summation - asking a model to manually total thousands of transaction lines in a chat context is a different story and not something I would trust. Worth keeping in mind as a scope call rather than assuming the report tools are still needed.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] Manual live verification via MCP and CLI (`general-ledger list`) against real Fortnox data, including the CP437 fix against real Swedish payroll text
- [x] CI (`npm test`) - pending, could not run locally (Windows Application Control policy blocks vitest's native `rolldown` binding on this machine)