### PR TITLE
fix: stop accepting read-only Times on supplier invoice accruals

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5254,7 +5254,10 @@ for (const definition of accrualResources) {
     .action(async (opts) => {
       const operations = await import('./operations/accruals.js');
       const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
-      const fields = JSON.parse(raw) as Record<string, unknown>;
+      const fields = operations.prepareAccrualFields(
+        definition.envelope,
+        JSON.parse(raw) as Record<string, unknown>,
+      );
       if (
         !(await confirmMutation(`Create ${definition.command}`, opts, {
           [definition.envelope]: fields,
@@ -5272,7 +5275,10 @@ for (const definition of accrualResources) {
     .action(async (documentNumber: string, opts) => {
       const operations = await import('./operations/accruals.js');
       const raw = opts.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(opts.input, 'utf-8');
-      const fields = JSON.parse(raw) as Record<string, unknown>;
+      const fields = operations.prepareAccrualFields(
+        definition.envelope,
+        JSON.parse(raw) as Record<string, unknown>,
+      );
       if (
         !(await confirmMutation(`Update ${definition.command} ${documentNumber}`, opts, {
           [definition.envelope]: fields,

--- a/src/operations/accruals.ts
+++ b/src/operations/accruals.ts
@@ -5,12 +5,24 @@ interface AccrualDefinition {
   endpoint: string;
   listKey: string;
   singleKey: string;
+  readOnlyFields?: readonly string[];
 }
 
 function createAccrualResourceOperations(
   transport: FortnoxTransport,
   definition: AccrualDefinition,
 ) {
+  // Server-derived fields Fortnox rejects on write ("Fältet Times är endast
+  // läsbart"), even though its own spec lists them as required on the payload.
+  // Stripping them lets a `get` response be fed back into create/update
+  // unchanged; Fortnox recomputes them from StartDate/EndDate and Period.
+  function stripReadOnlyFields(fields: Record<string, unknown>): Record<string, unknown> {
+    if (!definition.readOnlyFields) return fields;
+    const writable = { ...fields };
+    for (const field of definition.readOnlyFields) delete writable[field];
+    return writable;
+  }
+
   async function list() {
     const raw = await transport.request<Record<string, unknown>>(definition.endpoint);
     return {
@@ -29,7 +41,7 @@ function createAccrualResourceOperations(
   async function create(fields: Record<string, unknown>) {
     const raw = await transport.request<Record<string, unknown>>(definition.endpoint, {
       method: 'POST',
-      body: { [definition.singleKey]: fields },
+      body: { [definition.singleKey]: stripReadOnlyFields(fields) },
     });
     return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
   }
@@ -37,7 +49,7 @@ function createAccrualResourceOperations(
   async function update(documentNumber: string, fields: Record<string, unknown>) {
     const raw = await transport.request<Record<string, unknown>>(
       `${definition.endpoint}/${documentSegment(documentNumber)}`,
-      { method: 'PUT', body: { [definition.singleKey]: fields } },
+      { method: 'PUT', body: { [definition.singleKey]: stripReadOnlyFields(fields) } },
     );
     return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
   }
@@ -61,6 +73,7 @@ export function createAccrualOperations(transport: FortnoxTransport) {
     endpoint: 'supplierinvoiceaccruals',
     listKey: 'SupplierInvoiceAccruals',
     singleKey: 'SupplierInvoiceAccrual',
+    readOnlyFields: ['Times'],
   });
   const contracts = createAccrualResourceOperations(transport, {
     endpoint: 'contractaccruals',

--- a/src/operations/accruals.ts
+++ b/src/operations/accruals.ts
@@ -5,24 +5,24 @@ interface AccrualDefinition {
   endpoint: string;
   listKey: string;
   singleKey: string;
-  readOnlyFields?: readonly string[];
+}
+
+// Share write normalization with CLI previews and confirmation prompts.
+// Fortnox derives supplier-invoice Times from the schedule and rejects it on write.
+export function prepareAccrualFields(
+  envelope: string,
+  fields: Record<string, unknown>,
+): Record<string, unknown> {
+  if (envelope !== 'SupplierInvoiceAccrual') return fields;
+  const writable = { ...fields };
+  delete writable.Times;
+  return writable;
 }
 
 function createAccrualResourceOperations(
   transport: FortnoxTransport,
   definition: AccrualDefinition,
 ) {
-  // Server-derived fields Fortnox rejects on write ("Fältet Times är endast
-  // läsbart"), even though its own spec lists them as required on the payload.
-  // Stripping them lets a `get` response be fed back into create/update
-  // unchanged; Fortnox recomputes them from StartDate/EndDate and Period.
-  function stripReadOnlyFields(fields: Record<string, unknown>): Record<string, unknown> {
-    if (!definition.readOnlyFields) return fields;
-    const writable = { ...fields };
-    for (const field of definition.readOnlyFields) delete writable[field];
-    return writable;
-  }
-
   async function list() {
     const raw = await transport.request<Record<string, unknown>>(definition.endpoint);
     return {
@@ -41,7 +41,7 @@ function createAccrualResourceOperations(
   async function create(fields: Record<string, unknown>) {
     const raw = await transport.request<Record<string, unknown>>(definition.endpoint, {
       method: 'POST',
-      body: { [definition.singleKey]: stripReadOnlyFields(fields) },
+      body: { [definition.singleKey]: prepareAccrualFields(definition.singleKey, fields) },
     });
     return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
   }
@@ -49,7 +49,10 @@ function createAccrualResourceOperations(
   async function update(documentNumber: string, fields: Record<string, unknown>) {
     const raw = await transport.request<Record<string, unknown>>(
       `${definition.endpoint}/${documentSegment(documentNumber)}`,
-      { method: 'PUT', body: { [definition.singleKey]: stripReadOnlyFields(fields) } },
+      {
+        method: 'PUT',
+        body: { [definition.singleKey]: prepareAccrualFields(definition.singleKey, fields) },
+      },
     );
     return (raw[definition.singleKey] ?? {}) as Record<string, unknown>;
   }
@@ -73,7 +76,6 @@ export function createAccrualOperations(transport: FortnoxTransport) {
     endpoint: 'supplierinvoiceaccruals',
     listKey: 'SupplierInvoiceAccruals',
     singleKey: 'SupplierInvoiceAccrual',
-    readOnlyFields: ['Times'],
   });
   const contracts = createAccrualResourceOperations(transport, {
     endpoint: 'contractaccruals',

--- a/src/tools/accruals.ts
+++ b/src/tools/accruals.ts
@@ -84,7 +84,13 @@ export const ACCRUAL_TOOL_DEFINITIONS: readonly AccrualToolDefinition[] = [
       SupplierInvoiceNumber: z.number().int(),
       CostAccount: Account,
       Period: InvoicePeriod,
-      Times: z.number().int(),
+      // Times is deliberately NOT declared here: Fortnox rejects it on write
+      // ("Fältet Times är endast läsbart") and computes it from StartDate/
+      // EndDate and Period — the web UI shows it as a derived "Tot.antal" with
+      // no input field. operations/accruals.ts strips it defensively too, so a
+      // `get` response fed straight back into create/update still works, but
+      // the tool schema should not offer a field that would then be silently
+      // dropped a second time.
       SupplierInvoiceAccrualRows: z.array(AccrualRow).min(2),
     },
   },

--- a/tests/cli-accruals.test.ts
+++ b/tests/cli-accruals.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { FortnoxTransport } from '../src/fortnox-client.js';
+import { createAccrualOperations } from '../src/operations/accruals.js';
+
+const CLI_PATH = path.resolve('dist/cli.js');
+const CLI_TIMEOUT_MS = 30_000;
+
+const supplierInvoiceAccrual = {
+  AccrualAccount: 1790,
+  CostAccount: 6540,
+  Description: 'Annual service',
+  EndDate: '2026-12-31',
+  Period: 'MONTHLY',
+  StartDate: '2026-01-01',
+  SupplierInvoiceAccrualRows: [
+    { Account: 6540, Debit: 100, CostCenter: 'A1' },
+    { Account: 1790, Credit: 100, Project: 'P1' },
+  ],
+  SupplierInvoiceNumber: 42,
+  Times: 12,
+  Total: 1200,
+  VATIncluded: true,
+} as const;
+
+function parsePreview(output: string): Record<string, unknown> {
+  const marker = 'Request payload:\n';
+  const markerStart = output.indexOf(marker);
+  expect(markerStart).toBeGreaterThanOrEqual(0);
+  return JSON.parse(output.slice(markerStart + marker.length)) as Record<string, unknown>;
+}
+
+function runDryRun(
+  resource: 'invoice-accruals' | 'supplier-invoice-accruals' | 'contract-accruals',
+  action: 'create' | 'update',
+  inputMode: 'file' | 'stdin',
+  input: Record<string, unknown>,
+): string {
+  const tmpHome = mkdtempSync(path.join(tmpdir(), 'noxctl-169-home-'));
+  try {
+    const args = [CLI_PATH, resource, action];
+    if (action === 'update') args.push('7');
+    const inputText = JSON.stringify(input);
+    if (inputMode === 'file') {
+      const inputFile = path.join(tmpHome, 'accrual.json');
+      writeFileSync(inputFile, `${inputText}\n`);
+      args.push('--input', inputFile);
+    } else {
+      args.push('--input', '-');
+    }
+    args.push('--dry-run');
+
+    const options: ExecFileSyncOptions = {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome, NOXCTL_PROFILE: 'default' },
+      input: inputMode === 'stdin' ? inputText : undefined,
+      timeout: CLI_TIMEOUT_MS,
+    };
+    return execFileSync('node', args, options) as string;
+  } finally {
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
+}
+
+describe('supplier invoice accrual CLI previews', () => {
+  it.each([
+    { action: 'create', inputMode: 'file' },
+    { action: 'create', inputMode: 'stdin' },
+    { action: 'update', inputMode: 'file' },
+    { action: 'update', inputMode: 'stdin' },
+  ] as const)(
+    'previews the same writable $action request for $inputMode input',
+    async ({ action, inputMode }) => {
+      const request = vi.fn().mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7 } });
+      const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+      const input = structuredClone(supplierInvoiceAccrual) as Record<string, unknown>;
+      const originalInput = structuredClone(input);
+
+      if (action === 'create') {
+        await operations.createSupplierInvoiceAccrual(input);
+      } else {
+        await operations.updateSupplierInvoiceAccrual('7', input);
+      }
+      const writableBody = request.mock.calls[0]?.[1]?.body;
+
+      expect(input).toEqual(originalInput);
+      const output = runDryRun('supplier-invoice-accruals', action, inputMode, input);
+      const preview = parsePreview(output);
+      expect(preview).toEqual(writableBody);
+      expect(preview.SupplierInvoiceAccrual).not.toHaveProperty('Times');
+
+      expect(input).toEqual(originalInput);
+    },
+  );
+
+  it('keeps Times in ordinary invoice and contract accrual previews', async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+    const invoiceInput = { Total: 100, Times: 3 };
+    await operations.createInvoiceAccrual(invoiceInput);
+    const invoiceBody = request.mock.calls[0]?.[1]?.body;
+
+    const invoiceOutput = runDryRun('invoice-accruals', 'create', 'file', invoiceInput);
+    expect(parsePreview(invoiceOutput)).toEqual(invoiceBody);
+
+    request.mockClear();
+    const contractInput = { Total: 200, Times: 4 };
+    await operations.updateContractAccrual('7', contractInput);
+    const contractBody = request.mock.calls[0]?.[1]?.body;
+
+    const contractOutput = runDryRun('contract-accruals', 'update', 'stdin', contractInput);
+    expect(parsePreview(contractOutput)).toEqual(contractBody);
+  });
+});

--- a/tests/operations/accruals.test.ts
+++ b/tests/operations/accruals.test.ts
@@ -64,6 +64,23 @@ describe('accrual operations', () => {
 });
 
 describe('supplier invoice accrual read-only fields', () => {
+  const supplierInvoiceAccrual = {
+    AccrualAccount: 1790,
+    CostAccount: 6540,
+    Description: 'Annual service',
+    EndDate: '2026-12-31',
+    Period: 'MONTHLY',
+    StartDate: '2026-01-01',
+    SupplierInvoiceAccrualRows: [
+      { Account: 6540, Debit: 100, CostCenter: 'A1' },
+      { Account: 1790, Credit: 100, Project: 'P1' },
+    ],
+    SupplierInvoiceNumber: 42,
+    Times: 12,
+    Total: 1200,
+    VATIncluded: true,
+  } as const;
+
   it('strips Times from the create payload', async () => {
     const request = vi.fn().mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7 } });
     const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
@@ -98,5 +115,56 @@ describe('supplier invoice accrual read-only fields', () => {
     };
     expect(body.SupplierInvoiceAccrual).not.toHaveProperty('Times');
     expect(body.SupplierInvoiceAccrual.Total).toBe(9630);
+  });
+
+  it('keeps the caller input unchanged while retaining writable fields', async () => {
+    const request = vi.fn().mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7 } });
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+    const input = structuredClone(supplierInvoiceAccrual);
+
+    await operations.createSupplierInvoiceAccrual(input);
+
+    expect(input).toEqual(supplierInvoiceAccrual);
+    expect(request).toHaveBeenCalledWith('supplierinvoiceaccruals', {
+      method: 'POST',
+      body: {
+        SupplierInvoiceAccrual: {
+          AccrualAccount: supplierInvoiceAccrual.AccrualAccount,
+          CostAccount: supplierInvoiceAccrual.CostAccount,
+          Description: supplierInvoiceAccrual.Description,
+          EndDate: supplierInvoiceAccrual.EndDate,
+          Period: supplierInvoiceAccrual.Period,
+          StartDate: supplierInvoiceAccrual.StartDate,
+          SupplierInvoiceAccrualRows: supplierInvoiceAccrual.SupplierInvoiceAccrualRows,
+          SupplierInvoiceNumber: supplierInvoiceAccrual.SupplierInvoiceNumber,
+          Total: supplierInvoiceAccrual.Total,
+          VATIncluded: supplierInvoiceAccrual.VATIncluded,
+        },
+      },
+    });
+    const body = request.mock.calls[0]?.[1]?.body as {
+      SupplierInvoiceAccrual: Record<string, unknown>;
+    };
+    expect(body.SupplierInvoiceAccrual).not.toHaveProperty('Times');
+    expect(body.SupplierInvoiceAccrual.SupplierInvoiceAccrualRows).toEqual(
+      supplierInvoiceAccrual.SupplierInvoiceAccrualRows,
+    );
+  });
+
+  it('keeps Times for ordinary invoice and contract accrual writes', async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+
+    await operations.createInvoiceAccrual({ Total: 100, Times: 3 });
+    expect(request).toHaveBeenLastCalledWith('invoiceaccruals', {
+      method: 'POST',
+      body: { InvoiceAccrual: { Total: 100, Times: 3 } },
+    });
+
+    await operations.updateContractAccrual('7', { Total: 200, Times: 4 });
+    expect(request).toHaveBeenLastCalledWith('contractaccruals/7', {
+      method: 'PUT',
+      body: { ContractAccrual: { Total: 200, Times: 4 } },
+    });
   });
 });

--- a/tests/operations/accruals.test.ts
+++ b/tests/operations/accruals.test.ts
@@ -62,3 +62,41 @@ describe('accrual operations', () => {
     expect(request).not.toHaveBeenCalled();
   });
 });
+
+describe('supplier invoice accrual read-only fields', () => {
+  it('strips Times from the create payload', async () => {
+    const request = vi.fn().mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7 } });
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+
+    await operations.createSupplierInvoiceAccrual({
+      SupplierInvoiceNumber: 42,
+      AccrualAccount: 1710,
+      CostAccount: 5010,
+      Period: 'monthly',
+      StartDate: '2026-10-01',
+      EndDate: '2026-12-31',
+      Times: 3,
+      Total: 9630,
+    });
+
+    const body = request.mock.calls[0]?.[1]?.body as {
+      SupplierInvoiceAccrual: Record<string, unknown>;
+    };
+    expect(body.SupplierInvoiceAccrual).not.toHaveProperty('Times');
+    expect(body.SupplierInvoiceAccrual.Total).toBe(9630);
+    expect(body.SupplierInvoiceAccrual.AccrualAccount).toBe(1710);
+  });
+
+  it('strips Times from the update payload', async () => {
+    const request = vi.fn().mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7 } });
+    const operations = createAccrualOperations({ request } as unknown as FortnoxTransport);
+
+    await operations.updateSupplierInvoiceAccrual('7', { Times: 3, Total: 9630 });
+
+    const body = request.mock.calls[0]?.[1]?.body as {
+      SupplierInvoiceAccrual: Record<string, unknown>;
+    };
+    expect(body.SupplierInvoiceAccrual).not.toHaveProperty('Times');
+    expect(body.SupplierInvoiceAccrual.Total).toBe(9630);
+  });
+});

--- a/tests/tools/accruals.test.ts
+++ b/tests/tools/accruals.test.ts
@@ -3,14 +3,15 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from '../../src/index.js';
 import { ACCRUAL_TOOL_DEFINITIONS } from '../../src/tools/accruals.js';
+import type { FortnoxTransport } from '../../src/fortnox-client.js';
 
 vi.mock('../../src/auth.js', () => ({
   getValidToken: vi.fn().mockResolvedValue('mock-token'),
   getResolvedProfile: vi.fn().mockReturnValue('default'),
 }));
 
-async function setup() {
-  const server = createServer();
+async function setup(transport?: FortnoxTransport) {
+  const server = createServer(transport ? { transport } : undefined);
   const client = new Client({ name: 'accrual-test', version: '1.0.0' });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
@@ -140,5 +141,49 @@ describe('supplier invoice accrual read-only Times', () => {
     expect(Object.keys(create?.inputSchema?.properties ?? {})).toEqual(
       expect.arrayContaining(['StartDate', 'EndDate', 'Period']),
     );
+  });
+
+  it('rejects Times on create and update before the mocked transport is called', async () => {
+    const request = vi.fn();
+    const { client } = await setup({ request } as unknown as FortnoxTransport);
+    const payload = { ...payloads.supplier_invoice_accrual, Times: 12, confirm: true };
+
+    for (const [name, arguments_] of [
+      ['fortnox_create_supplier_invoice_accrual', payload],
+      ['fortnox_update_supplier_invoice_accrual', { documentNumber: '7', ...payload }],
+    ] as const) {
+      const result = await client.callTool({ name, arguments: arguments_ });
+      expect(result.isError, name).toBe(true);
+    }
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('accepts create and update without Times and sends the exact writable payload', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ SupplierInvoiceAccrual: { DocumentNumber: 7, Total: 1200 } });
+    const { client } = await setup({ request } as unknown as FortnoxTransport);
+    const payload = { ...payloads.supplier_invoice_accrual, confirm: true };
+
+    const createResult = await client.callTool({
+      name: 'fortnox_create_supplier_invoice_accrual',
+      arguments: payload,
+    });
+    expect(createResult.isError).toBeFalsy();
+    expect(request).toHaveBeenLastCalledWith('supplierinvoiceaccruals', {
+      method: 'POST',
+      body: { SupplierInvoiceAccrual: payloads.supplier_invoice_accrual },
+    });
+
+    const updateResult = await client.callTool({
+      name: 'fortnox_update_supplier_invoice_accrual',
+      arguments: { documentNumber: '7', ...payload },
+    });
+    expect(updateResult.isError).toBeFalsy();
+    expect(request).toHaveBeenLastCalledWith('supplierinvoiceaccruals/7', {
+      method: 'PUT',
+      body: { SupplierInvoiceAccrual: payloads.supplier_invoice_accrual },
+    });
   });
 });

--- a/tests/tools/accruals.test.ts
+++ b/tests/tools/accruals.test.ts
@@ -42,7 +42,6 @@ const payloads = {
       { Account: 1790, Credit: 100 },
     ],
     SupplierInvoiceNumber: 7,
-    Times: 12,
     Total: 1200,
   },
   contract_accrual: {
@@ -126,5 +125,20 @@ describe('accrual tools', () => {
       expect(result.isError, name).toBeFalsy();
     }
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('supplier invoice accrual read-only Times', () => {
+  it('does not advertise Times on the create tool', async () => {
+    const { client } = await setup();
+    const { tools } = await client.listTools();
+    const create = tools.find((t) => t.name === 'fortnox_create_supplier_invoice_accrual');
+
+    expect(create).toBeDefined();
+    expect(Object.keys(create?.inputSchema?.properties ?? {})).not.toContain('Times');
+    // The writable fields Fortnox does derive Times from must still be offered.
+    expect(Object.keys(create?.inputSchema?.properties ?? {})).toEqual(
+      expect.arrayContaining(['StartDate', 'EndDate', 'Period']),
+    );
   });
 });


### PR DESCRIPTION
Creating a supplier invoice accrual failed against the live API with "Fältet Times är endast läsbart". Fortnox computes Times from StartDate/EndDate and Period — the web UI shows it as a derived "Tot.antal" with no input field — but the tool schema made it required, so every create sent it and was rejected.

Note Fortnox's spec contradicts its own API here: the POST payload schema lists Times as required and doesn't mark it readOnly. Fixed against observed behaviour instead. Same shape as the Country fix in 5787989.

Times is now dropped from the tool schema rather than accepted-and-ignored, since the server is strict and would otherwise take an argument it always throws away. The operations layer still strips it, which covers the CLI's schema-less --input path.

Behaviour change: callers currently passing Times will get an error instead of silence. That's intended.

The failing npm audit check is the stale hono pin, fixed separately in [#168](https://github.com/hedborg/noxctl/pull/168) — this goes green once that merges.