### PR TITLE
fix(deps): remediate production audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,9 +1665,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,9 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
-    "ip-address": "10.3.1"
+    "ip-address": "10.3.1",
+    "qs": "6.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- update the existing fast-uri override from 3.1.5 to patched 3.1.6
- add a qs 6.16.0 override for the SDK Express dependency chain
- regenerate the lockfile without changing the MCP SDK or other direct dependencies

## Context
New advisories published on 2026-09-02 made the repository-wide production audit fail. This is independent of PR #161, which does not change package.json or package-lock.json.

## Verification
- npm audit --omit=dev: 0 vulnerabilities
- npm run verify: 92 files, 1,056 tests passed
- npm run check:release: passed, including offline API coverage, embedded consumer, production audit, and package dry run
- independent read-only patch review: no findings