### PR TITLE
fix: preserve ledger amounts and SRU metadata, validate year IDs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,29 @@
 # Project Status
 
+## Issue #165 — 2026-09-06
+
+- Worktree `/private/tmp/noxctl-165`, branch `fix/165-general-ledger-followups`,
+  based on merged PR #161 (`c1527727569aecf4306c7d2f71718942397c1500`).
+- Implemented complete ledger debit/credit display, positive safe integer
+  financial-year validation at CLI/MCP/operations boundaries (including lookup
+  results), and SRU preservation when account records arrive out of order.
+- Regression tests reproduced the defects before fixes. `npm run verify` passes:
+  version consistency, lint, formatting, build, and 1,170 tests in 96 files.
+  The built CLI also rejects `--year 4.5` locally with exit code 1.
+- M5 `qwen3-coder-next-80b` provided a partially adopted SRU proposal; it reached
+  its time cap before testing. The conductor reduced duplicate tests and
+  verified the fix locally.
+- Independent review: Claude Opus 5 found no correctness/regression defects.
+  Accepted the fixed-width padding cost to keep the change local to the ledger;
+  broader formatter changes and malformed-record behavior are out of scope.
+  Zod 4 enforces safe integers, and built-CLI validation preserves JSON errors.
+- Still open: confirm terminal-backslash encoding with a synthetic/non-sensitive
+  **actual Fortnox export**. No such fixture was found in the repository; the
+  owner has been asked for its path. Existing escaped-quote and literal-backslash
+  regressions pass. Escape semantics remain unchanged. Do not close #165 yet.
+
+## Earlier handoff (historical)
+
 **Last session:** 2026-08-29
 **Branch:** `fix/117-keychain-recovery`
 **Published:** `v0.7.4` on GitHub and `noxctl@0.7.4` on npm (both verified 2026-08-28)

--- a/src/cli-validators.ts
+++ b/src/cli-validators.ts
@@ -1,0 +1,10 @@
+import { InvalidArgumentError } from 'commander';
+
+/** Commander passes the previous option value as its second parser argument. */
+export function parsePositiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!/^\d+$/.test(value) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('Expected a positive safe integer.');
+  }
+  return parsed;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command, Option } from 'commander';
+import { parsePositiveInteger } from './cli-validators.js';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import {
@@ -2795,7 +2796,7 @@ generalLedger
   .option(
     '--year <number>',
     'Financial year (optional; resolved automatically from --from otherwise)',
-    parseInt,
+    parsePositiveInteger,
   )
   .option('--account <number>', 'Filter to one account number')
   .option('--series <code>', 'Filter to one voucher series (e.g. "A")')

--- a/src/operations/general-ledger.ts
+++ b/src/operations/general-ledger.ts
@@ -48,7 +48,14 @@ export function createGeneralLedgerOperations(transport: FortnoxTransport) {
         `No financial year found covering ${fromDate}. Pass financialYear explicitly.`,
       );
     }
-    return Number(list[0]!.Id);
+    const rawId = list[0]!.Id;
+    const id = typeof rawId === 'string' && /^\d+$/.test(rawId) ? Number(rawId) : rawId;
+    if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
+      throw new Error(
+        'Invalid financial year ID returned by Fortnox. Pass financialYear explicitly.',
+      );
+    }
+    return id;
   }
 
   // The flat, dated, per-account transaction list every other report in this
@@ -56,6 +63,12 @@ export function createGeneralLedgerOperations(transport: FortnoxTransport) {
   // range: fetchSie proxies straight to Fortnox's SIE export, which needs
   // one to scope the file it generates.
   async function getGeneralLedger(params: GeneralLedgerParams): Promise<GeneralLedgerEntry[]> {
+    if (
+      params.financialYear !== undefined &&
+      (!Number.isSafeInteger(params.financialYear) || params.financialYear <= 0)
+    ) {
+      throw new Error('financialYear must be a positive safe integer.');
+    }
     const financialYear = params.financialYear ?? (await resolveFinancialYear(params.fromDate));
     const parsed = await fetchSie(transport, { ...params, financialYear });
     return parsed.transactions

--- a/src/sie.ts
+++ b/src/sie.ts
@@ -181,7 +181,9 @@ export function parseSie(text: string): ParsedSie {
       organisationNumber = tokenize(line)[1];
     } else if (tag === 'KONTO') {
       const [, number, description] = tokenize(line);
-      if (number) accounts.set(number, { number, description: description ?? '' });
+      if (number) {
+        accounts.set(number, { ...accounts.get(number), number, description: description ?? '' });
+      }
     } else if (tag === 'SRU') {
       const [, number, sru] = tokenize(line);
       if (number) {

--- a/src/tools/general-ledger.ts
+++ b/src/tools/general-ledger.ts
@@ -28,6 +28,8 @@ export function registerGeneralLedgerTools(
       toDate: z.string().describe('Till datum (YYYY-MM-DD)'),
       financialYear: z
         .number()
+        .int()
+        .positive()
         .optional()
         .describe(
           'Räkenskapsår-ID (från fortnox_list_financialyears) — löses annars upp automatiskt från fromDate',

--- a/src/views.ts
+++ b/src/views.ts
@@ -647,7 +647,9 @@ export const absenceTransactionDetailColumns: Column[] = [
   { key: 'Project', header: 'Project', width: 12 },
 ];
 
-// --- General ledger (target ≤80 cols) ---
+// --- General ledger ---
+// Our SIE parser accepts at most MAX_SAFE_INTEGER cents: 14 whole digits + dot + 2 decimals.
+// Reserve 17 characters so every accepted debit/credit remains complete.
 
 export const generalLedgerColumns: Column[] = [
   { key: 'transactionDate', header: 'Date', width: 10 },
@@ -659,8 +661,8 @@ export const generalLedgerColumns: Column[] = [
   },
   { key: 'account', header: 'Account', width: 8, align: 'right' },
   { key: 'text', header: 'Text', width: 28 },
-  { key: 'debit', header: 'Debit', width: 12, align: 'right', format: currency },
-  { key: 'credit', header: 'Credit', width: 12, align: 'right', format: currency },
+  { key: 'debit', header: 'Debit', width: 17, align: 'right', format: currency },
+  { key: 'credit', header: 'Credit', width: 17, align: 'right', format: currency },
 ];
 
 // Schedule times

--- a/tests/cli-validators.test.ts
+++ b/tests/cli-validators.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { parsePositiveInteger } from '../src/cli-validators.js';
+
+describe('positive integer CLI option', () => {
+  it.each(['abc', '', '0', '-1', '4.5', '12abc', '1e2', '0x10', '9007199254740992'])(
+    'rejects %s',
+    (value) => {
+      expect(() => parsePositiveInteger(value)).toThrow(/positive safe integer/i);
+    },
+  );
+  it('uses decimal parsing when Commander passes the previous option value', () => {
+    const command = new Command().option('--year <number>', 'Financial year', parsePositiveInteger);
+    command.parse(['--year', '12', '--year', '12'], { from: 'user' });
+    expect(command.opts().year).toBe(12);
+  });
+});

--- a/tests/operations/general-ledger.test.ts
+++ b/tests/operations/general-ledger.test.ts
@@ -39,6 +39,52 @@ function stubTransport(): FortnoxTransport {
 }
 
 describe('getGeneralLedger', () => {
+  it.each([NaN, Infinity, 0, -1, 4.5, 9007199254740992, null, '4'])(
+    'rejects invalid explicit financialYear %s without transport',
+    async (financialYear) => {
+      const transport = stubTransport();
+      const { getGeneralLedger } = createGeneralLedgerOperations(transport);
+      await expect(
+        getGeneralLedger({
+          fromDate: '2026-08-01',
+          toDate: '2026-08-31',
+          financialYear: financialYear as number,
+        }),
+      ).rejects.toThrow(/financialYear.*positive safe integer/i);
+      expect(transport.request).not.toHaveBeenCalled();
+      expect(transport.requestFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([undefined, null, '', 'abc', '4.5', '0x10', true, 0, -1, 4.5, 9007199254740992])(
+    'rejects invalid resolved year ID %s before SIE export',
+    async (Id) => {
+      const transport = stubTransport();
+      vi.mocked(transport.request).mockResolvedValue({
+        FinancialYears: [{ Id, FromDate: '2026-01-01', ToDate: '2026-12-31' }],
+      });
+      const { getGeneralLedger } = createGeneralLedgerOperations(transport);
+      await expect(
+        getGeneralLedger({ fromDate: '2026-08-01', toDate: '2026-08-31' }),
+      ).rejects.toThrow(/financial year.*ID/i);
+      expect(transport.requestFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts a decimal string ID from financial-year lookup', async () => {
+    const transport = stubTransport();
+    vi.mocked(transport.request).mockResolvedValue({
+      FinancialYears: [{ Id: '12', FromDate: '2026-01-01', ToDate: '2026-12-31' }],
+    });
+    await createGeneralLedgerOperations(transport).getGeneralLedger({
+      fromDate: '2026-08-01',
+      toDate: '2026-08-31',
+    });
+    expect(transport.requestFile).toHaveBeenCalledWith('sie/4', {
+      params: { fromdate: '2026-08-01', todate: '2026-08-31', financialyear: 12 },
+    });
+  });
+
   it('requests sie/4 for the given date range', async () => {
     const transport = stubTransport();
     const { getGeneralLedger } = createGeneralLedgerOperations(transport);

--- a/tests/sie.test.ts
+++ b/tests/sie.test.ts
@@ -36,6 +36,24 @@ const SAMPLE_SIE = [
 ].join('\r\n');
 
 describe('parseSie', () => {
+  it('preserves an SRU code declared before the account description', () => {
+    const result = parseSie('#SRU 3000 7410\n#KONTO 3000 "Sales"');
+    expect(result.accounts.get('3000')).toEqual({
+      number: '3000',
+      description: 'Sales',
+      sru: '7410',
+    });
+  });
+
+  it('preserves the SRU code when an account description is replaced', () => {
+    const result = parseSie('#KONTO 3000 "Initial"\n#SRU 3000 7410\n#KONTO 3000 "Updated"');
+    expect(result.accounts.get('3000')).toEqual({
+      number: '3000',
+      description: 'Updated',
+      sru: '7410',
+    });
+  });
+
   it('extracts company metadata', () => {
     const result = parseSie(SAMPLE_SIE);
     expect(result.companyName).toBe('Test AB');

--- a/tests/tools/general-ledger.test.ts
+++ b/tests/tools/general-ledger.test.ts
@@ -79,6 +79,46 @@ describe('fortnox_general_ledger', () => {
     vi.restoreAllMocks();
   });
 
+  it.each(['1234567890.12', '90071992547409.00'])(
+    'keeps large debit and credit %s complete in the MCP table',
+    async (amount) => {
+      mockSieFetch(SAMPLE_SIE.replaceAll('1000', amount));
+      const { client, server } = await setupClientServer();
+      try {
+        const result = await client.callTool({
+          name: 'fortnox_general_ledger',
+          arguments: { fromDate: '2026-08-01', toDate: '2026-08-31' },
+        });
+        const text = (result.content as { text: string }[])[0].text;
+        expect(result.isError).not.toBe(true);
+        expect(text.split(amount)).toHaveLength(3);
+        expect(text).not.toContain('…');
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    },
+  );
+
+  it.each([0, -1, 4.5, 9007199254740992])(
+    'rejects invalid financialYear %s before fetching',
+    async (financialYear) => {
+      mockSieFetch();
+      const { client, server } = await setupClientServer();
+      try {
+        const result = await client.callTool({
+          name: 'fortnox_general_ledger',
+          arguments: { fromDate: '2026-08-01', toDate: '2026-08-31', financialYear },
+        });
+        expect(result.isError).toBe(true);
+        expect(global.fetch).not.toHaveBeenCalled();
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    },
+  );
+
   it('lists all transaction rows for the date range', async () => {
     mockSieFetch();
     const { client } = await setupClientServer();


### PR DESCRIPTION
General-ledger MCP tables now preserve complete debit/credit amounts up to the parser’s accepted limit. Financial-year identifiers must be positive safe integers at the CLI, MCP, and operations boundaries, including IDs resolved from Fortnox. SIE account descriptions now retain an SRU code supplied before or between account records.

Regression coverage includes billion-scale and maximum-width amounts, malformed and repeated CLI year options, invalid MCP and resolved year IDs, and both SRU record-order cases.

Independent review: Claude Opus 5 found no correctness or regression defects. The fixed column-width padding cost is accepted to keep the change scoped to the ledger.

Validation: `npm run verify` passes (1,170 tests in 96 files), and the built CLI rejects `--year 4.5` with exit code 1 before transport.

Partially addresses #165. Terminal-backslash encoding still needs a synthetic/non-sensitive actual Fortnox export; no fixture is available locally. Escape semantics are unchanged and existing literal-backslash/escaped-quote tests pass. This PR must not auto-close #165.
